### PR TITLE
re-fix wildcards for mysql

### DIFF
--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -813,7 +813,7 @@ class Image {
 		 */
 
 		// no tags, do a simple search
-		if($positive_tag_count + $negative_tag_count == 0) {
+		if($positive_tag_count === 0 && $negative_tag_count === 0) {
 			$query = new Querylet("
 				SELECT images.*
 				FROM images

--- a/core/util.inc.php
+++ b/core/util.inc.php
@@ -412,6 +412,11 @@ function endsWith(/*string*/ $haystack, /*string*/ $needle) {
 	return (substr($haystack, $start) === $needle);
 }
 
+if(!function_exists("mb_strlen")) {  // D:
+	function mb_strlen($str) {return strlen($str);}
+	function mb_internal_encoding($enc) {}
+	function mb_strtolower($str) {return strtolower($str);}
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\
 * HTML Generation                                                           *


### PR DESCRIPTION
see #547

The general approach here is to keep wildcards in their wildcard form until as late as possible, so that the searching function can treat them specially (as opposed to expanding them at the start and then having no idea which tags were requested and which are part of a wildcard expansion)