### PR TITLE
Fix for #147

### DIFF
--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -484,7 +484,7 @@ class Image {
 				if(empty($id)) {
 					// a new tag
 					$database->execute(
-							"INSERT INTO tags(tag) VALUES (:tag)",
+							"INSERT IGNORE INTO tags(tag) VALUES (:tag)",
 							array("tag"=>$tag));
 					$database->execute(
 							"INSERT INTO image_tags(image_id, tag_id)


### PR DESCRIPTION
From the MySQL manual: "If you use the IGNORE keyword, errors that occur while executing the INSERT statement are ignored. For example, without IGNORE, a row that duplicates an existing UNIQUE index or PRIMARY KEY value in the table causes a duplicate-key error and the statement is aborted. With IGNORE, the row still is not inserted, but no error occurs. Ignored errors may generate warnings instead, although duplicate-key errors do not."

**\* NOT TESTED WITH PGSQL ***
