### PR TITLE
PHP Version check in the code should use a configurable value.

### DIFF
--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -59,9 +59,19 @@ class Image {
 	/** @var string[]|null */
 	public $tag_array;
 
-	public $owner_id, $owner_ip;
+	/** @var int */
+	public $owner_id;
+	
+	/** @var string */
+	public $owner_ip;
+	
+	/** @var string */
 	public $posted;
+	
+	/** @var string */
 	public $source;
+    
+	/** @var boolean */
 	public $locked;
 
 	/**

--- a/core/sys_config.inc.php
+++ b/core/sys_config.inc.php
@@ -41,7 +41,7 @@ _d("TIMEZONE", null);        // string   timezone
 _d("CORE_EXTS", "bbcode,user,mail,upload,image,view,handle_pixel,ext_manager,setup,upgrade,handle_404,comment,tag_list,index,tag_edit,alias_editor"); // extensions to always enable
 _d("EXTRA_EXTS", "");        // string   optional extra extensions
 _d("BASE_URL", null);        // string   force a specific base URL (default is auto-detect)
-
+_d("MIN_PHP_VERSION", '5.6');// string   minium supported PHP version
 
 /*
  * Calculated settings - you should never need to change these

--- a/core/user.class.php
+++ b/core/user.class.php
@@ -1,6 +1,10 @@
 <?php
 
-/** @private */
+/**
+ * @private
+ * @param mixed $row
+ * @return User
+ */
 function _new_user($row) {
 	return new User($row);
 }

--- a/core/util.inc.php
+++ b/core/util.inc.php
@@ -1602,7 +1602,7 @@ function score_assert_handler($file, $line, $code, $desc = null) {
 function _version_check() {
 	if(MIN_PHP_VERSION)
 	{
-        if(version_compare(phpversion(), MIN_PHP_VERSION, ">=") == FALSE) {
+        if(version_compare(phpversion(), MIN_PHP_VERSION, ">=") === FALSE) {
             print "
 Shimmie (SCore Engine) does not support versions of PHP lower than ".MIN_PHP_VERSION."
 (PHP reports that it is version ".phpversion().")

--- a/core/util.inc.php
+++ b/core/util.inc.php
@@ -1600,14 +1600,17 @@ function score_assert_handler($file, $line, $code, $desc = null) {
 /** @privatesection */
 
 function _version_check() {
-	$min_version = "5.4.8";
-	if(version_compare(PHP_VERSION, $min_version) == -1) {
-		print "
-Currently SCore Engine doesn't support versions of PHP lower than $min_version --
-if your web host is running an older version, they are dangerously out of
+	if(MIN_PHP_VERSION)
+	{
+        if(version_compare(phpversion(), MIN_PHP_VERSION, ">=") == FALSE) {
+            print "
+Shimmie (SCore Engine) does not support versions of PHP lower than ".MIN_PHP_VERSION."
+(PHP reports that it is version ".phpversion().")
+If your web host is running an older version, they are dangerously out of
 date and you should plan on moving elsewhere.
 ";
-		exit;
+            exit;
+        }
 	}
 }
 

--- a/ext/ext_manager/main.php
+++ b/ext/ext_manager/main.php
@@ -12,7 +12,10 @@
  *   extensions and read their documentation
  */
 
-/** @private */
+/**
+ * @private
+ * @return int
+ */
 function __extman_extcmp(ExtensionInfo $a, ExtensionInfo $b) {
 	return strcmp($a->name, $b->name);
 }
@@ -189,6 +192,9 @@ class ExtManager extends Extension {
 		$this->write_config($extras);
 	}
 
+    /**
+     * @param string[] $extra
+     */
 	private function write_config($extras) {
 		file_put_contents(
 			"data/config/extensions.conf.php",

--- a/ext/ext_manager/main.php
+++ b/ext/ext_manager/main.php
@@ -193,7 +193,7 @@ class ExtManager extends Extension {
 	}
 
     /**
-     * @param string[] $extra
+     * @param string[] $extras
      */
 	private function write_config($extras) {
 		file_put_contents(

--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -376,7 +376,7 @@ class ImageIO extends Extension {
 		$image->tag_array = array();
 		send_event(new TagSetEvent($image, $tags_to_set));
 
-		if($image->source) {
+		if($image->source !== null) {
 			log_info("core-image", "Source for Image #{$image->id} set to: {$image->source}");
 		}
 	}

--- a/ext/index/main.php
+++ b/ext/index/main.php
@@ -225,6 +225,7 @@ class PostListBuildingEvent extends Event {
 }
 
 class Index extends Extension {
+    /** @var int */
 	private $stpen = 0;  // search term parse event number
 
 	public function onInitExt(InitExtEvent $event) {

--- a/ext/upgrade/main.php
+++ b/ext/upgrade/main.php
@@ -129,6 +129,7 @@ class Upgrade extends Extension {
 		}
 	}
 
+    /** @return int */
 	public function get_priority() {return 5;}
 }
 

--- a/ext/word_filter/main.php
+++ b/ext/word_filter/main.php
@@ -43,6 +43,9 @@ class WordFilter extends Extension {
 		return $text;
 	}
 
+	/**
+	 * @return string[]
+	 */
 	private function get_map() {
 		global $config;
 		$raw = $config->get_string("word_filter");


### PR DESCRIPTION
This changes the PHP version check in util.inc.php to use a configuration constant, rather than the hard-coded version number in the code itself. (As it seems this hard-coded version number is easy to forget about -- and then it never gets updated.).
Also includes some more linting and PHPDoc comments.