### PR TITLE
fix pools link on home page to point at site://pool and not site://pools

### DIFF
--- a/ext/home/main.php
+++ b/ext/home/main.php
@@ -70,7 +70,7 @@ class Home extends Extension {
 		}
 		else {
 			$main_links = '[url=site://post/list]Posts[/url] [url=site://comment/list]Comments[/url] [url=site://tags]Tags[/url]';
-			if(class_exists("Pools")) {$main_links .= ' [url=site://pools]Pools[/url]';}
+			if(class_exists("Pools")) {$main_links .= ' [url=site://pool]Pools[/url]';}
 			if(class_exists("Wiki")) {$main_links .= ' [url=site://wiki]Wiki[/url]';}
 			$main_links .= ' [url=site://ext_doc]Documentation[/url]';
 		}


### PR DESCRIPTION
Extension 'home' contains a "Pools" link which incorrectly links to a nonexistent 'pools' page.  This has been corrected to point at the 'pool' page, as the Pools class handles requests for, and refers to, it's page as 'pool' and not 'pools'.
