### PR TITLE
fix numeric_score to use make_link for user profile links

### DIFF
--- a/ext/numeric_score/main.php
+++ b/ext/numeric_score/main.php
@@ -58,7 +58,7 @@ class NumericScore extends Extension {
 			$html = "<table>";
 			foreach($x as $vote) {
 				$html .= "<tr><td>";
-				$html .= "<a href='/user/{$vote['username']}'>{$vote['username']}</a>";
+				$html .= "<a href='".make_link("user/{$vote['username']}")."'>{$vote['username']}</a>";
 				$html .= "</td><td>";
 				$html .= $vote['score'];
 				$html .= "</td></tr>";


### PR DESCRIPTION
After following the 'See All Votes' link on a post's page, it provides a list of users that voted.  This is a list of links which point to user profiles; however, they are not created using make_link, and instead were referencing the http root ("/user/username").  

This causes problems when Shimmie is located in a subdirectory off of the site root, such as in the example http://example.com/shimmie2/user/myuser.  

This commit updates the extension to use make_link, which is preferred over direct use of relative links.
