### PR TITLE
Special chars in tags barf filter_var

### DIFF
--- a/ext/ouroboros_api/main.php
+++ b/ext/ouroboros_api/main.php
@@ -387,9 +387,11 @@ class OuroborosAPI extends Extension
                     // @TODO Should move the validation logic into OuroborosPost instead?
                     if ($user->can("create_image")) {
                         $post = array(
-                            'tags' => !empty($_REQUEST['post']['tags']) ? filter_var(
-                                    urldecode($_REQUEST['post']['tags']),
-                                    FILTER_SANITIZE_STRING
+                            'tags' => !empty($_REQUEST['post']['tags']) ? Tag::implode(
+                                    array_map(
+                                        array('Tag', 'sanitise'),
+                                        Tag::explode(urldecode($_REQUEST['post']['tags']))
+                                    )
                                 ) : 'tagme',
                             'file' => !empty($_REQUEST['post']['file']) ? filter_var(
                                     $_REQUEST['post']['file'],


### PR DESCRIPTION
Due to how FILTER_SANITIZE_STRING works, if you had special chars in
your tags (eg. <3 or !) the string would be cut before the offending
character(s) and in worst case, result in no tags passing to the API

(re-created the old pullrequest #398 in develop-branch)
