### PR TITLE
Update pool description formatter (code injection vulnerability)

### DIFF
--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -154,8 +154,9 @@ class PoolsTheme extends Themelet {
 				}
 			}
 
-			$bb = new BBCode();
-			$page->add_block(new Block(html_escape($pool['title']), $bb->format($pool['description']), "main", 10));
+			$tfe = new TextFormattingEvent($pool['description']);
+			send_event($tfe);
+			$page->add_block(new Block(html_escape($pool['title']), $tfe->formatted, "main", 10));
 		}
 	}
 


### PR DESCRIPTION
Fixes a code injection vulnerability where pool descriptions were allowed to have arbitrary HTML in them.

For reference, try using this as a pool description:
`<script>alert("BOO!");</script>`

It should be noted that I only guessed at this solution based on what the comments extension does. It seems to work, though.