### PR TITLE
give mp3s width and height, for sake of thumbnailing

### DIFF
--- a/ext/handle_mp3/main.php
+++ b/ext/handle_mp3/main.php
@@ -34,9 +34,9 @@ class MP3FileHandler extends DataHandlerExtension {
 
 		$image = new Image();
 
-		// FIXME: need more flash format specs :|
-		$image->width = 0;
-		$image->height = 0;
+		// this needs to be a square, larger than thumbnail size
+		$image->width = 1000;
+		$image->height = 1000;
 
 		$image->filesize  = $metadata['size'];
 		$image->hash      = $metadata['hash'];


### PR DESCRIPTION
width and height of 0 means that the thumbnails are 0x0, which also creates a divide by zero error... Claiming that they have a width and height (even though they're not images) makes the thumbnailing work