### PR TITLE
Use tables for tag lists

### DIFF
--- a/ext/tag_list/theme.php
+++ b/ext/tag_list/theme.php
@@ -229,13 +229,13 @@ class TagListTheme extends Themelet {
 		// if($n++) $display_html .= "\n<br/>";
 		if(!is_null($config->get_string('info_link'))) {
 			$link = html_escape(str_replace('$tag', $tag, $config->get_string('info_link')));
-			$display_html .= ' <td class="tag_info_link_cell"><a class="tag_info_link'.$tag_category_css.'" '.$tag_category_style.'href="'.$link.'">?</a></td>';
+			$display_html .= '<td class="tag_info_link_cell"> <a class="tag_info_link'.$tag_category_css.'" '.$tag_category_style.'href="'.$link.'">?</a></td>';
 		}
 		$link = $this->tag_link($row['tag']);
-		$display_html .= ' <td class="tag_name_cell"><a class="tag_name'.$tag_category_css.'" '.$tag_category_style.'href="'.$link.'">'.$h_tag_no_underscores.'</a></td>';
+		$display_html .= '<td class="tag_name_cell"> <a class="tag_name'.$tag_category_css.'" '.$tag_category_style.'href="'.$link.'">'.$h_tag_no_underscores.'</a></td>';
 
 		if($config->get_bool("tag_list_numbers")) {
-			$display_html .= " <td class='tag_count_cell'><span class='tag_count'>$count</span></td>";
+			$display_html .= "<td class='tag_count_cell'> <span class='tag_count'>$count</span></td>";
 		}
 
 		return array($category, $display_html);

--- a/themes/danbooru/style.css
+++ b/themes/danbooru/style.css
@@ -132,6 +132,15 @@ overflow:hidden;
 text-align:left;
 width:150px;
 }
+TABLE.tag_list {
+	border-collapse: collapse;
+}
+TABLE.tag_list>THEAD {
+	display: none;
+}
+TABLE.tag_list>TBODY>TR>TD {
+	display: inline;
+}
 .tag_count {
 color:#AAAAAA;
 }

