### PR TITLE
Enhance zoom

### DIFF
--- a/ext/handle_ico/theme.php
+++ b/ext/handle_ico/theme.php
@@ -4,7 +4,8 @@ class IcoFileHandlerTheme extends Themelet {
 	public function display_image(Page $page, Image $image) {
 		$ilink = make_link("get_ico/{$image->id}/{$image->id}.ico");
 		$html = "
-			<img id='main_image' src='$ilink'>
+			<img id='main_image' class='shm-main-image' alt='main image' src='$ilink'
+			data-width='{$image->width}' data-height='{$image->height}'>
 		";
 		$page->add_block(new Block("Image", $html, "main", 10));
 	}

--- a/ext/handle_pixel/script.js
+++ b/ext/handle_pixel/script.js
@@ -1,5 +1,7 @@
 $(function() {
-	function zoom(zoom_type) {
+	function zoom(zoom_type, save_cookie) {
+		save_cookie = save_cookie === undefined ? true : save_cookie;
+		
 		var img = $('.shm-main-image');
 		
 		if(zoom_type == "full") {
@@ -21,7 +23,9 @@ $(function() {
 		
 		$(".shm-zoomer").val(zoom_type);
 		
-		Cookies.set("ui-image-zoom", zoom_type, {expires: 365});
+		if (save_cookie) {
+			Cookies.set("ui-image-zoom", zoom_type, {expires: 365});
+		}
 	}
 
 	$(".shm-zoomer").change(function(e) {
@@ -29,7 +33,7 @@ $(function() {
 	});
 	$(window).resize(function(e) {
 		$(".shm-zoomer").each(function (e) {
-			zoom(this.options[this.selectedIndex].value)
+			zoom(this.options[this.selectedIndex].value, false)
 		});
 	});
 

--- a/ext/handle_pixel/script.js
+++ b/ext/handle_pixel/script.js
@@ -27,6 +27,11 @@ $(function() {
 	$(".shm-zoomer").change(function(e) {
 		zoom(this.options[this.selectedIndex].value);
 	});
+	$(window).resize(function(e) {
+		$(".shm-zoomer").each(function (e) {
+			zoom(this.options[this.selectedIndex].value)
+		});
+	});
 
 	$("img.shm-main-image").click(function(e) {
 		switch(Cookies.get("ui-image-zoom")) {

--- a/ext/handle_pixel/script.js
+++ b/ext/handle_pixel/script.js
@@ -28,7 +28,7 @@ $(function() {
 		zoom(this.options[this.selectedIndex].value);
 	});
 
-	$(".shm-main-image").click(function(e) {
+	$("img.shm-main-image").click(function(e) {
 		switch(Cookies.get("ui-image-zoom")) {
 			case "full": zoom("width"); break;
 			default: zoom("full"); break;

--- a/ext/handle_svg/main.php
+++ b/ext/handle_svg/main.php
@@ -101,6 +101,9 @@ class MiniSVGParser {
 	/** @var int */
 	public $height=0;
 
+	/** @var int */
+	private $xml_depth=0;
+
 	/** @param string $file */
 	function __construct($file) {
 		$xml_parser = xml_parser_create();
@@ -110,13 +113,15 @@ class MiniSVGParser {
 	}
 
 	function startElement($parser, $name, $attrs) {
-		if($name == "SVG") {
+		if($name == "SVG" && $this->xml_depth == 0) {
 			$this->width = int_escape($attrs["WIDTH"]);
 			$this->height = int_escape($attrs["HEIGHT"]);
 		}
+		$this->xml_depth++;
 	}
 
 	function endElement($parser, $name) {
+		$this->xml_depth--;
 	}
 }
 

--- a/ext/handle_svg/theme.php
+++ b/ext/handle_svg/theme.php
@@ -5,8 +5,8 @@ class SVGFileHandlerTheme extends Themelet {
 		$ilink = make_link("get_svg/{$image->id}/{$image->id}.svg");
 //		$ilink = $image->get_image_link();
 		$html = "
-			<object data='$ilink' type='image/svg+xml' width='{$image->width}' height='{$image->height}'>
-			    <embed src='$ilink' type='image/svg+xml' width='{$image->width}' height='{$image->height}' />
+			<object data='$ilink' type='image/svg+xml' data-width='{$image->width}' data-height='{$image->height}' id='main_image' class='shm-main-image'>
+				<embed src='$ilink' type='image/svg+xml' />
 			</object>
 		";
 		$page->add_block(new Block("Image", $html, "main", 10));

--- a/ext/handle_video/theme.php
+++ b/ext/handle_video/theme.php
@@ -42,7 +42,12 @@ class VideoFileHandlerTheme extends Themelet {
 				$html .= $html_fallback;
 			} else {
 				$html .= "
-					<video controls " . ($autoplay ? 'autoplay' : '') . " width=\"100%\" " . ($loop ? 'loop' : '') . ">
+					<video controls class='shm-main-image' id='main_image' alt='main image'"
+						. ($autoplay ? ' autoplay' : '')
+						. ($loop ? ' loop' : '')
+						. " data-width='{$image->width}' "
+						. " data-height='{$image->height}'>
+
 						<source src='{$ilink}' type='{$supportedExts[$ext]}'>
 
 						<!-- If browser doesn't support filetype, fallback to flash -->


### PR DESCRIPTION
# New features

- Added zoom support to webm, svg, and ico
    - Note that this makes webm no longer stretch to 100% width. An additional zoom mode could be added if the old behavior is desired.
- Re-apply zoom upon window resize
    - This affects the "Fit Height" and "Fit Both" zoom modes. Before, the user would have to refresh the page or toggle zoom settings to get the zoom to update.
- When loading an SVG, it now uses the size of the outermost SVG element. Before, the size could be reported incorrectly when there were nested SVG elements.



# Considerations

- The code that handles zooming is part of the handle_pixel extension. Making it handle other formats may be considered a breach of responsibility. Perhaps the zoom functionality could be moved to its own extension.
- This expands the usage of `.shm-main-image` and `#main_image` to other types of main post content. This has implications for CSS because now post content can be styled at once, regardless of whether it is pixel, webm, svg, or ico. Personally, I feel that this is a good change.



# Limitations

- I didn't expand support to flash-based video. I can't test it (flash video doesn't work for me), and its height is hard-coded to 480px which makes me feel that changing it may break something.
- Click-to-zoom is disabled for webm so that the player controls are still accessible.
- Click-to-zoom is disabled for SVG because said format can contain interactive content and I couldn't get SVG click detection to work in any browser anyways.



# Issues

- Supporting zooming means that the content's width and height can't be set directly in the HTML. This may cause jitteriness because then determining the content's size is deferred until handle_pixel's zoom script runs. Note that this issue already affected pixel images.
- The SVG theme uses a double-elemented method of embedding SVGs (`<object><embed/><object>`). This could potentially cause issues in some browsers because it's currently set such that the zoom code only interacts with the outer `<object>` element. Regardless, it works on the latest desktop Chrome, Edge, and Firefox.