### PR TITLE
Fix comment-delete injection

### DIFF
--- a/core/util.inc.php
+++ b/core/util.inc.php
@@ -16,6 +16,16 @@ function html_escape($input) {
 }
 
 /**
+ * Unescape data that was made safe for printing into HTML
+ *
+ * @param $input
+ * @return string
+ */
+function html_unescape($input) {
+	return html_entity_decode($input, ENT_QUOTES, "UTF-8");
+}
+
+/**
  * Make sure some data is safe to be used in integer context
  *
  * @param $input

--- a/ext/comment/theme.php
+++ b/ext/comment/theme.php
@@ -259,8 +259,6 @@ class CommentListTheme extends Themelet {
 		else {
 			$h_userlink = '<a class="username" href="'.make_link('user/'.$h_name).'">'.$h_name.'</a>';
 		}
-		$stripped_nonl = str_replace("\n", "\\n", substr($tfe->stripped, 0, 50));
-		$stripped_nonl = str_replace("\r", "\\r", $stripped_nonl);
 
 		$hb = ($comment->owner_class == "hellbanned" ? "hb" : "");
 		if($trim) {
@@ -280,9 +278,14 @@ class CommentListTheme extends Themelet {
 			}
 			$h_reply = " - <a href='javascript: replyTo($i_image_id, $i_comment_id, \"$h_name\")'>Reply</a>";
 			$h_ip = $user->can("view_ip") ? "<br>".show_ip($comment->poster_ip, "Comment posted {$comment->posted}") : "";
-			$h_del = $user->can("delete_comment") ?
-				' - <a onclick="return confirm(\'Delete comment by '.$h_name.':\\n'.$stripped_nonl.'\');" '.
-				'href="'.make_link('comment/delete/'.$i_comment_id.'/'.$i_image_id).'">Del</a>' : '';
+			$h_del = "";
+			if ($user->can("delete_comment")) {
+				$comment_preview = substr(html_unescape($tfe->stripped), 0, 50);
+				$j_delete_confirm_message = json_encode("Delete comment by {$comment->owner_name}:\n$comment_preview");
+				$h_delete_script = html_escape("return confirm($j_delete_confirm_message);");
+				$h_delete_link = make_link("comment/delete/$i_comment_id/$i_image_id");
+				$h_del = " - <a onclick='$h_delete_script' href='$h_delete_link'>Del</a>";
+			}
 			$html = "
 				<div class=\"comment $hb\" id=\"c$i_comment_id\">
 					<div class=\"info\">

--- a/ext/tag_editcloud/main.php
+++ b/ext/tag_editcloud/main.php
@@ -134,7 +134,7 @@ class TagEditCloud extends Extension {
 			}
 
 			$size = sprintf("%.2f", max($row['scaled'],0.5));
-			$js = htmlspecialchars('tageditcloud_toggle_tag(this,'.json_encode($full_tag).')',ENT_QUOTES); //Ugly, but it works
+			$js = html_escape('tageditcloud_toggle_tag(this,'.json_encode($full_tag).')'); //Ugly, but it works
 
 			if(array_search($row['tag'],$image->get_tag_array()) !== FALSE) {
 				if($used_first) {

--- a/themes/danbooru/comment.theme.php
+++ b/themes/danbooru/comment.theme.php
@@ -111,12 +111,15 @@ class CustomCommentListTheme extends CommentListTheme {
 		$i_image_id = int_escape($comment->image_id);
 		$h_posted = autodate($comment->posted);
 
-		$stripped_nonl = str_replace("\n", "\\n", substr($tfe->stripped, 0, 50));
-		$stripped_nonl = str_replace("\r", "\\r", $stripped_nonl);
 		$h_userlink = "<a class='username' href='".make_link("user/$h_name")."'>$h_name</a>";
-		$h_del = $user->can("delete_comment") ?
-			' - <a onclick="return confirm(\'Delete comment by '.$h_name.':\\n'.$stripped_nonl.'\');" '.
-			'href="'.make_link('comment/delete/'.$i_comment_id.'/'.$i_image_id).'">Del</a>' : '';
+		$h_del = "";
+		if ($user->can("delete_comment")) {
+			$comment_preview = substr(html_unescape($tfe->stripped), 0, 50);
+			$j_delete_confirm_message = json_encode("Delete comment by {$comment->owner_name}:\n$comment_preview");
+			$h_delete_script = html_escape("return confirm($j_delete_confirm_message);");
+			$h_delete_link = make_link("comment/delete/$i_comment_id/$i_image_id");
+			$h_del = " - <a onclick='$h_delete_script' href='$h_delete_link'>Del</a>";
+		}
 		//$h_imagelink = $trim ? "<a href='".make_link("post/view/$i_image_id")."'>&gt;&gt;&gt;</a>\n" : "";
 		if($trim) {
 			return "<p class='comment'>$h_userlink $h_del<br/>$h_posted<br/>$h_comment</p>";

--- a/themes/danbooru2/comment.theme.php
+++ b/themes/danbooru2/comment.theme.php
@@ -101,12 +101,15 @@ class CustomCommentListTheme extends CommentListTheme {
 		$i_image_id = int_escape($comment->image_id);
 		$h_posted = autodate($comment->posted);
 
-		$stripped_nonl = str_replace("\n", "\\n", substr($tfe->stripped, 0, 50));
-		$stripped_nonl = str_replace("\r", "\\r", $stripped_nonl);
 		$h_userlink = "<a class='username' href='".make_link("user/$h_name")."'>$h_name</a>";
-		$h_del = $user->can("delete_comment") ?
-			' - <a onclick="return confirm(\'Delete comment by '.$h_name.':\\n'.$stripped_nonl.'\');" '.
-			'href="'.make_link('comment/delete/'.$i_comment_id.'/'.$i_image_id).'">Del</a>' : '';
+		$h_del = "";
+		if ($user->can("delete_comment")) {
+			$comment_preview = substr(html_unescape($tfe->stripped), 0, 50);
+			$j_delete_confirm_message = json_encode("Delete comment by {$comment->owner_name}:\n$comment_preview");
+			$h_delete_script = html_escape("return confirm($j_delete_confirm_message);");
+			$h_delete_link = make_link("comment/delete/$i_comment_id/$i_image_id");
+			$h_del = " - <a onclick='$h_delete_script' href='$h_delete_link'>Del</a>";
+		}
 		//$h_imagelink = $trim ? "<a href='".make_link("post/view/$i_image_id")."'>&gt;&gt;&gt;</a>\n" : "";
 		if($trim) {
 			return "<p class='comment'>$h_userlink $h_del<br/>$h_posted<br/>$h_comment</p>";

--- a/themes/futaba/comment.theme.php
+++ b/themes/futaba/comment.theme.php
@@ -70,13 +70,16 @@ class CustomCommentListTheme extends CommentListTheme {
 		$i_comment_id = int_escape($comment->comment_id);
 		$i_image_id = int_escape($comment->image_id);
 
-		$stripped_nonl = str_replace("\n", "\\n", substr($tfe->stripped, 0, 50));
-		$stripped_nonl = str_replace("\r", "\\r", $stripped_nonl);
 		$h_userlink = "<a href='".make_link("user/$h_name")."'>$h_name</a>";
 		$h_date = $comment->posted;
-		$h_del = $user->can("delete_comment") ?
-			' - <a onclick="return confirm(\'Delete comment by '.$h_name.':\\n'.$stripped_nonl.'\');" '.
-			'href="'.make_link('comment/delete/'.$i_comment_id.'/'.$i_image_id).'">Del</a>' : '';
+		$h_del = "";
+		if ($user->can("delete_comment")) {
+			$comment_preview = substr(html_unescape($tfe->stripped), 0, 50);
+			$j_delete_confirm_message = json_encode("Delete comment by {$comment->owner_name}:\n$comment_preview");
+			$h_delete_script = html_escape("return confirm($j_delete_confirm_message);");
+			$h_delete_link = make_link("comment/delete/$i_comment_id/$i_image_id");
+			$h_del = " - <a onclick='$h_delete_script' href='$h_delete_link'>Del</a>";
+		}
 		$h_reply = "[<a href='".make_link("post/view/$i_image_id")."'>Reply</a>]";
 
 		if($inner_id == 0) {


### PR DESCRIPTION
# Overview

This fixes a JS code injection vulnerability that affected the "delete comment" dialog. By using a crafted comment, it was possible to inject a small amount of Javascript (~50 characters) to be executed whenever a user tries to delete an affected comment.

# Examples

Below are examples of crafted comments and the effects they would have without this fix.

### Show a message
```
')&&alert('BOO!
```

### Make a comment undeletable (simple)
```
')==('
```

### Make a comment undeletable (advanced)
```
hitler did nothn wrong[align=right]')==('[/align]
```

# Notes

In order to correctly escape the strings used in the JS-based comment deletion prompt, it was necessary to unescape the result of the TextFormattingEvent because it had already been escaped for HTML. While doing so felt a little dirty, there was no other way besides making deeper changes.