### PR TITLE
Windows sucks... symlink fixes for enabling and disabling extensions.

### DIFF
--- a/core/util.inc.php
+++ b/core/util.inc.php
@@ -612,7 +612,13 @@ function ip_in_range($IP, $CIDR) {
  */
 function deltree($f) {
 	if (is_link($f)) {
-		unlink($f);
+		//Because Windows (I know, bad excuse)
+		if (PHP_OS === 'WINNT') {
+			rmdir($f);
+		}
+		else {
+			unlink($f);
+		}
 	}
 	else if(is_dir($f)) {
 		foreach(glob($f.'/*') as $sf) {

--- a/ext/ext_manager/main.php
+++ b/ext/ext_manager/main.php
@@ -177,7 +177,14 @@ class ExtManager extends SimpleExtension {
 					// yes, even though we are in /, and thus the path to contrib is
 					// ./contrib, the link needs to be ../ because it is literal data
 					// which will be interpreted relative to ./ext/ by the OS
-					symlink("../contrib/$fname", "ext/$fname");
+					
+					//Because Windows (I know, bad excuse)
+					if (PHP_OS === 'WINNT') {
+						symlink(realpath("./contrib/$fname"), realpath("./ext/").'/'.$fname);
+					}
+					else {
+						symlink("../contrib/$fname", "ext/$fname");
+					}
 				}
 				else {
 					full_copy("contrib/$fname", "ext/$fname");


### PR DESCRIPTION
Yup, got around on updating shimmie to the latest version and playing around with it.
After a few /facepalms due to AllowOverride Off, I enabled a few extensions I used before (clean install except DB & Images), this lead to searching da logs because the extensions wouldn't symlink to the /ext/ directory.

Few lines of code and probably useless if-clause later, the Windows only symlink fix works. Allows enabling and disabling the extension, yet won't delete them from /contrib/ (I had this happen once, was fun :3)
