### PR TITLE
Mass tagger fixes

### DIFF
--- a/ext/mass_tagger/script.js
+++ b/ext/mass_tagger/script.js
@@ -34,3 +34,8 @@ function toggle_tag( button, id ) {
 		list.val(string);
 	}
 }
+
+$(function () {
+	// Clear the selection, in case it was autocompleted by the browser.
+	$('#mass_tagger_ids').val("");
+});

--- a/ext/mass_tagger/script.js
+++ b/ext/mass_tagger/script.js
@@ -24,12 +24,12 @@ function toggle_tag( button, id ) {
     var string = list.val();
     
     if( (string.indexOf(id) == 0) || (string.indexOf(":"+id) > -1) ) {
-		$(button).css('border', 'none');
+		$(button).removeClass('mass-tagger-selected');
 		string = string.replace(id, '');
 		list.val(string);
 	}
 	else {
-		$(button).css('border', '3px solid blue');
+		$(button).addClass('mass-tagger-selected');
 		string += id;
 		list.val(string);
 	}

--- a/ext/mass_tagger/style.css
+++ b/ext/mass_tagger/style.css
@@ -1,0 +1,3 @@
+.mass-tagger-selected {
+	border: 3px solid blue;
+}


### PR DESCRIPTION
- Clear selected images on load in case they were autocompleted by the browser.
    - Otherwise you could end up with images that were selected but didn't have the selection effect.
- Use CSS for mass tagger button styling
    - Uses the class name `mass-tagger-selected`
    - Makes it easier to style the selection effect