### PR TITLE
Fix the notes extension to work properly on SQLite

### DIFF
--- a/ext/notes/main.php
+++ b/ext/notes/main.php
@@ -276,8 +276,7 @@ class Notes extends Extension {
 				(?, ?, ?, ?, now(), ?, ?, ?, ?, ?)",
 				array(1, $imageID, $user_id, $_SERVER['REMOTE_ADDR'], $noteX1, $noteY1, $noteHeight, $noteWidth, $noteText));
 
-		$result = $database->get_row("SELECT LAST_INSERT_ID() AS noteID", array());
-		$noteID = $result["noteID"];
+		$noteID = $database->get_last_insert_id('notes_id_seq');
 
 		log_info("notes", "Note added {$noteID} by {$user->name}");
 
@@ -304,9 +303,9 @@ class Notes extends Extension {
 				(?, ?, now())",
 				array($image_id, $user_id));
 
-		$result = $database->get_row("SELECT LAST_INSERT_ID() AS requestID", array());
+		$resultID = $database->get_last_insert_id('note_request_id_seq');
 
-		log_info("notes", "Note requested {$result["requestID"]} by {$user->name}");
+		log_info("notes", "Note requested {$requestID} by {$user->name}");
 	}
 	
 	


### PR DESCRIPTION
By default, the notes extension doesn't work with an SQLite database. Throws an error about `LAST_INSERT_ID()` not existing when you try to add a note. This PR just makes it use the equivalent SQLite function there.

It looks like Postgres would probably need something different again there. I'm not familiar with it though, so I just left it alone.