### PR TITLE
Image info tweaks

### DIFF
--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -103,9 +103,7 @@ class Ratings extends Extension {
 	}
 	
 	public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event) {
-		if($this->can_rate()) {
-			$event->add_part($this->theme->get_rater_html($event->image->id, $event->image->rating), 80);
-		}
+		$event->add_part($this->theme->get_rater_html($event->image->id, $event->image->rating), 80);
 	}
 	
 	public function onImageInfoSet(ImageInfoSetEvent $event) {

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -103,7 +103,7 @@ class Ratings extends Extension {
 	}
 	
 	public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event) {
-		$event->add_part($this->theme->get_rater_html($event->image->id, $event->image->rating), 80);
+		$event->add_part($this->theme->get_rater_html($event->image->id, $event->image->rating, $this->can_rate()), 80);
 	}
 	
 	public function onImageInfoSet(ImageInfoSetEvent $event) {

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -10,13 +10,17 @@ class RatingsTheme extends Themelet {
 		$s_checked = $rating == 's' ? " checked" : "";
 		$q_checked = $rating == 'q' ? " checked" : "";
 		$e_checked = $rating == 'e' ? " checked" : "";
+		$human_rating = Ratings::rating_to_human($rating);
 		$html = "
 			<tr>
 				<th>Rating</th>
 				<td>
-					<input type='radio' name='rating' value='s' id='s'$s_checked><label for='s'>Safe</label>
-					<input type='radio' name='rating' value='q' id='q'$q_checked><label for='q'>Questionable</label>
-					<input type='radio' name='rating' value='e' id='e'$e_checked><label for='e'>Explicit</label>
+					<span class='view'>$human_rating</span>
+					<span class='edit'>
+						<input type='radio' name='rating' value='s' id='s'$s_checked><label for='s'>Safe</label>
+						<input type='radio' name='rating' value='q' id='q'$q_checked><label for='q'>Questionable</label>
+						<input type='radio' name='rating' value='e' id='e'$e_checked><label for='e'>Explicit</label>
+					</span>
 				</td>
 			</tr>
 		";

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -6,7 +6,7 @@ class RatingsTheme extends Themelet {
 	 * @param string $rating
 	 * @return string
 	 */
-	public function get_rater_html(/*int*/ $image_id, /*string*/ $rating) {
+	public function get_rater_html(/*int*/ $image_id, /*string*/ $rating, /*bool*/ $can_rate) {
 		$s_checked = $rating == 's' ? " checked" : "";
 		$q_checked = $rating == 'q' ? " checked" : "";
 		$e_checked = $rating == 'e' ? " checked" : "";
@@ -15,12 +15,16 @@ class RatingsTheme extends Themelet {
 			<tr>
 				<th>Rating</th>
 				<td>
+		".($can_rate ? "
 					<span class='view'>$human_rating</span>
 					<span class='edit'>
 						<input type='radio' name='rating' value='s' id='s'$s_checked><label for='s'>Safe</label>
 						<input type='radio' name='rating' value='q' id='q'$q_checked><label for='q'>Questionable</label>
 						<input type='radio' name='rating' value='e' id='e'$e_checked><label for='e'>Explicit</label>
 					</span>
+		" : "
+					$human_rating
+		")."
 				</td>
 			</tr>
 		";

--- a/ext/relatationships/theme.php
+++ b/ext/relatationships/theme.php
@@ -30,7 +30,7 @@ class RelationshipsTheme extends Themelet {
 		global $user;
 
 		$h_parent_id = $image->parent_id;
-		$s_parent_id = $h_parent_id ?: "None.";
+		$s_parent_id = $h_parent_id ?: "None";
 
 		$html = "<tr>\n".
 		        "	<th>Parent</th>\n".


### PR DESCRIPTION
- Hide the rating editor outside of edit mode
  - Instead, it shows the human-friendly name of the current rating. Note that this has no effect when JS is disabled because then there's no choice but to show the editor.
- Show image rating in image info box even when not logged in
  - I found it odd that the image's rating would disappear if you weren't logged in. This fixes that.
- Removed trailing period from "Parent: None." for consistency
  - No other image editor properties that I know of use a trailing period