### PR TITLE
Use generic NavBlock on pool pages (fixes a JS error)

### DIFF
--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -136,14 +136,13 @@ class PoolsTheme extends Themelet {
 		$page->set_title($heading);
 		$page->set_heading($heading);
 
-		$nav_html = '<a href="'.make_link().'">Index</a>';
 		$poolnav_html = '
 			<a href="'.make_link("pool/list").'">Pool Index</a>
 			<br><a href="'.make_link("pool/new").'">Create Pool</a>
 			<br><a href="'.make_link("pool/updated").'">Pool Changes</a>
 		';
 
-		$page->add_block(new Block($nav_html, null, "left", 5, "indexnavleft"));
+		$page->add_block(new NavBlock());
 		$page->add_block(new Block("Pool Navigation", $poolnav_html, "left", 10));
 
 		if(count($pools) == 1) {


### PR DESCRIPTION
This change replaces the "Index" block on the pool pages with a generic NavBlock.

The reason for this change is twofold:
1. It's more consistent with the other pages
2. It fixes a javascript error that can occur when using the lite theme

To expand upon number 2:

A javascript error occurs under the following conditions:
- You are using the lite theme
- You visit any of the pool pages

Here's a rundown of why this happens:
1. The lite theme is set to create a shm-toggler out of each block in the sidebar ([themes/lite/layout.class.php#L225](https://github.com/shish/shimmie2/blob/3051334d8f153862a3e1b1a6de65c08b31ede52d/themes/lite/layout.class.php#L225)). The shm-toggler must have an anchor to work with, so it generates one from the block's title.
2. However, there is one problem with doing that: While that would work for most blocks, this block in particular is special. This is because it uses HTML directly inside its header ([ext/pools.theme.php#L146](https://github.com/shish/shimmie2/blob/3051334d8f153862a3e1b1a6de65c08b31ede52d/ext/pools/theme.php#L146)), resulting in the generation of an invalid anchor.
3. Later, jQuery gets a hold of and chokes on said invalid anchor ([lib/shimmie.js#L65](https://github.com/shish/shimmie2/blob/3051334d8f153862a3e1b1a6de65c08b31ede52d/lib/shimmie.js#L65))
4. ... and that's how you make a javascript error.