### PR TITLE
Fix bookmarklets

### DIFF
--- a/ext/upload/bookmarklet.js
+++ b/ext/upload/bookmarklet.js
@@ -29,18 +29,16 @@ else if(CA === 2) { // New Tags
  * jQuery should always active here, meaning we can use jQuery in this part of the bookmarklet.
  */
 
-if(document.getElementById("post_tag_string") !== null) {
+if(document.getElementById("image-container") !== null) {
+	var imageContainer = $('#image-container')[0];
 	if (typeof tag !== "ftp://ftp." && chk !==1) {
-		var tag = $('#post_tag_string').text().replace(/\n/g, "");
+		var tag = imageContainer.getAttribute('data-tags');
 	}
 	tag = tag.replace(/\+/g, "%2B");
 
 	var source = "http://" + document.location.hostname + document.location.href.match("\/posts\/[0-9]+");
 
-	var rlist = $('[name="post[rating]"]');
-	for( var x=0; x < 3; x++){
-		var rating = (rlist[x].checked === true ? rlist[x].value : rating);
-	}
+	var rating = imageContainer.getAttribute('data-rating');
 
 	var fileinfo = $('#sidebar > section:eq(3) > ul > :contains("Size") > a');
 	var furl = "http://" + document.location.hostname + fileinfo.attr('href');

--- a/ext/upload/bookmarklet.js
+++ b/ext/upload/bookmarklet.js
@@ -92,6 +92,7 @@ else if(document.getElementById('tag-sidebar') !== null) {
 	}
 	fileinfo = fileinfo || document.getElementsByTagName('embed')[0]; //If fileinfo is null then image is most likely flash.
 	var furl = fileinfo.href || fileinfo.src;
+	furl = furl.split('?')[0]; // Remove trailing variables, if present.
 	var fs = (fileinfo.innerText.match(/[0-9]+ (KB|MB)/) || ["0 KB"])[0].split(" ");
 	var filesize = (fs[1] === "MB" ? fs[0] * 1024 : fs[0]);
 

--- a/ext/upload/bookmarklet.js
+++ b/ext/upload/bookmarklet.js
@@ -81,9 +81,14 @@ else if(document.getElementById('tag-sidebar') !== null) {
 		var fileinfo = document.getElementById("highres");
 		//NOTE: If highres doesn't exist, post must be flash (only sankakucomplex has flash)
 	}else if(source.search("gelbooru\\.com") >= 0){
-		var fileinfo = document.getElementById('pfd').parentNode.parentNode.getElementsByTagName('a')[0];
-		//gelbooru has no easy way to select the original image link, so we need to double check it is the correct link.
-		fileinfo = (fileinfo.getAttribute('href') === "#" ? document.getElementById('pfd').parentNode.parentNode.getElementsByTagName('a')[1] : fileinfo);
+		// Try to find the "Original image" link in the options sidebar.
+		var fileinfo;
+		var nodes = document.getElementById('pfd').parentNode.parentNode.getElementsByTagName('a');
+		for (var i = 0; i < nodes.length; i++) {
+			if (nodes[i].getAttribute('href') === "#") continue;
+			fileinfo = nodes[i];
+			break;
+		}
 	}
 	fileinfo = fileinfo || document.getElementsByTagName('embed')[0]; //If fileinfo is null then image is most likely flash.
 	var furl = fileinfo.href || fileinfo.src;

--- a/ext/upload/bookmarklet.js
+++ b/ext/upload/bookmarklet.js
@@ -60,15 +60,11 @@ if(document.getElementById("image-container") !== null) {
 }
 
 /*
- * konachan | sankakucomplex | gelbooru
+ * konachan | sankakucomplex | gelbooru | etc.
  */
 else if(document.getElementById('tag-sidebar') !== null) {
 	if (typeof tag !== "ftp://ftp." && chk !==1) {
-		if(document.location.href.search("sankakucomplex\\.com") >= 0 || document.location.href.search("gelbooru\\.com")){
-			var tag = document.getElementById('tag-sidebar').innerText.replace(/ /g, "_").replace(/[\?_]*(.*?)_(\(\?\)_)?[0-9]+$/gm, "$1 ");
-		}else{
-			var tag = document.getElementById("post_tags").value;
-		}
+		var tag = document.getElementById('tag-sidebar').innerText.replace(/ /g, "_").replace(/[\?_]*(.*?)_(\(\?\)_)?[0-9]+$/gm, "$1 ");
 	}
 	tag = tag.replace(/\+/g, "%2B");
 
@@ -76,10 +72,9 @@ else if(document.getElementById('tag-sidebar') !== null) {
 
 	var rating = document.getElementById("stats").innerHTML.match("Rating: ([a-zA-Z]+)")[1];
 
-	if(source.search("sankakucomplex\\.com") >= 0 || source.search("konachan\\.com") >= 0){
+	if(document.getElementById('highres') !== null) {
 		var fileinfo = document.getElementById("highres");
-		//NOTE: If highres doesn't exist, post must be flash (only sankakucomplex has flash)
-	}else if(source.search("gelbooru\\.com") >= 0){
+	}else if(document.getElementById('pfd') !== null){
 		// Try to find the "Original image" link in the options sidebar.
 		var fileinfo;
 		var nodes = document.getElementById('pfd').parentNode.parentNode.getElementsByTagName('a');
@@ -89,7 +84,7 @@ else if(document.getElementById('tag-sidebar') !== null) {
 			break;
 		}
 	}
-	fileinfo = fileinfo || document.getElementsByTagName('embed')[0]; //If fileinfo is null then image is most likely flash.
+	fileinfo = fileinfo || document.getElementsByTagName('embed')[0]; //If fileinfo is null then assume that the image is flash.
 	var furl = fileinfo.href || fileinfo.src;
 	furl = furl.split('?')[0]; // Remove trailing variables, if present.
 	var fs = (fileinfo.innerText.match(/[0-9]+ (KB|MB)/) || ["0 KB"])[0].split(" ");

--- a/ext/upload/bookmarklet.js
+++ b/ext/upload/bookmarklet.js
@@ -49,6 +49,7 @@ if(document.getElementById("post_tag_string") !== null) {
 
 	if(supext.search(furl.match("[a-zA-Z0-9]+$")[0]) !== -1){
 		if(filesize <= maxsize){
+			history.pushState(history.state, document.title, location.href);
 			location.href = ste+furl+"&tags="+tag+"&rating="+rating+"&source="+source;
 		}
 		else{
@@ -98,6 +99,7 @@ else if(document.getElementById('tag-sidebar') !== null) {
 
 	if(supext.search(furl.match("[a-zA-Z0-9]+$")[0]) !== -1){
 		if(filesize <= maxsize){
+			history.pushState(history.state, document.title, location.href);
 			location.href = ste+furl+"&tags="+tag+"&rating="+rating+"&source="+source;
 		}
 		else{
@@ -134,6 +136,7 @@ else if(document.getElementsByTagName("title")[0].innerHTML.search("Image [0-9.-
 	if(tag.search(/\bflash\b/) === -1) {
 		var img = document.getElementById("main_image").src;
 		if(supext.search(img.match(".*\\.([a-z0-9]+)")[1]) !== -1) {
+			history.pushState(history.state, document.title, location.href);
 			location.href = ste+img+"&tags="+tag+"&source="+source;
 		}
 		else{
@@ -143,6 +146,7 @@ else if(document.getElementsByTagName("title")[0].innerHTML.search("Image [0-9.-
 	else{
 		var mov = document.location.hostname+document.getElementsByName("movie")[0].value;
 		if(supext.search("swf") !== -1) {
+			history.pushState(history.state, document.title, location.href);
 			location.href = ste+mov+"&tags="+tag+"&source="+source;
 		}
 		else{

--- a/ext/upload/bookmarklet.js
+++ b/ext/upload/bookmarklet.js
@@ -66,7 +66,7 @@ if(document.getElementById("post_tag_string") !== null) {
 else if(document.getElementById('tag-sidebar') !== null) {
 	if (typeof tag !== "ftp://ftp." && chk !==1) {
 		if(document.location.href.search("sankakucomplex\\.com") >= 0 || document.location.href.search("gelbooru\\.com")){
-			var tag = document.getElementById('tag-sidebar').innerText.replace(/ /g, "_").replace(/[\?_]*(.*?)_(\(\?\)_)?[0-9]+\n/g, "$1 ");
+			var tag = document.getElementById('tag-sidebar').innerText.replace(/ /g, "_").replace(/[\?_]*(.*?)_(\(\?\)_)?[0-9]+$/gm, "$1 ");
 		}else{
 			var tag = document.getElementById("post_tags").value;
 		}

--- a/ext/upload/main.php
+++ b/ext/upload/main.php
@@ -389,11 +389,14 @@ class Upload extends Extension {
 			$metadata['tags'] = $tags;
 			$metadata['source'] = (($url == $source) && !$config->get_bool('upload_tlsource') ? "" : $source);
 			
+			$ext = false;
 			if (is_array($headers)) {
-				$metadata['extension'] = getExtension(findHeader($headers, 'Content-Type'));
-			} else {
-				$metadata['extension'] = $pathinfo['extension'];
+				$ext = getExtension(findHeader($headers, 'Content-Type'));
 			}
+			if ($ext === false) {
+				$ext = $pathinfo['extension'];
+			}
+			$metadata['extension'] = $ext;
 			
 			/* check for locked > adds to metadata if it has */
 			if(!empty($locked)){

--- a/ext/upload/theme.php
+++ b/ext/upload/theme.php
@@ -228,6 +228,7 @@ class UploadTheme extends Themelet {
 		if(class_exists("ICOFileHandler")){$supported_ext .= " ico ani cur";}
 		if(class_exists("MP3FileHandler")){$supported_ext .= " mp3";}
 		if(class_exists("SVGFileHandler")){$supported_ext .= " svg";}
+		if(class_exists("VideoFileHandler")){$supported_ext .= " flv mp4 ogv webm m4v";}
 		$title = "Booru to " . $config->get_string('title');
 		// CA=0: Ask to use current or new tags | CA=1: Always use current tags | CA=2: Always use new tags
 		$html .= '<p><a href="javascript:


### PR DESCRIPTION
This should fix some of the issues with bookmarklets.

### Known limitations:
- Importing from another Shimmie was and still is troublesome. It still has difficulty with videos and ratings in this regard, from what I've tested.
- If the source is using HTTPS, then the destination will have to as well. Otherwise it won't work in most popular browsers due to mixed content errors. It's recommended that the destination be using HTTPS for the highest compatibility.
- A few sites still don't work due to hotlink protection.