### PR TITLE
Fix rating circumvention issue

### DIFF
--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -104,20 +104,11 @@ class Ratings extends Extension {
 			$set = Ratings::privs_to_sql(Ratings::get_user_privs($user));
 			$event->add_querylet(new Querylet("rating IN ($set)"));
 		}
-		if(preg_match("/^rating=([sqeu]+)$/", $event->term, $matches)) {
-			$sqes = $matches[1];
-			$arr = array();
-			$length = strlen($sqes);
-			for($i=0; $i<$length; $i++) {
-				$arr[] = "'" . $sqes[$i] . "'";
-			}
-			$set = join(', ', $arr);
+		if(preg_match("/^rating=(?:([sqeu]+)|(safe|questionable|explicit|unknown))$", strtolower($event->term), $matches)) {
+			$ratings = $matches[1] ? $matches[1] : array($matches[2][0]);
+			$ratings = array_intersect($ratings, str_split(Ratings::get_user_privs($user)));
+			$set = "'" . join("', '", $ratings) . "'";
 			$event->add_querylet(new Querylet("rating IN ($set)"));
-		}
-		if(preg_match("/^rating=(safe|questionable|explicit|unknown)$/", strtolower($event->term), $matches)) {
-			$text = $matches[1];
-			$char = $text[0];
-			$event->add_querylet(new Querylet("rating = :img_rating", array("img_rating"=>$char)));
 		}
 	}
 


### PR DESCRIPTION
Users could circumvent the "ratings visible" setting just by searching for the rating.  I assumed you intended them as priveleges and not defaults due to the way in which it redirects out of pages which display the things.

I also cleaned up the two regexes and the weird iteration to build a comma-delimited list of quoted strings to unify into one single regex and handling for it (I think it's clearer, if you disagree I'll revert that change)

There's still an odd bug where the pagination doesn't seem to adjust to match the different query, I'm not sure if/how to override that, since I've only been poking at SCore/Shimmie for a day or so now
