### PR TITLE
Fix "starts-with" header in tag list when escaping required

### DIFF
--- a/ext/tag_list/main.php
+++ b/ext/tag_list/main.php
@@ -297,13 +297,15 @@ class TagList extends Extension {
 		
 		$lastLetter = "";
 		foreach($tag_data as $row) {
-			$h_tag = html_escape($row['tag']);
-			$count = $row['count'];
-			if($lastLetter != mb_strtolower(substr($h_tag, 0, count($starts_with)+1))) {
-				$lastLetter = mb_strtolower(substr($h_tag, 0, count($starts_with)+1));
-				$html .= "<p>$lastLetter<br>";
+			$tag = $row['tag'];
+			if($lastLetter != mb_strtolower(substr($tag, 0, count($starts_with)+1))) {
+				$lastLetter = mb_strtolower(substr($tag, 0, count($starts_with)+1));
+				$h_lastLetter = html_escape($lastLetter); 
+				$html .= "<p>$h_lastLetter<br>";
 			}
-			$link = $this->tag_link($row['tag']);
+			$link = $this->tag_link($tag);
+			$h_tag = html_escape($tag);
+			$count = $row['count'];
 			$html .= "<a href='$link'>$h_tag&nbsp;($count)</a>\n";
 		}
 


### PR DESCRIPTION
This fixes the "starts-with" headers* on the tags/alphabetic page. Before, the headers would be wrong if they started with an escaped character.

This also escapes the resulting header so that it no longer generates invalid HTML in such cases.

\* Note that these headers are only visible when paged tag lists is disabled.