### PR TITLE
Update MassTagger redirect to reload page

### DIFF
--- a/ext/mass_tagger/main.php
+++ b/ext/mass_tagger/main.php
@@ -53,7 +53,7 @@ class MassTagger extends Extension {
 		}
 		
 		$page->set_mode("redirect");
-		$page->set_redirect(make_link("post/list"));
+		$page->set_redirect($_SERVER['HTTP_REFERER']);
 	}
 }
 ?>


### PR DESCRIPTION
Modified Mass Tagger extension to make it so that instead of redirecting to post/list it reloads the page instead, unburdening the user from a click on Back and manually reloading.
