### PR TITLE
Misc. Bugfixes

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -53,6 +53,7 @@ AddType audio/ogg      oga ogg opus
 AddType image/jpeg     jpg jpeg
 AddType image/bmp      bmp
 AddType image/svg+xml  svg svgz
+AddType image/x-icon   ico ani cur
 AddType image/webp     webp
 AddType video/mp4      f4v f4p m4v mp4
 AddType video/ogg      ogv

--- a/ext/handle_ico/main.php
+++ b/ext/handle_ico/main.php
@@ -67,9 +67,9 @@ class IcoFileHandler extends Extension {
 		$image = new Image();
 
 		$fp = fopen($filename, "r");
-		$header = unpack("snull/stype/scount", fread($fp, 6));
+		$header = unpack("Snull/Stype/Scount", fread($fp, 6));
 
-		$subheader = unpack("cwidth/cheight/ccolours/cnull/splanes/sbpp/lsize/loffset", fread($fp, 16));
+		$subheader = unpack("Cwidth/Cheight/Ccolours/Cnull/Splanes/Sbpp/Lsize/loffset", fread($fp, 16));
 		fclose($fp);
 
 		$width = $subheader['width'];
@@ -94,7 +94,7 @@ class IcoFileHandler extends Extension {
 	private function check_contents($file) {
 		if(!file_exists($file)) return false;
 		$fp = fopen($file, "r");
-		$header = unpack("snull/stype/scount", fread($fp, 6));
+		$header = unpack("Snull/Stype/Scount", fread($fp, 6));
 		fclose($fp);
 		return ($header['null'] == 0 && ($header['type'] == 0 || $header['type'] == 1));
 	}

--- a/ext/handle_ico/main.php
+++ b/ext/handle_ico/main.php
@@ -35,20 +35,6 @@ class IcoFileHandler extends Extension {
 		}
 	}
 
-	public function onPageRequest(PageRequestEvent $event) {
-		global $page;
-		if($event->page_matches("get_ico")) {
-			$id = int_escape($event->get_arg(0));
-			$image = Image::by_id($id);
-			$hash = $image->hash;
-			$ha = substr($hash, 0, 2);
-
-			$page->set_type("image/x-icon");
-			$page->set_mode("data");
-			$page->set_data(file_get_contents("images/$ha/$hash"));
-		}
-	}
-
 	/**
 	 * @param string $ext
 	 * @return bool

--- a/ext/handle_ico/test.php
+++ b/ext/handle_ico/test.php
@@ -4,7 +4,6 @@ class IcoHandlerTest extends ShimmiePHPUnitTestCase {
 		$this->log_in_as_user();
 		$image_id = $this->post_image("lib/static/favicon.ico", "shimmie favicon");
 		$this->get_page("post/view/$image_id"); // test for no crash
-		$this->get_page("get_ico/$image_id"); // test for no crash
 
 		# FIXME: test that the thumb works
 		# FIXME: test that it gets displayed properly

--- a/ext/handle_ico/theme.php
+++ b/ext/handle_ico/theme.php
@@ -2,7 +2,7 @@
 
 class IcoFileHandlerTheme extends Themelet {
 	public function display_image(Page $page, Image $image) {
-		$ilink = make_link("get_ico/{$image->id}/{$image->id}.ico");
+		$ilink = $image->get_image_link();
 		$html = "
 			<img id='main_image' src='$ilink'>
 		";

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -110,7 +110,10 @@ class Ratings extends Extension {
 	
 	public function onImageInfoSet(ImageInfoSetEvent $event) {
 		if($this->can_rate() && isset($_POST["rating"])) {
-			send_event(new RatingSetEvent($event->image, $_POST['rating']));
+			$rating = $_POST["rating"];
+			if (Ratings::rating_is_valid($rating)) {
+				send_event(new RatingSetEvent($event->image, $rating));
+			}
 		}
 	}
 
@@ -208,6 +211,22 @@ class Ratings extends Extension {
 			case "q": return "Questionable";
 			case "e": return "Explicit";
 			default:  return "Unknown";
+		}
+	}
+
+	/**
+	 * @param string $rating
+	 * @return bool
+	 */
+	public static function rating_is_valid(/*string*/ $rating) {
+		switch($rating) {
+			case "s":
+			case "q":
+			case "e":
+			case "u":
+				return true;
+			default:
+				return false;
 		}
 	}
 

--- a/ext/tag_edit/main.php
+++ b/ext/tag_edit/main.php
@@ -214,7 +214,7 @@ class TagEdit extends Extension {
 
 	public function onImageInfoSet(ImageInfoSetEvent $event) {
 		global $user;
-		if($user->can("edit_image_owner")) {
+		if($user->can("edit_image_owner") && isset($_POST['tag_edit__owner'])) {
 			$owner = User::by_name($_POST['tag_edit__owner']);
 			if ($owner instanceof User) {
 				send_event(new OwnerSetEvent($event->image, $owner));


### PR DESCRIPTION
- Read ICO header with proper sign
  - Fixes width/height being read incorrectly when >= 128
- Use Image->get_image_link() on ICO files
  - Makes ICO files respect the "Nice URLs" option
- Check for existence of POST var tag_edit__owner before using it
  - Fixes an error when tag_edit__owner isn't supplied, useful for automated processes where you don't want to modify the owner
- Sanitize ratings
  - Before, it was possible to use a crafted POST to set a bogus rating. As a result, the post would become unviewable by anyone.
- Remove get_ico page
  - It's no longer needed because ICO now uses Image->get_image_link()
  - It's recommended to use ./image/$image_id instead