### PR TITLE
Fixes for bulk add results

### DIFF
--- a/ext/bulk_add/main.php
+++ b/ext/bulk_add/main.php
@@ -32,7 +32,11 @@ class BulkAdd extends Extension {
 				set_time_limit(0);
 				$bae = new BulkAddEvent($_POST['dir']);
 				send_event($bae);
-				if(strlen($bae->results) > 0) {
+				if(is_array($bae->results)) {
+					foreach($bae->results as $result) {
+						 $this->theme->add_status("Adding files", $result);
+					}
+				} else if(strlen($bae->results) > 0) {
 					$this->theme->add_status("Adding files", $bae->results);
 				}
 				$this->theme->display_upload_results($page);

--- a/ext/bulk_add/theme.php
+++ b/ext/bulk_add/theme.php
@@ -12,9 +12,9 @@ class BulkAddTheme extends Themelet {
 		$page->add_block(new NavBlock());
 		$html = "";
 		foreach($this->messages as $block) {
-			$html .= "<br/>" . html_escape($html);
+			$html .= "<br/>" . $block->body;
 		}
-		$page->add_block(new Block("Results", $block));
+		$page->add_block(new Block("Results", $html));
 	}
 
 	/*


### PR DESCRIPTION
The bulk add screen was having errors resulting from the block handling of the page. This allows the results to display on my system.