### PR TITLE
Move tag sanitization, alias resolving & tag parsing from set_tags > TagSetEvent

### DIFF
--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -627,8 +627,9 @@ class Image {
 	 * Send list of metatags to be parsed.
 	 *
 	 * @param [] $metatags
+	 * @param int $image_id
 	 */
-	public function parse_metatags(/*arr*/ $metatags, $image_id) {
+	public function parse_metatags($metatags, $image_id) {
 		foreach($metatags as $tag) {
 			$ttpe = new TagTermParseEvent($tag, $image_id, TRUE);
 			send_event($ttpe);

--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -576,9 +576,6 @@ class Image {
 		assert('is_array($tags) && count($tags) > 0', var_export($tags, true));
 		global $database;
 
-		$tags = array_map(array('Tag', 'sanitise'), $tags);
-		$tags = Tag::resolve_aliases($tags);
-
 		if(count($tags) <= 0) {
 			throw new SCoreException('Tried to set zero tags');
 		}
@@ -588,12 +585,6 @@ class Image {
 			$this->delete_tags_from_image();
 			// insert each new tags
 			foreach($tags as $tag) {
-				$ttpe = new TagTermParseEvent($tag, $this->id);
-				send_event($ttpe);
-				if($ttpe->is_metatag()) {
-					continue;
-				}
-
 				if(mb_strlen($tag, 'UTF-8') > 255){
 					flash_message("The tag below is longer than 255 characters, please use a shorter tag.\n$tag\n");
 					continue;

--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -1247,7 +1247,7 @@ class Tag {
 		$i = 0;
 		$tag_count = count($tags);
 		while($i<$tag_count) {
-			$aliases = explode(' ', Tag::resolve_alias($tags[$i]));
+			$aliases = Tag::explode(Tag::resolve_alias($tags[$i]), FALSE);
 			foreach($aliases as $alias){
 				if(!in_array($alias, $new)){
 					if($tags[$i] == $alias){

--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -1147,6 +1147,8 @@ class Tag {
 			$tag_array = array("tagme");
 		}
 
+		$tag_array = array_iunique($tag_array); //remove duplicate tags
+
 		sort($tag_array);
 
 		return $tag_array;

--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -624,6 +624,18 @@ class Image {
 	}
 
 	/**
+	 * Send list of metatags to be parsed.
+	 *
+	 * @param [] $metatags
+	 */
+	public function parse_metatags(/*arr*/ $metatags, $image_id) {
+		foreach($metatags as $tag) {
+			$ttpe = new TagTermParseEvent($tag, $image_id, TRUE);
+			send_event($ttpe);
+		}
+	}
+
+	/**
 	 * Delete this image from the database and disk
 	 */
 	public function delete() {

--- a/ext/numeric_score/main.php
+++ b/ext/numeric_score/main.php
@@ -258,7 +258,7 @@ class NumericScore extends Extension {
 	public function onTagTermParse(TagTermParseEvent $event) {
 		$matches = array();
 
-		if(preg_match("/^vote[=|:](up|down|remove)$/", $event->term, $matches)) {
+		if(preg_match("/^vote[=|:](up|down|remove)$/", $event->term, $matches) && $event->parse) {
 			global $user;
 			$score = ($matches[1] == "up" ? 1 : ($matches[1] == "down" ? -1 : 0));
 			if(!$user->is_anonymous()) {

--- a/ext/numeric_score/main.php
+++ b/ext/numeric_score/main.php
@@ -247,9 +247,9 @@ class NumericScore extends Extension {
 				"images.id in (SELECT image_id FROM numeric_score_votes WHERE user_id=:ns_user_id AND score=-1)",
 				array("ns_user_id"=>$iid)));
 		}
-		else if(preg_match("/^order[=|:](numeric_)?(score)[_]?(desc|asc)?$/i", $event->term, $matches)){
+		else if(preg_match("/^order[=|:](?:numeric_)?(score)(?:_(desc|asc))?$/i", $event->term, $matches)){
 			$default_order_for_column = "DESC";
-			$sort = isset($matches[3]) ? strtoupper($matches[3]) : $default_order_for_column;
+			$sort = isset($matches[2]) ? strtoupper($matches[2]) : $default_order_for_column;
 			Image::$order_sql = "images.numeric_score $sort";
 			$event->add_querylet(new Querylet("1=1")); //small hack to avoid metatag being treated as normal tag
 		}

--- a/ext/relatationships/main.php
+++ b/ext/relatationships/main.php
@@ -58,7 +58,7 @@ class Relationships extends Extension {
 	public function onTagTermParse(TagTermParseEvent $event) {
 		$matches = array();
 
-		if(preg_match("/^parent[=|:]([0-9]+|none)$/", $event->term, $matches)) {
+		if(preg_match("/^parent[=|:]([0-9]+|none)$/", $event->term, $matches) && $event->parse) {
 			$parentID = $matches[1];
 
 			if($parentID == "none" || $parentID == "0"){
@@ -67,7 +67,7 @@ class Relationships extends Extension {
 				$this->set_parent($event->id, $parentID);
 			}
 		}
-		else if(preg_match("/^child[=|:]([0-9]+)$/", $event->term, $matches)) {
+		else if(preg_match("/^child[=|:]([0-9]+)$/", $event->term, $matches) && $event->parse) {
 			$childID = $matches[1];
 
 			$this->set_child($event->id, $childID);

--- a/ext/tag_edit/main.php
+++ b/ext/tag_edit/main.php
@@ -110,6 +110,13 @@ class TagSetEvent extends Event {
 		$tag_array = Tag::resolve_aliases($tag_array);
 
 		foreach($tag_array as $tag) {
+			if((strpos($tag, ':') === FALSE) && (strpos($tag, '=') === FALSE)) {
+				//Tag doesn't contain : or =, meaning it can't possibly be a metatag.
+				//This should help speed wise, as it avoids running every single tag through a bunch of preg_match instead.
+				array_push($this->tags, $tag);
+				continue;
+			}
+
 			$ttpe = new TagTermParseEvent($tag, $this->image->id, FALSE); //Only check for metatags, don't parse. Parsing is done after set_tags.
 			send_event($ttpe);
 

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -313,8 +313,8 @@ class UserPage extends Extension {
 		global $user;
 
 		$matches = array();
-		if(preg_match("/^(poster|user)[=|:](.*)$/i", $event->term, $matches)) {
-			$duser = User::by_name($matches[2]);
+		if(preg_match("/^(?:poster|user)[=|:](.*)$/i", $event->term, $matches)) {
+			$duser = User::by_name($matches[1]);
 			if(!is_null($duser)) {
 				$user_id = $duser->id;
 			}
@@ -323,12 +323,12 @@ class UserPage extends Extension {
 			}
 			$event->add_querylet(new Querylet("images.owner_id = $user_id"));
 		}
-		else if(preg_match("/^(poster|user)_id[=|:]([0-9]+)$/i", $event->term, $matches)) {
-			$user_id = int_escape($matches[2]);
+		else if(preg_match("/^(?:poster|user)_id[=|:]([0-9]+)$/i", $event->term, $matches)) {
+			$user_id = int_escape($matches[1]);
 			$event->add_querylet(new Querylet("images.owner_id = $user_id"));
 		}
-		else if($user->can("view_ip") && preg_match("/^(poster|user)_ip[=|:]([0-9\.]+)$/i", $event->term, $matches)) {
-			$user_ip = $matches[2]; // FIXME: ip_escape?
+		else if($user->can("view_ip") && preg_match("/^(?:poster|user)_ip[=|:]([0-9\.]+)$/i", $event->term, $matches)) {
+			$user_ip = $matches[1]; // FIXME: ip_escape?
 			$event->add_querylet(new Querylet("images.owner_ip = '$user_ip'"));
 		}
 	}


### PR DESCRIPTION
This should help any extension which uses onTagSet. Proper tags are now sent, and metatags are not.

Other things:
* Minor speed tweaks, which is mainly avoiding looping over possible duplicate tags & doing a simple pre-check to see if a tag could be a metatag (rather than running the tag through 10~ preg_match).
* resolve_aliases should now use Tag::explode instead of explode. This fixes a rare case where an empty tag could be passed.