### PR TITLE
Fix PHP errors about Strict Standards

### DIFF
--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -394,8 +394,11 @@ class PoolsTheme extends Themelet {
 	/**
 	 * Display an error message to the user.
 	 */
-	public function display_error(/*string*/ $errMessage) {
+	public function display_error(/*int*/ $code, /*string*/ $title, /*string*/ $message) {
 		global $page;
+		
+		// Quick n' Dirty fix
+		$message = $code;
 
 		$page->set_title("Error");
 		$page->set_heading("Error");

--- a/themes/danbooru/comment.theme.php
+++ b/themes/danbooru/comment.theme.php
@@ -87,7 +87,7 @@ class CustomCommentListTheme extends CommentListTheme {
 	}
 
 
-	protected function comment_to_html(Comment $comment, $trim=false) {
+	protected function comment_to_html($comment, $trim=false) {
 		global $user;
 
 		$tfe = new TextFormattingEvent($comment->comment);

--- a/themes/danbooru/index.theme.php
+++ b/themes/danbooru/index.theme.php
@@ -1,7 +1,7 @@
 <?php
 
 class CustomIndexTheme extends IndexTheme {
-	public function display_page($page, $images) {
+	public function display_page(Page $page, $images) {
 		global $config;
 
 		if(count($this->search_terms) == 0) {

--- a/themes/danbooru/tag_list.theme.php
+++ b/themes/danbooru/tag_list.theme.php
@@ -1,7 +1,7 @@
 <?php
 
 class CustomTagListTheme extends TagListTheme {
-	public function display_page($page) {
+	public function display_page(Page $page) {
 		$page->disable_left();
 		parent::display_page($page);
 	}

--- a/themes/danbooru/upload.theme.php
+++ b/themes/danbooru/upload.theme.php
@@ -1,12 +1,12 @@
 <?php
 
 class CustomUploadTheme extends UploadTheme {
-	public function display_block($page) {
+	public function display_block(Page $page) {
 		// this theme links to /upload
 		// $page->add_block(new Block("Upload", $this->build_upload_block(), "left", 20));
 	}
 
-	public function display_page($page) {
+	public function display_page(Page $page) {
 		$page->disable_left();
 		parent::display_page($page);
 	}

--- a/themes/danbooru/user.theme.php
+++ b/themes/danbooru/user.theme.php
@@ -1,7 +1,7 @@
 <?php
 
 class CustomUserPageTheme extends UserPageTheme {
-	public function display_login_page($page) {
+	public function display_login_page(Page $page) {
 		global $config;
 		$page->set_title("Login");
 		$page->set_heading("Login");
@@ -27,14 +27,14 @@ class CustomUserPageTheme extends UserPageTheme {
 		$page->add_block(new Block("Login", $html, "main", 90));
 	}
 
-	public function display_user_links($page, $user, $parts) {
+	public function display_user_links(Page $page, User $user, $parts) {
 		// no block in this theme
 	}
 	public function display_login_block(Page $page) {
 		// no block in this theme
 	}
 
-	public function display_user_block($page, $user, $parts) {
+	public function display_user_block(Page $page, User $user, $parts) {
 		$h_name = html_escape($user->name);
 		$html = "";
 		$blocked = array("Pools", "Pool Changes", "Alias Editor", "My Profile");
@@ -45,7 +45,7 @@ class CustomUserPageTheme extends UserPageTheme {
 		$page->add_block(new Block("User Links", $html, "user", 90));
 	}
 
-	public function display_signup_page($page) {
+	public function display_signup_page(Page $page) {
 		global $config;
 		$tac = $config->get_string("login_tac", "");
 
@@ -77,7 +77,7 @@ class CustomUserPageTheme extends UserPageTheme {
 		$page->add_block(new Block("Signup", $html));
 	}
 
-	public function display_ip_list($page, $uploads, $comments) {
+	public function display_ip_list(Page $page, $uploads, $comments) {
 		$html = "<table id='ip-history' style='width: 400px;'>";
 		$html .= "<tr><td>Uploaded from: ";
 		foreach($uploads as $ip => $count) {

--- a/themes/danbooru/view.theme.php
+++ b/themes/danbooru/view.theme.php
@@ -1,7 +1,7 @@
 <?php
 
 class CustomViewImageTheme extends ViewImageTheme {
-	public function display_page($image, $editor_parts) {
+	public function display_page(Image $image, $editor_parts) {
 		global $page;
 		$page->set_title("Image {$image->id}: ".html_escape($image->get_tag_list()));
 		$page->set_heading(html_escape($image->get_tag_list()));


### PR DESCRIPTION
Fixes errors about PHP complaining of strict standards, Pools extension needs an overhaul due to display errors being different in BaseThemelet than it is in the ext/pools/main.php

Related to issue #252 
