### PR TITLE
Use new-style constructors everywhere

### DIFF
--- a/core/config.class.php
+++ b/core/config.class.php
@@ -181,7 +181,7 @@ class DatabaseConfig extends BaseConfig {
 	/*
 	 * Load the config table from a database
 	 */
-	public function DatabaseConfig(Database $database) {
+	public function __construct(Database $database) {
 		$this->database = $database;
 
 		$cached = $this->database->cache->get("config");

--- a/core/database.class.php
+++ b/core/database.class.php
@@ -5,7 +5,7 @@ class Querylet {
 	var $sql;
 	var $variables;
 
-	public function Querylet($sql, $variables=array()) {
+	public function __construct($sql, $variables=array()) {
 		$this->sql = $sql;
 		$this->variables = $variables;
 	}
@@ -28,7 +28,7 @@ class TagQuerylet {
 	var $tag;
 	var $positive;
 
-	public function TagQuerylet($tag, $positive) {
+	public function __construct($tag, $positive) {
 		$this->tag = $tag;
 		$this->positive = $positive;
 	}
@@ -37,7 +37,7 @@ class ImgQuerylet {
 	var $qlet;
 	var $positive;
 
-	public function ImgQuerylet($qlet, $positive) {
+	public function __construct($qlet, $positive) {
 		$this->qlet = $qlet;
 		$this->positive = $positive;
 	}
@@ -290,7 +290,7 @@ class Database {
 	 * need it. There are some pages where all the data is in cache, so the
 	 * DB connection is on-demand.
 	 */
-	public function Database() {
+	public function __construct() {
 		$this->connect_cache();
 	}
 

--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -49,7 +49,7 @@ class Image {
 	 * One will very rarely construct an image directly, more common
 	 * would be to use Image::by_id, Image::by_hash, etc
 	 */
-	public function Image($row=null) {
+	public function __construct($row=null) {
 		if(!is_null($row)) {
 			foreach($row as $name => $value) {
 				// some databases use table.name rather than name

--- a/core/user.class.php
+++ b/core/user.class.php
@@ -30,7 +30,7 @@ class User {
 	 * One will very rarely construct a user directly, more common
 	 * would be to use User::by_id, User::by_session, etc
 	 */
-	public function User($row) {
+	public function __construct($row) {
 		global $_user_classes;
 
 		$this->id = int_escape($row['id']);

--- a/ext/admin/main.php
+++ b/ext/admin/main.php
@@ -25,7 +25,7 @@
  */
 class AdminBuildingEvent extends Event {
 	var $page;
-	public function AdminBuildingEvent(Page $page) {
+	public function __construct(Page $page) {
 		$this->page = $page;
 	}
 }

--- a/ext/alias_editor/main.php
+++ b/ext/alias_editor/main.php
@@ -14,7 +14,7 @@ class AddAliasEvent extends Event {
 	var $oldtag;
 	var $newtag;
 
-	public function AddAliasEvent($oldtag, $newtag) {
+	public function __construct($oldtag, $newtag) {
 		$this->oldtag = trim($oldtag);
 		$this->newtag = trim($newtag);
 	}

--- a/ext/artists/main.php
+++ b/ext/artists/main.php
@@ -11,7 +11,7 @@
 class AuthorSetEvent extends Event {
     var $image, $user, $author;
 
-    public function AuthorSetEvent(Image $image, User $user, /*string*/ $author)
+    public function __construct(Image $image, User $user, /*string*/ $author)
     {
         $this->image = $image;
         $this->user = $user;

--- a/ext/ext_manager/main.php
+++ b/ext/ext_manager/main.php
@@ -22,7 +22,7 @@ class ExtensionInfo {
 	var $ext_name, $name, $link, $author, $email;
 	var $description, $documentation, $version, $visibility;
 
-	function ExtensionInfo($main) {
+	function __construct($main) {
 		$matches = array();
 		$lines = file($main);
 		$number_of_lines = count($lines);

--- a/ext/favorites/main.php
+++ b/ext/favorites/main.php
@@ -16,7 +16,7 @@
 class FavoriteSetEvent extends Event {
 	var $image_id, $user, $do_set;
 
-	public function FavoriteSetEvent(/*int*/ $image_id, User $user, /*boolean*/ $do_set) {
+	public function __construct(/*int*/ $image_id, User $user, /*boolean*/ $do_set) {
 		assert(is_numeric($image_id));
 		assert(is_bool($do_set));
 

--- a/ext/handle_svg/main.php
+++ b/ext/handle_svg/main.php
@@ -88,7 +88,7 @@ class SVGFileHandler extends Extension {
 class MiniSVGParser {
 	var $valid=false, $width=0, $height=0;
 
-	function MiniSVGParser($file) {
+	function __construct($file) {
 		$xml_parser = xml_parser_create();
 		xml_set_element_handler($xml_parser, array($this, "startElement"), array($this, "endElement"));
 		$this->valid = xml_parse($xml_parser, file_get_contents($file), true);

--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -22,7 +22,7 @@ class ImageAdditionEvent extends Event {
 	 * @sa TagSetEvent
 	 * @param $image	The new image to add.
 	 */
-	public function ImageAdditionEvent(Image $image) {
+	public function __construct(Image $image) {
 		$this->image = $image;
 	}
 }
@@ -48,7 +48,7 @@ class ImageDeletionEvent extends Event {
 	 *
 	 * @param $image 	The image being deleted
 	*/
-	public function ImageDeletionEvent(Image $image) {
+	public function __construct(Image $image) {
 		$this->image = $image;
 	}
 }
@@ -70,7 +70,7 @@ class ImageReplaceEvent extends Event {
 	 * @param $image
 	 *   The image object of the new image to use
 	 */
-	public function ImageReplaceEvent(/*int*/ $id, Image $image) {
+	public function __construct(/*int*/ $id, Image $image) {
 		$this->id = $id;
 		$this->image = $image;
 	}
@@ -96,7 +96,7 @@ class ThumbnailGenerationEvent extends Event {
 	 * @param $hash	The unique hash of the image
 	 * @param $type	The type of the image
 	 */
-	public function ThumbnailGenerationEvent($hash, $type, $force=false) {
+	public function __construct($hash, $type, $force=false) {
 		$this->hash = $hash;
 		$this->type = $type;
 		$this->force = $force;
@@ -113,7 +113,7 @@ class ThumbnailGenerationEvent extends Event {
 class ParseLinkTemplateEvent extends Event {
 	var $link, $original, $image;
 
-	public function ParseLinkTemplateEvent($link, Image $image) {
+	public function __construct($link, Image $image) {
 		$this->link = $link;
 		$this->original = $link;
 		$this->image = $image;

--- a/ext/image_hash_ban/main.php
+++ b/ext/image_hash_ban/main.php
@@ -13,7 +13,7 @@
 class RemoveImageHashBanEvent extends Event {
 	var $hash;
 
-	public function RemoveImageHashBanEvent($hash) {
+	public function __construct($hash) {
 		$this->hash = $hash;
 	}
 }
@@ -23,7 +23,7 @@ class AddImageHashBanEvent extends Event {
 	var $hash;
 	var $reason;
 
-	public function AddImageHashBanEvent($hash, $reason) {
+	public function __construct($hash, $reason) {
 		$this->hash = $hash;
 		$this->reason = $reason;
 	}

--- a/ext/index/main.php
+++ b/ext/index/main.php
@@ -163,7 +163,7 @@ class SearchTermParseEvent extends Event {
 	var $context = null;
 	var $querylets = array();
 
-	public function SearchTermParseEvent($term, $context) {
+	public function __construct($term, $context) {
 		$this->term = $term;
 		$this->context = $context;
 	}

--- a/ext/ipban/main.php
+++ b/ext/ipban/main.php
@@ -16,7 +16,7 @@
 class RemoveIPBanEvent extends Event {
 	var $id;
 
-	public function RemoveIPBanEvent($id) {
+	public function __construct($id) {
 		$this->id = $id;
 	}
 }
@@ -27,7 +27,7 @@ class AddIPBanEvent extends Event {
 	var $reason;
 	var $end;
 
-	public function AddIPBanEvent(/*string(ip)*/ $ip, /*string*/ $reason, /*string*/ $end) {
+	public function __construct(/*string(ip)*/ $ip, /*string*/ $reason, /*string*/ $end) {
 		$this->ip = trim($ip);
 		$this->reason = trim($reason);
 		$this->end = trim($end);

--- a/ext/numeric_score/main.php
+++ b/ext/numeric_score/main.php
@@ -13,7 +13,7 @@
 class NumericScoreSetEvent extends Event {
 	var $image_id, $user, $score;
 
-	public function NumericScoreSetEvent(/*int*/ $image_id, User $user, /*int*/ $score) {
+	public function __construct(/*int*/ $image_id, User $user, /*int*/ $score) {
 		$this->image_id = $image_id;
 		$this->user = $user;
 		$this->score = $score;

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -22,7 +22,7 @@
 class RatingSetEvent extends Event {
 	var $image, $rating;
 
-	public function RatingSetEvent(Image $image, /*char*/ $rating) {
+	public function __construct(Image $image, /*char*/ $rating) {
 		assert(in_array($rating, array("s", "q", "e", "u")));
 		$this->image = $image;
 		$this->rating = $rating;

--- a/ext/report_image/main.php
+++ b/ext/report_image/main.php
@@ -12,7 +12,7 @@
 class RemoveReportedImageEvent extends Event {
 	var $id;
 
-	public function RemoveReportedImageEvent($id) {
+	public function __construct($id) {
 		$this->id = $id;
 	}
 }
@@ -22,7 +22,7 @@ class AddReportedImageEvent extends Event {
 	var $image_id;
 	var $reason;
 
-	public function AddReportedImageEvent($image_id, $reporter_id, $reason) {
+	public function __construct($image_id, $reporter_id, $reason) {
 		$this->reporter_id = $reporter_id;
 		$this->image_id = $image_id;
 		$this->reason = $reason;

--- a/ext/simpletest/main.php
+++ b/ext/simpletest/main.php
@@ -207,7 +207,7 @@ class ShimmieWebTestCase extends SCoreWebTestCase {
 
 /** @private */
 class TestFinder extends TestSuite {
-	function TestFinder($hint) {
+	function __construct($hint) {
 		if(strpos($hint, "..") !== FALSE) return;
 		
 		// Select the test cases for "All" extensions.

--- a/ext/simpletest/theme.php
+++ b/ext/simpletest/theme.php
@@ -10,7 +10,7 @@ class SCoreWebReporter extends HtmlReporter {
 	var $fails;
 	var $exceptions;
 
-	public function SCoreReporter(Page $page) {
+	public function __construct(Page $page) {
 		$this->page = $page;
 		$this->fails = 0;
 		$this->exceptions = 0;

--- a/ext/tag_edit/main.php
+++ b/ext/tag_edit/main.php
@@ -43,7 +43,7 @@ class OwnerSetEvent extends Event {
 	var $image;
 	var $owner;
 
-	public function OwnerSetEvent(Image $image, User $owner) {
+	public function __construct(Image $image, User $owner) {
 		$this->image = $image;
 		$this->owner = $owner;
 	}
@@ -60,7 +60,7 @@ class SourceSetEvent extends Event {
 	var $image;
 	var $source;
 
-	public function SourceSetEvent(Image $image, $source) {
+	public function __construct(Image $image, $source) {
 		$this->image = $image;
 		$this->source = $source;
 	}
@@ -77,7 +77,7 @@ class TagSetEvent extends Event {
 	var $image;
 	var $tags;
 
-	public function TagSetEvent(Image $image, $tags) {
+	public function __construct(Image $image, $tags) {
 		$this->image = $image;
 		$this->tags = Tag::explode($tags);
 	}
@@ -93,7 +93,7 @@ class LockSetEvent extends Event {
 	var $image;
 	var $locked;
 
-	public function LockSetEvent(Image $image, $locked) {
+	public function __construct(Image $image, $locked) {
 		assert(is_bool($locked));
 		$this->image = $image;
 		$this->locked = $locked;
@@ -109,7 +109,7 @@ class TagTermParseEvent extends Event {
 	var $id = null;
 	var $metatag = false;
 
-	public function TagTermParseEvent($term, $id) {
+	public function __construct($term, $id) {
 		$this->term = $term;
 		$this->id = $id;
 	}

--- a/ext/upload/main.php
+++ b/ext/upload/main.php
@@ -19,7 +19,7 @@ class DataUploadEvent extends Event {
 	 * @param $tmpname The temporary file used for upload.
 	 * @param $metadata Info about the file, should contain at least "filename", "extension", "tags" and "source".
 	 */
-	public function DataUploadEvent(/*string*/ $tmpname, /*array*/ $metadata) {
+	public function __construct(/*string*/ $tmpname, /*array*/ $metadata) {
 		assert(file_exists($tmpname));
 
 		$this->tmpname = $tmpname;

--- a/ext/view/main.php
+++ b/ext/view/main.php
@@ -31,7 +31,7 @@ class ImageInfoBoxBuildingEvent extends Event {
 	var $image;
 	var $user;
 
-	public function ImageInfoBoxBuildingEvent(Image $image, User $user) {
+	public function __construct(Image $image, User $user) {
 		$this->image = $image;
 		$this->user = $user;
 	}
@@ -45,7 +45,7 @@ class ImageInfoBoxBuildingEvent extends Event {
 class ImageInfoSetEvent extends Event {
 	var $image;
 
-	public function ImageInfoSetEvent(Image $image) {
+	public function __construct(Image $image) {
 		$this->image = $image;
 	}
 }
@@ -55,7 +55,7 @@ class ImageAdminBlockBuildingEvent extends Event {
 	var $image = null;
 	var $user = null;
 
-	public function ImageAdminBlockBuildingEvent(Image $image, User $user) {
+	public function __construct(Image $image, User $user) {
 		$this->image = $image;
 		$this->user = $user;
 	}


### PR DESCRIPTION
Seems that lots of the scrutinizer-ci warnings are false-positives due to the mixing of old and new style constructors, hopefully this will make them go away so the more important warnings are clearer :3
