### PR TITLE
Bumping Ouroros API to v0.2: now with XML support and post creation!

### DIFF
--- a/ext/ouroboros_api/main.php
+++ b/ext/ouroboros_api/main.php
@@ -11,6 +11,7 @@
  *       <ul>
  *         <li>Index/List</li>
  *         <li>Show</li>
+ *         <li>Create</li>
  *       </ul>
  *     </li>
  *     <li>Tag:
@@ -269,10 +270,12 @@ class OuroborosPost extends _SafeOuroborosImage {
             $this->tags = $post['tags'];
         }
         if (array_key_exists('file', $post)) {
-            assert(is_array($post['file']));
-            assert(array_key_exists('tmp_name', $post['file']));
-            assert(array_key_exists('name', $post['file']));
-            $this->file = $post['file'];
+            if (!is_null($post['file'])) {
+                assert(is_array($post['file']));
+                assert(array_key_exists('tmp_name', $post['file']));
+                assert(array_key_exists('name', $post['file']));
+                $this->file = $post['file'];
+            }
         }
         if (array_key_exists('rating', $post)) {
             assert(


### PR DESCRIPTION
And user auth support. Huzzah!
- Cleaned up the code a bit, some refactoring, added a wrapper class for a new post (probably useless but it looks so OO!)
- XML is supported with `XMLWriter` which means minimum PHP version required is `5.1.2` (Shimmie2 has `5.1+`)
- The post creation accepts either multipart file or attempts a transload with tons of the code copied and mangled from `ext/danbooru_api`.
  - Currently, there's no check if the user can even upload. This may or may not be a problem as this _should_ be handled by the `DataUploadEvent`-handler, will fix if this isn't the case.
- The `$this->tryAuth()` block on top of the event handler tries to populate `$user` with the current user if possible by checking either the cookies or request for user and session.
