### PR TITLE
Added video playback options for autoplay and loop

### DIFF
--- a/ext/handle_video/main.php
+++ b/ext/handle_video/main.php
@@ -2,7 +2,7 @@
 /*
  * Name: Handle Video
  * Author: velocity37 <velocity37@gmail.com>
- * Modified By: Shish <webmaster@shishnet.org>, jgen <jeffgenovy@gmail.com>
+ * Modified By: Shish <webmaster@shishnet.org>, jgen <jeffgenovy@gmail.com>, im-mi <im.mi.mail.mi@gmail.com>
  * License: GPLv2
  * Description: Handle FLV, MP4, OGV and WEBM video files.
  * Documentation:
@@ -42,6 +42,9 @@ class VideoFileHandler extends DataHandlerExtension {
 			$config->set_int("ext_handle_video_version", 1);
 			log_info("pools", "extension installed");
 		}
+
+		$config->set_default_bool('video_playback_autoplay', TRUE);
+		$config->set_default_bool('video_playback_loop', TRUE);
 	}
 
 	public function onSetupBuilding(SetupBuildingEvent $event) {
@@ -66,6 +69,12 @@ class VideoFileHandler extends DataHandlerExtension {
 		$sb->add_label("<br>");
 		$sb->add_bool_option("video_thumb_ignore_aspect_ratio", "Ignore aspect ratio when creating thumbnails: ");
 
+		$event->panel->add_block($sb);
+		
+		$sb = new SetupBlock("Video Playback Options");
+		$sb->add_bool_option("video_playback_autoplay", "Autoplay: ");
+		$sb->add_label("<br>");
+		$sb->add_bool_option("video_playback_loop", "Loop: ");
 		$event->panel->add_block($sb);
 	}
 

--- a/ext/handle_video/theme.php
+++ b/ext/handle_video/theme.php
@@ -2,10 +2,13 @@
 
 class VideoFileHandlerTheme extends Themelet {
 	public function display_image(Page $page, Image $image) {
+		global $config;
 		$ilink = $image->get_image_link();
 		$thumb_url = make_http($image->get_thumb_link()); //used as fallback image
 		$ext = strtolower($image->get_ext());
 		$full_url = make_http($ilink);
+		$autoplay = $config->get_bool("video_playback_autoplay");
+		$loop = $config->get_bool("video_playback_loop");
 
 		$html = "Video not playing? <a href='" . $image->parse_link_template(make_link('image/$id/$id%20-%20$tags.$ext')) . "'>Click here</a> to download the file.<br/>";
 
@@ -25,7 +28,12 @@ class VideoFileHandlerTheme extends Themelet {
 							<param name=\"allowFullScreen\" value=\"true\" />
 							<param name=\"wmode\" value=\"opaque\" />
 
-							<param name=\"flashVars\" value=\"controls=true&autoplay=true&poster={$thumb_url}&file={$full_url}\" />
+							<param name=\"flashVars\" value=\""
+								. "controls=true"
+								. "&autoplay=" . ($autoplay ? 'true' : 'false')
+								. "&poster={$thumb_url}"
+								. "&file={$full_url}"
+								. "&loop=" . ($loop ? 'true' : 'false') . "\" />
 							<img src=\"{$thumb_url}\" />
 						</object>";
 
@@ -34,7 +42,7 @@ class VideoFileHandlerTheme extends Themelet {
 				$html .= $html_fallback;
 			} else {
 				$html .= "
-					<video controls autoplay width=\"100%\">
+					<video controls " . ($autoplay ? 'autoplay' : '') . " width=\"100%\" " . ($loop ? 'loop' : '') . ">
 						<source src='{$ilink}' type='{$supportedExts[$ext]}'>
 
 						<!-- If browser doesn't support filetype, fallback to flash -->


### PR DESCRIPTION
This patch adds a board config block for video playback options.

Two new options are available:
- Autoplay (default = true)
- Loop* (default = true)

It works with the HTML5 player and _probably_ with the Flash player. I haven't been able to test the latter because it doesn't work at all for me on the develop branch.

\* This makes looping the default again (a0a39784d42fe02ba63b6c1a3e631352539313b2). The move from Jaris to MediaElement (b0daab87662adf130ebca9a3f9efe24c0dd44cfd) had disabled it.