### PR TITLE
Allow Nice URLs when served via HTTPS

### DIFF
--- a/ext/setup/main.php
+++ b/ext/setup/main.php
@@ -218,7 +218,7 @@ class Setup extends Extension {
 				$host .= ":" . $_SERVER["SERVER_PORT"];
 			}
 		}
-		$full = "http://" . $host . $_SERVER["PHP_SELF"];
+                $full = ($_SERVER["HTTPS"] ? "https://" : "http://") . $host . $_SERVER["PHP_SELF"];
 		$test_url = str_replace("/index.php", "/nicetest", $full);
 
 		$nicescript = "<script language='javascript'>


### PR DESCRIPTION
Use $_SERVER['HTTPS'] to construct the nicetest URL, allowing Shimmie to use nice URLs when served over HTTPS. Currently this is failing because of cross domain security on (at least) Chrome.
