### PR TITLE
Bump the version number before releasing

### DIFF
--- a/core/sys_config.inc.php
+++ b/core/sys_config.inc.php
@@ -36,7 +36,7 @@ _d("COMPILE_ELS", false);    // boolean  pre-build the list of event listeners
 _d("NICE_URLS", false);      // boolean  force niceurl mode
 _d("SEARCH_ACCEL", false);   // boolean  use search accelerator
 _d("WH_SPLITS", 1);          // int      how many levels of subfolders to put in the warehouse
-_d("VERSION", '2.5.5+');     // string   shimmie version
+_d("VERSION", '2.6.0+');     // string   shimmie version
 _d("TIMEZONE", null);        // string   timezone
 _d("CORE_EXTS", "bbcode,user,mail,upload,image,view,handle_pixel,ext_manager,setup,upgrade,handle_404,comment,tag_list,index,tag_edit,alias_editor"); // extensions to always enable
 _d("EXTRA_EXTS", "");        // string   optional extra extensions

--- a/install.php
+++ b/install.php
@@ -3,7 +3,7 @@
  * Shimmie Installer
  *
  * @package    Shimmie
- * @copyright  Copyright (c) 2007-2015, Shish et al.
+ * @copyright  Copyright (c) 2007-2017, Shish et al.
  * @author     Shish [webmaster at shishnet.org], jgen [jeffgenovy at gmail.com]
  * @link       http://code.shishnet.org/shimmie2/
  * @license    http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2


### PR DESCRIPTION
Given the amount of time (and churn) between releases, we should probably bump the version number before releasing (#599). 
(Note: In the official release we should remove the "+" from the version number.)