### PR TITLE
Look for the source in _GET and not in _POST when uploading via _GET

### DIFF
--- a/ext/upload/main.php
+++ b/ext/upload/main.php
@@ -193,7 +193,7 @@ class Upload extends Extension {
 				}
 				else if(!empty($_GET['url'])) {
 					$url = $_GET['url'];
-					$source = isset($_POST['source']) ? $_POST['source'] : $url;
+					$source = isset($_GET['source']) ? $_GET['source'] : $url;
 					$tags = array('tagme');
 					if(!empty($_GET['tags']) && $_GET['tags'] != "null") {
 						$tags = Tag::explode($_GET['tags']);


### PR DESCRIPTION
From line 194 to 204 of /shimmie2/ext/upload/main.php we handle uploads initiated via a GET request. While we take the URL and the tags from the GET vars, the script checks for the existence of $_POST['source']. 

I created a pull request to change that.
