### PR TITLE
Fix tags not being escaped for HTML in some cases (code injection vulnerability)

### DIFF
--- a/core/basethemelet.class.php
+++ b/core/basethemelet.class.php
@@ -54,7 +54,7 @@ class BaseThemelet {
 		$h_view_link = make_link('post/view/'.$i_id);
 		$h_thumb_link = $image->get_thumb_link();
 		$h_tip = html_escape($image->get_tooltip());
-		$h_tags = strtolower($image->get_tag_list());
+		$h_tags = html_escape(strtolower($image->get_tag_list()));
 
 		$extArr = array_flip(array('swf', 'svg', 'mp3')); //List of thumbless filetypes
 		if(!isset($extArr[$image->ext])){

--- a/ext/tag_list/theme.php
+++ b/ext/tag_list/theme.php
@@ -216,7 +216,7 @@ class TagListTheme extends Themelet {
 		$count = $row['calc_count'];
 		// if($n++) $display_html .= "\n<br/>";
 		if(!is_null($config->get_string('info_link'))) {
-			$link = str_replace('$tag', $tag, $config->get_string('info_link'));
+			$link = html_escape(str_replace('$tag', $tag, $config->get_string('info_link')));
 			$display_html .= ' <a class="tag_info_link'.$tag_category_css.'" '.$tag_category_style.'href="'.$link.'">?</a>';
 		}
 		$link = $this->tag_link($row['tag']);


### PR DESCRIPTION
This fixes an issue where tags were not always escaped, allowing for code injection.

Try adding this tag to a post, then view it in the post list:
`'><script>alert("BOO!");</script>`