### PR TITLE
Fix SVG XSS

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -25,12 +25,6 @@
 	RewriteRule ^(.*)$ index.php?q=$1&%{QUERY_STRING} [L]
 </IfModule>
 
-<IfModule mod_php5.c>
-	php_flag register_globals 0 
-	php_flag magic_quotes_gpc 0 
-	php_flag magic_quotes_runtime 0
-</IfModule>
-
 <IfModule mod_expires.c>
 	ExpiresActive On
 	<FilesMatch "([0-9a-f]{32}|\.(gif|jpe?g|png|css|js))$">

--- a/.htaccess
+++ b/.htaccess
@@ -12,7 +12,7 @@
 </FilesMatch>
 
 <IfModule mod_rewrite.c>
-	RewriteEngine  on
+	RewriteEngine On
 
 	# rather than link to images/ha/hash and have an ugly filename,
 	# we link to images/hash/tags.ext; mod_rewrite splits things so
@@ -37,19 +37,31 @@
 	#ExpiresByType text/plain "now"
 </IfModule>
 
-<ifmodule mod_deflate.c>
+<IfModule mod_deflate.c>
 	AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css
 	AddOutputFilterByType DEFLATE application/x-javascript application/javascript
-</ifmodule>
+</IfModule>
 
-AddType audio/mp4      f4a f4b m4a
-AddType audio/ogg      oga ogg opus
-AddType image/jpeg     jpg jpeg
-AddType image/bmp      bmp
-AddType image/svg+xml  svg svgz
+#EXT: handle_pixel
+AddType image/jpeg  jpg jpeg
+AddType image/gif   gif
+AddType image/png   png
+
+#EXT: handle_ico
 AddType image/x-icon   ico ani cur
-AddType image/webp     webp
+
+#EXT: handle_flash
+AddType application/x-shockwave-flash swf
+
+#EXT: handle_mp3
+AddType audio/mpeg mp3
+
+#EXT: handle_svg
+AddType image/svg+xml  svg svgz
+
+#EXT: handle_video
+AddType video/x-flv    flv
 AddType video/mp4      f4v f4p m4v mp4
+AddType audio/mp4      f4a f4b m4a
 AddType video/ogg      ogv
 AddType video/webm     webm
-AddType video/x-flv    flv

--- a/ext/handle_svg/main.php
+++ b/ext/handle_svg/main.php
@@ -3,7 +3,7 @@
  * Name: Handle SVG
  * Author: Shish <webmaster@shishnet.org>
  * Link: http://code.shishnet.org/shimmie2/
- * Description: Handle SVG files. (No thumbnail is generated for SVG files)
+ * Description: Handle static SVG files. (No thumbnail is generated for SVG files)
  */
 
 class SVGFileHandler extends Extension {

--- a/ext/handle_svg/theme.php
+++ b/ext/handle_svg/theme.php
@@ -5,9 +5,8 @@ class SVGFileHandlerTheme extends Themelet {
 		$ilink = make_link("get_svg/{$image->id}/{$image->id}.svg");
 //		$ilink = $image->get_image_link();
 		$html = "
-			<object data='$ilink' type='image/svg+xml' data-width='{$image->width}' data-height='{$image->height}' id='main_image' class='shm-main-image'>
-				<embed src='$ilink' type='image/svg+xml' />
-			</object>
+			<img src='$ilink' id='main_image' class='shm-main-image' data-width='{$image->width}' data-height='{$image->height}' />
+
 		";
 		$page->add_block(new Block("Image", $html, "main", 10));
 	}

--- a/ext/handle_svg/theme.php
+++ b/ext/handle_svg/theme.php
@@ -6,7 +6,6 @@ class SVGFileHandlerTheme extends Themelet {
 //		$ilink = $image->get_image_link();
 		$html = "
 			<img src='$ilink' id='main_image' class='shm-main-image' data-width='{$image->width}' data-height='{$image->height}' />
-
 		";
 		$page->add_block(new Block("Image", $html, "main", 10));
 	}


### PR DESCRIPTION
SVG allows inline Javascript execution when fetched as an \<object\>. Using \<img\> stops this.  
Example SVG using alert(): [example.svg](https://codeanimu.net/random/archive/uploads/example.svg)

Some related reading:
* https://bartblaze.blogspot.co.uk/2016/11/nemucod-downloader-spreading-via.html
* https://security.stackexchange.com/q/143141
* https://stackoverflow.com/questions/33387722
* https://www.w3.org/wiki/SVG_Security