--- a/themes/danbooru/style.css
+++ b/themes/danbooru/style.css
@@ -140,6 +140,11 @@ TABLE.tag_list>THEAD {
 }
 TABLE.tag_list>TBODY>TR>TD {
 	display: inline;
+	padding: 0;
+	line-height: 1em;
+}
+TABLE.tag_list>TBODY>TR>TD:after {
+	content: " ";
 }
 .tag_count {
 color:#AAAAAA;

--- a/themes/danbooru2/style.css
+++ b/themes/danbooru2/style.css
@@ -161,6 +161,11 @@ TABLE.tag_list>THEAD {
 }
 TABLE.tag_list>TBODY>TR>TD {
 	display: inline;
+	padding: 0;
+	line-height: 1em;
+}
+TABLE.tag_list>TBODY>TR>TD:after {
+	content: " ";
 }
 .tag_count {
 display:inline-block;

--- a/themes/danbooru2/style.css
+++ b/themes/danbooru2/style.css
@@ -152,6 +152,16 @@ max-width:150px;
 width:15rem;
 text-align:left;
 }
+TABLE.tag_list {
+	width: auto;
+	border-collapse: collapse;
+}
+TABLE.tag_list>THEAD {
+	display: none;
+}
+TABLE.tag_list>TBODY>TR>TD {
+	display: inline;
+}
 .tag_count {
 display:inline-block;
 margin-left:0.4rem;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -104,6 +104,10 @@ TABLE.tag_list>THEAD {
 }
 TABLE.tag_list>TBODY>TR>TD {
 	display: inline;
+	padding: 0;
+}
+TABLE.tag_list>TBODY>TR>TD:after {
+	content: " ";
 }
 
 .more:after {

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -96,6 +96,16 @@ NAV SELECT {
 	padding: 0px;
 }
 
+TABLE.tag_list {
+	border-collapse: collapse;
+}
+TABLE.tag_list>THEAD {
+	display: none;
+}
+TABLE.tag_list>TBODY>TR>TD {
+	display: inline;
+}
+
 .more:after {
 	content: " >>>";
 }

--- a/themes/futaba/style.css
+++ b/themes/futaba/style.css
@@ -62,6 +62,20 @@ TD {
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+*             the navigation bar, and all its blocks             *
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+TABLE.tag_list {
+	border-collapse: collapse;
+}
+TABLE.tag_list>THEAD {
+	display: none;
+}
+TABLE.tag_list>TBODY>TR>TD {
+	display: inline;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 *                     specific page types                        *
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/themes/futaba/style.css
+++ b/themes/futaba/style.css
@@ -73,6 +73,11 @@ TABLE.tag_list>THEAD {
 }
 TABLE.tag_list>TBODY>TR>TD {
 	display: inline;
+	padding: 0;
+	line-height: 1em;
+}
+TABLE.tag_list>TBODY>TR>TD:after {
+	content: " ";
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

--- a/themes/lite/style.css
+++ b/themes/lite/style.css
@@ -218,6 +218,16 @@ NAV SELECT {
 	text-align: left;
 }
 
+TABLE.tag_list {
+	border-collapse: collapse;
+}
+TABLE.tag_list>THEAD {
+	display: none;
+}
+TABLE.tag_list>TBODY>TR>TD {
+	display: inline;
+}
+
 .more:after {
 	content: " >>>";
 }

--- a/themes/lite/style.css
+++ b/themes/lite/style.css
@@ -226,6 +226,11 @@ TABLE.tag_list>THEAD {
 }
 TABLE.tag_list>TBODY>TR>TD {
 	display: inline;
+	padding: 0;
+	line-height: 1em;
+}
+TABLE.tag_list>TBODY>TR>TD:after {
+	content: " ";
 }
 
 .more:after {

--- a/themes/material/style.css
+++ b/themes/material/style.css
@@ -9,4 +9,9 @@ TABLE.tag_list>THEAD {
 }
 TABLE.tag_list>TBODY>TR>TD {
   display: inline;
+  padding: 0;
+  line-height: 1em;
+}
+TABLE.tag_list>TBODY>TR>TD:after {
+  content: " ";
 }

--- a/themes/material/style.css
+++ b/themes/material/style.css
@@ -1,3 +1,12 @@
 .nav-card{
   min-height: 3em;
 }
+TABLE.tag_list {
+  border-collapse: collapse;
+}
+TABLE.tag_list>THEAD {
+  display: none;
+}
+TABLE.tag_list>TBODY>TR>TD {
+  display: inline;
+}

--- a/themes/warm/style.css
+++ b/themes/warm/style.css
@@ -117,6 +117,17 @@ NAV SELECT {
 	padding: 0px;
 }
 
+TABLE.tag_list {
+	width: 100%;
+	border-collapse: collapse;
+}
+TABLE.tag_list>THEAD {
+	display: none;
+}
+TABLE.tag_list>TBODY>TR>TD {
+	display: inline;
+}
+
 .more:after {
 	content: " >>>";
 }

--- a/themes/warm/style.css
+++ b/themes/warm/style.css
@@ -126,6 +126,11 @@ TABLE.tag_list>THEAD {
 }
 TABLE.tag_list>TBODY>TR>TD {
 	display: inline;
+	padding: 0;
+	line-height: 1em;
+}
+TABLE.tag_list>TBODY>TR>TD:after {
+	content: " ";
 }
 
 .more:after {


### PR DESCRIPTION
# Overview

This change organizes the sidebar tag lists into tables. Originally I had used lists, but then later decided that tables were a better fit (see https://github.com/shish/shimmie2/pull/581).

Additionally, this updates all of the built-in themes to keep the same general look.



# Rationale

Tag lists are currently structured as a bunch of loose elements punctuated with `<br/>` tags. Organizing them as a table has several advantages:
- Cleaner HTML
- Easier to style
- Sortable*

\* This feature is implemented and works, but it requires that the table headers be visible. All of the built-in themes hide the table headers.



# Issues

- The spacing is slightly different now. Often, the tag list is shifted downward by a pixel or two. This also varies a little across browsers, with Edge notably increasing the line height sometimes by a pixel or so. The differences here are negligible, however.
- Copying from the tag list in Edge now produces three spaces between columns instead of one like it did before.
- This change will likely affect any non-standard themes. However, getting the original look back should be easy in most cases (a few lines of CSS).



# Other Notes

Also added were various classes to aid in styling:
- The tag list itself has the `tag_list` class.
- The columns and cells have classes that match their contents (ex. `tag_name`, `tag_name_cell`, and `tag_name_column`)