### PR TITLE
Don't check the certificate when transloading

### DIFF
--- a/core/util.inc.php
+++ b/core/util.inc.php
@@ -713,7 +713,7 @@ function get_prefixed_cookie(/*string*/ $name) {
  */
 function set_prefixed_cookie($name, $value, $time, $path) {
 	global $config;
-	$full_name = $config->get_string('cookie_prefix','shm')."_".$name;
+	$full_name = COOKIE_PREFIX."_".$name;
 	setcookie($full_name, $value, $time, $path);
 }
 


### PR DESCRIPTION
This allows the download of images via https even if the cert is self-signed.

I'm not familiar with fopen so I don't know how it behaves with https-links.
