### PR TITLE
Don't silently ignore invalid URLs

### DIFF
--- a/core/extension.class.php
+++ b/core/extension.class.php
@@ -142,7 +142,7 @@ abstract class DataHandlerExtension extends Extension {
 	public function onDataUpload(DataUploadEvent $event) {
 		global $user;
 
-		if($this->supported_ext($event->type) && $this->check_contents($event->tmpname)) {
+		if(($supported_ext = $this->supported_ext($event->type)) && ($check_contents = $this->check_contents($event->tmpname))) {
 			if(!move_upload_to_archive($event)) return;
 			send_event(new ThumbnailGenerationEvent($event->hash, $event->type));
 
@@ -197,8 +197,8 @@ abstract class DataHandlerExtension extends Extension {
 				}
 			}
 		}
-		else{
-			throw new UploadException("Unsupported extension or file isn't an image");
+		elseif($supported_ext && !$check_contents){
+			throw new UploadException("Invalid or corrupted file");
 		}
 	}
 


### PR DESCRIPTION
Scenario: Providing an invalid url via $_GET (wrong/missing extension or file isn't an image (also happens on download errors))
Behavior before: Silently redirect to index
Behavior after: Display error message

// Edit / Offtopic: HAPPY NEW YEAR!
