### PR TITLE
Fixes themelet 'undefined variable query' errors

### DIFF
--- a/core/basethemelet.class.php
+++ b/core/basethemelet.class.php
@@ -38,7 +38,7 @@ class BaseThemelet {
 	 * a block since thumbs tend to go inside blocks...
 	 */
 	public function build_thumb_html(Image $image) {
-		global $config;
+		global $config, $query;
 		$i_id = (int) $image->id;
 		$h_view_link = make_link('post/view/'.$i_id, $query);
 		$h_thumb_link = $image->get_thumb_link();

--- a/themes/danbooru/themelet.class.php
+++ b/themes/danbooru/themelet.class.php
@@ -1,7 +1,7 @@
 <?php
 class Themelet extends BaseThemelet {
 	public function build_thumb_html(Image $image) {
-		global $config;
+		global $config, $query;
 		$h_view_link = make_link("post/view/{$image->id}", $query);
 		$h_thumb_link = $image->get_thumb_link();
 		$h_tip = html_escape($image->get_tooltip());

--- a/themes/danbooru2/themelet.class.php
+++ b/themes/danbooru2/themelet.class.php
@@ -1,7 +1,7 @@
 <?php
 class Themelet extends BaseThemelet {
 	public function build_thumb_html(Image $image) {
-		global $config;
+		global $config, $query;
 		$h_view_link = make_link("post/view/{$image->id}", $query);
 		$h_thumb_link = $image->get_thumb_link();
 		$h_tip = html_escape($image->get_tooltip());

--- a/themes/futaba/themelet.class.php
+++ b/themes/futaba/themelet.class.php
@@ -5,7 +5,7 @@ class Themelet extends BaseThemelet {
 	 * a block since thumbs tend to go inside blocks...
 	 */
 	public function build_thumb_html(Image $image) {
-		global $config;
+		global $config, $query;
 		$h_view_link = make_link("post/view/{$image->id}", $query);
 		$h_thumb_link = $image->get_thumb_link();
 		$h_tip = html_escape($image->get_tooltip());

--- a/themes/lite/themelet.class.php
+++ b/themes/lite/themelet.class.php
@@ -5,7 +5,7 @@ class Themelet extends BaseThemelet {
 	 * a block since thumbs tend to go inside blocks...
 	 */
 	public function build_thumb_html(Image $image) {
-		global $config;
+		global $config, $query;
 		$i_id = (int) $image->id;
 		$h_view_link = make_link('post/view/'.$i_id, $query);
 		$h_thumb_link = $image->get_thumb_link();


### PR DESCRIPTION
My install seems to give me an error in the Themelet built_thumb_html functions:
`Notice: Undefined variable: query in /www/shimmie2/themes/danbooru2/themelet.class.php on line 5`

Seems to go away if we add $query to globals, so I thought it'd be nice to put in the rest of them.
