### PR TITLE
Fixes #505 & other small fixes

### DIFF
--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -1168,6 +1168,7 @@ class Tag {
 	 */
 	public static function resolve_alias($tag) {
 		assert('is_string($tag)');
+		global $database;
 
 		$negative = false;
 		if(!empty($tag) && ($tag[0] == '-')) {
@@ -1175,14 +1176,18 @@ class Tag {
 			$tag = substr($tag, 1);
 		}
 
-		global $database;
+
 		$newtag = $database->get_one(
 			$database->scoreql_to_sql("SELECT newtag FROM aliases WHERE SCORE_STRNORM(oldtag)=SCORE_STRNORM(:tag)"),
-			array("tag"=>$tag));
+			array("tag"=>$tag)
+		);
+
 		if(empty($newtag)) {
+			//tag has no alias, use old tag
 			$newtag = $tag;
 		}
-		return $negative ? "-$newtag" : $newtag;
+
+		return !$negative ? $newtag : preg_replace("/(\S+)/", "-$1", $newtag);
 	}
 
 	/**

--- a/core/util.inc.php
+++ b/core/util.inc.php
@@ -1257,39 +1257,39 @@ function full_copy($source, $target) {
  * @return array file list
  */
 function list_files(/*string*/ $base, $_sub_dir="") {
-    assert(is_dir($base));
+	assert(is_dir($base));
 
-    $file_list = array();
+	$file_list = array();
 
-    $files = array();
-    $dir = opendir("$base/$_sub_dir");
-    while($f = readdir($dir)) {
-        $files[] = $f;
-    }
-    closedir($dir);
-    sort($files);
+	$files = array();
+	$dir = opendir("$base/$_sub_dir");
+	while($f = readdir($dir)) {
+		$files[] = $f;
+	}
+	closedir($dir);
+	sort($files);
 
-    foreach($files as $filename) {
-        $full_path = "$base/$_sub_dir/$filename";
+	foreach($files as $filename) {
+		$full_path = "$base/$_sub_dir/$filename";
 
-        if(is_link($full_path)) {
-            // ignore
-        }
-        else if(is_dir($full_path)) {
-            if($filename == "." || $filename == "..") {
-                $file_list = array_merge(
-                    $file_list,
-                    list_files($base, "$_sub_dir/$filename")
-                );
-            }
-        }
-        else {
-            $full_path = str_replace("//", "/", $full_path);
-            $file_list[] = $full_path;
-        }
-    }
+		if(is_link($full_path)) {
+			// ignore
+		}
+		else if(is_dir($full_path)) {
+			if($filename == "." || $filename == "..") {
+				$file_list = array_merge(
+					$file_list,
+					list_files($base, "$_sub_dir/$filename")
+				);
+			}
+		}
+		else {
+			$full_path = str_replace("//", "/", $full_path);
+			$file_list[] = $full_path;
+		}
+	}
 
-    return $file_list;
+	return $file_list;
 }
 
 

--- a/core/util.inc.php
+++ b/core/util.inc.php
@@ -1276,7 +1276,8 @@ function list_files(/*string*/ $base, $_sub_dir="") {
 			// ignore
 		}
 		else if(is_dir($full_path)) {
-			if($filename == "." || $filename == "..") {
+			if(!($filename == "." || $filename == "..")) {
+				//subdirectory found
 				$file_list = array_merge(
 					$file_list,
 					list_files($base, "$_sub_dir/$filename")

--- a/ext/bulk_add/main.php
+++ b/ext/bulk_add/main.php
@@ -24,6 +24,12 @@ class BulkAdd extends Extension {
 				$list = add_dir($_POST['dir']);
 				if(strlen($list) > 0) {
 					$this->theme->add_status("Adding files", $list);
+				} else {
+					if(is_dir($_POST['dir'])) {
+						$this->theme->add_status("No files in directory", "No files exists in specified directory ({$_POST['dir']}).");
+					} else {
+						$this->theme->add_status("Directory does not exist", "Specified directory does not exist ({$_POST['dir']}).");
+					}
 				}
 				$this->theme->display_upload_results($page);
 			}

--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -143,7 +143,7 @@ class PoolsTheme extends Themelet {
 			<br><a href="'.make_link("pool/updated").'">Pool Changes</a>
 		';
 
-		$page->add_block(new Block($nav_html, null, "left", 5));
+		$page->add_block(new Block($nav_html, null, "left", 5, "indexnavleft"));
 		$page->add_block(new Block("Pool Navigation", $poolnav_html, "left", 10));
 
 		if(count($pools) == 1) {


### PR DESCRIPTION
This should fix the issue in #505.
Bulk_Add no longer gets stuck in loop when checking for subdirectory & properly notifies the user if files don't exist in directory or directory doesn't exist, rather than showing no handler exist error.

Two other minor fixes included:
* Negative aliases should properly convert each aliased tag to negative, rather than just the first tag.
* Pools index link was throwing JS errors as was also being used as ID, using specified ID fixes this.