### PR TITLE
Allow transload from urls with query string

### DIFF
--- a/ext/handle_pixel/main.php
+++ b/ext/handle_pixel/main.php
@@ -9,6 +9,7 @@
 class PixelFileHandler extends DataHandlerExtension {
 	protected function supported_ext($ext) {
 		$exts = array("jpg", "jpeg", "gif", "png");
+		$ext = (($pos = strpos($ext,'?')) !== false) ? substr($ext,0,$pos) : $ext;
 		return in_array(strtolower($ext), $exts);
 	}
 
@@ -25,8 +26,8 @@ class PixelFileHandler extends DataHandlerExtension {
 
 		$image->filesize  = $metadata['size'];
 		$image->hash      = $metadata['hash'];
-		$image->filename  = $metadata['filename'];
-		$image->ext       = $metadata['extension'];
+		$image->filename  = (($pos = strpos($metadata['filename'],'?')) !== false) ? substr($metadata['filename'],0,$pos) : $metadata['filename'];
+		$image->ext       = (($pos = strpos($metadata['extension'],'?')) !== false) ? substr($metadata['extension'],0,$pos) : $metadata['extension'];
 		$image->tag_array = Tag::explode($metadata['tags']);
 		$image->source    = $metadata['source'];
 


### PR DESCRIPTION
There are cases where removing the query string results in a different output like with some of Flickr's medium sized images (?zz=1 query string).

Up until now I changed the /shimmie2/ext/handle_pixel/main.php by myself but maybe you're interested in implementing it.

I figured out how to create pull requests so I created one and closed the old normal issue.
