### PR TITLE
Redirect to default page if referer isn't set

### DIFF
--- a/ext/mass_tagger/main.php
+++ b/ext/mass_tagger/main.php
@@ -53,6 +53,7 @@ class MassTagger extends Extension {
 		}
 		
 		$page->set_mode("redirect");
+		if(!isset($_SERVER['HTTP_REFERER'])) $_SERVER['HTTP_REFERER'] = make_link();
 		$page->set_redirect($_SERVER['HTTP_REFERER']);
 	}
 }


### PR DESCRIPTION
Instead of displaying `You should be redirected to <a href=""></a>`
