### PR TITLE
Only examine response headers if we actually have them & remove duplicate 'class' attribute.

### DIFF
--- a/core/util.inc.php
+++ b/core/util.inc.php
@@ -960,11 +960,6 @@ function transload($url, $mfile) {
 		fwrite($fp, $data);
 		fclose($fp);
 
-		//
-		// Scrutinizer-ci complains that $http_response_header does not exist,
-		// however, $http_response_header is actually a super-global.
-		// I have filed a bug with PHP-Analyzer here: https://github.com/scrutinizer-ci/php-analyzer/issues/212
-		//
 		$headers = http_parse_headers(implode("\n", $http_response_header));
 
 		return $headers;

--- a/ext/tag_edit/theme.php
+++ b/ext/tag_edit/theme.php
@@ -49,7 +49,7 @@ class TagEditTheme extends Themelet {
 				<td>
 		".($user->can("edit_image_tag") ? "
 					<span class='view'>$h_tag_links</span>
-					<input class='edit' type='text' name='tag_edit__tags' value='$h_tags' class='autocomplete_tags' id='tag_editor'>
+					<input class='edit autocomplete_tags' type='text' name='tag_edit__tags' value='$h_tags' id='tag_editor'>
 		" : "
 					$h_tag_links
 		")."

--- a/ext/upload/main.php
+++ b/ext/upload/main.php
@@ -364,9 +364,10 @@ class Upload extends Extension {
 
 		$tmp_filename = tempnam(ini_get('upload_tmp_dir'), "shimmie_transload");
 
+		// transload() returns Array or Bool, depending on the transload_engine.
 		$headers = transload($url, $tmp_filename);
-
-		$s_filename = findHeader($headers, 'Content-Disposition');
+		
+		$s_filename = is_array($headers) ? findHeader($headers, 'Content-Disposition') : null;
 		$h_filename = ($s_filename ? preg_replace('/^.*filename="([^ ]+)"/i', '$1', $s_filename) : null);
 		$filename = $h_filename ?: basename($url);
 


### PR DESCRIPTION
This pull request is a minor change that fixes the warnings issue (reported in #487) and also fixes the auto-complete for the tag edit box (reported in #489).

```
Warning: array_key_exists() expects parameter 2 to be array, boolean given in /home/xxx/public_html/core/util.inc.php on line 1004

Warning: array_change_key_case() expects parameter 1 to be array, boolean given in /home/xxx/public_html/core/util.inc.php on line 1007

Warning: array_key_exists() expects parameter 2 to be array, null given in /home/xxx/public_html/core/util.inc.php on line 1008

Warning: array_key_exists() expects parameter 2 to be array, boolean given in /home/xxx/public_html/core/util.inc.php on line 1004

Warning: array_change_key_case() expects parameter 1 to be array, boolean given in /home/xxx/public_html/core/util.inc.php on line 1007

Warning: array_key_exists() expects parameter 2 to be array, null given in /home/xxx/public_html/core/util.inc.php on line 1008
```

Basically, transload() will return a Bool us wget is set as the transload_engine.
In this case, we have no headers to examine and shouldn't call findHeaders().
