### PR TITLE
Ignore arrow key navigation when modifier keys held

### DIFF
--- a/ext/arrowkey_navigation/main.php
+++ b/ext/arrowkey_navigation/main.php
@@ -47,6 +47,7 @@ class ArrowkeyNavigation extends Extension {
 			(function($){
 				$(document).keyup(function(e) {
 					if($(e.target).is('input', 'textarea')){ return; }
+					if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) { return; }
 					if (e.keyCode == 37) { window.location.href = '{$prev_url}'; }
 					else if (e.keyCode == 39) { window.location.href = '{$next_url}'; }
 				});


### PR DESCRIPTION
Fixes an issue where the arrow key navigation extension would conflict with browser forward / back shortcuts