### PR TITLE
Fix for issue 330 - "Tag list does not handle non-english text correctly"

### DIFF
--- a/ext/tag_list/main.php
+++ b/ext/tag_list/main.php
@@ -243,12 +243,28 @@ class TagList extends Extension {
 
 		$html = "";
 		if($config->get_bool("tag_list_pages")) $html .= $this->build_az();
+		
+		/*
+		  strtolower() vs. mb_strtolower()
+		  ( See http://www.php.net/manual/en/function.mb-strtolower.php for more info )
+		 
+		  PHP5's strtolower function does not support Unicode (UTF-8) properly, so
+		  you have to use another function, mb_strtolower, to handle UTF-8 strings.
+		  
+		  What's worse is that mb_strtolower is horribly SLOW.
+		  
+		  It would probably be better to have a config option for the Tag List that
+		  would allow you to specify if there are UTF-8 tags.
+		  
+		*/ 
+		mb_internal_encoding('UTF-8');
+		
 		$lastLetter = "";
 		foreach($tag_data as $row) {
 			$h_tag = html_escape($row['tag']);
 			$count = $row['count'];
-			if($lastLetter != strtolower(substr($h_tag, 0, count($starts_with)+1))) {
-				$lastLetter = strtolower(substr($h_tag, 0, count($starts_with)+1));
+			if($lastLetter != mb_strtolower(substr($h_tag, 0, count($starts_with)+1))) {
+				$lastLetter = mb_strtolower(substr($h_tag, 0, count($starts_with)+1));
 				$html .= "<p>$lastLetter<br>";
 			}
 			$link = $this->tag_link($row['tag']);


### PR DESCRIPTION
This should fix issue #330. 

The problem is that PHP5 does handle UTF-8 natively. (ie: strtolower is really only for ASCII text)
In order to support other languages you need to use mb_strtolower. 
( See http://www.php.net/manual/en/function.mb-strtolower.php for more info )

The only downside to using this though is that it is much SLOWER than strtolower. 

If you have Shimmie setup to cache the tag list then it shouldn't be a problem, but I was thinking that perhaps there should be some option in Shimmie's config for supporting UTF-8 for tags or something.

Any thoughts or ideas are welcome.
