### PR TITLE
Store tag lists logically inside HTML lists

### DIFF
--- a/ext/tag_list/style.css
+++ b/ext/tag_list/style.css
@@ -1,0 +1,5 @@
+.tag_list {
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
+}

--- a/ext/tag_list/theme.php
+++ b/ext/tag_list/theme.php
@@ -61,14 +61,18 @@ class TagListTheme extends Themelet {
 			$category = $split[0];
 			$tag_html = $split[1];
 			if(!isset($tag_categories_html[$category])) {
-				$tag_categories_html[$category] = '';
+				$tag_categories_html[$category] = '<ul class="tag_list">';
 			}
-			$tag_categories_html[$category] .= $tag_html . '<br />';
+			$tag_categories_html[$category] .= "<li>$tag_html</li>";
 
 			if(!isset($tag_categories_count[$category])) {
 				$tag_categories_count[$category] = 0;
 			}
 			$tag_categories_count[$category] += 1;
+		}
+
+		foreach(array_keys($tag_categories_html) as $category) {
+			$tag_categories_html[$category] .= "</ul>";
 		}
 
 		asort($tag_categories_html);
@@ -111,14 +115,16 @@ class TagListTheme extends Themelet {
 		else {
 			$tag_category_dict = array();
 		}
-		$main_html = '';
+		$main_html = '<ul class="tag_list">';
 
 		foreach($tag_infos as $row) {
 			$split = $this->return_tag($row, $tag_category_dict);
 			//$category = $split[0];
 			$tag_html = $split[1];
-			$main_html .= $tag_html . '<br />';
+			$main_html .= "<li>$tag_html</li>";
 		}
+
+		$main_html .= '</ul>';
 
 		if($config->get_string('tag_list_image_type')=="tags") {
 			$page->add_block(new Block("Tags", $main_html, "left", 10));
@@ -147,14 +153,16 @@ class TagListTheme extends Themelet {
 		else {
 			$tag_category_dict = array();
 		}
-		$main_html = '';
+		$main_html = '<ul class="tag_list">';
 
 		foreach($tag_infos as $row) {
 			$split = self::return_tag($row, $tag_category_dict);
 			//$category = $split[0];
 			$tag_html = $split[1];
-			$main_html .= $tag_html . '<br />';
+			$main_html .= "<li>$tag_html</li>";
 		}
+
+		$main_html .= '</ul>';
 
 		$main_html .= "&nbsp;<br><a class='more' href='".make_link("tags")."'>Full List</a>\n";
 		$page->add_block(new Block("Popular Tags", $main_html, "left", 60));
@@ -179,14 +187,16 @@ class TagListTheme extends Themelet {
 		else {
 			$tag_category_dict = array();
 		}
-		$main_html = '';
+		$main_html = '<ul class="tag_list">';
 
 		foreach($tag_infos as $row) {
 			$split = self::return_tag($row, $tag_category_dict);
 			//$category = $split[0];
 			$tag_html = $split[1];
-			$main_html .= $tag_html . '<br />';
+			$main_html .= "<li>$tag_html</li>";
 		}
+
+		$main_html .= '</ul>';
 
 		$main_html .= "&nbsp;<br><a class='more' href='".make_link("tags")."'>Full List</a>\n";
 		$page->add_block(new Block("refine Search", $main_html, "left", 60));

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -100,6 +100,9 @@ NAV SELECT {
 	content: " >>>";
 }
 
+.tag_list {
+	text-align: inherit;
+}
 .tag_count:before {
 	content: "(";
 }

--- a/themes/warm/style.css
+++ b/themes/warm/style.css
@@ -121,6 +121,9 @@ NAV SELECT {
 	content: " >>>";
 }
 
+.tag_list {
+	text-align: inherit;
+}
 .tag_count:before {
 	content: "(";
 }


### PR DESCRIPTION
**Update:** This PR has been superseded by https://github.com/shish/shimmie2/pull/583

This change wraps the sidebar tag lists into HTML lists. Before, they were structured as a bunch of loose elements punctuated with `<br/>` tags. This makes the resulting HTML a little more organized and makes it much easier to style the tag lists.

The resulting lists were given the class `tag_list`, similar to the other classes used by the `tag_list` extension including `tag_name`, `tag_info_link`, and `tag_count`.

Minimal changes were made to keep the built-in themes looking the same. However, the Material theme is very slightly different now since it uses a 1px larger font for `<ul>`. This I didn't feel was worth changing because that theme's style is very much set in stone.