### PR TITLE
Added check to initialize tags, when only categorized tags are available...

### DIFF
--- a/ext/tag_list/theme.php
+++ b/ext/tag_list/theme.php
@@ -62,7 +62,7 @@ class TagListTheme extends Themelet {
 		}
 
 		asort($tag_categories_html);
-		$main_html = $tag_categories_html[' '];
+		if(isset($tag_categories_html[' '])) $main_html = $tag_categories_html[' ']; else $main_html = null;
 		unset($tag_categories_html[' ']);
 
 		foreach(array_keys($tag_categories_html) as $category) {
@@ -272,4 +272,3 @@ class TagListTheme extends Themelet {
 		return make_link("post/list/$u_tag/1");
 	}
 }
-


### PR DESCRIPTION
... for image

Without this if/initialization there was a PHP-Notice to warn for the not set variable.
This will fix it.

(Usualy one does not show notices, but they are still logged and therefore one is collecting dump in the logfiles)
![screenshot](https://cloud.githubusercontent.com/assets/4625629/3217487/11be56e2-efe0-11e3-984b-20f986812ef4.png)
