### PR TITLE
Ensure that metadata['tags'] is always an array

### DIFF
--- a/core/imageboard.pack.php
+++ b/core/imageboard.pack.php
@@ -1210,7 +1210,7 @@ function move_upload_to_archive(DataUploadEvent $event) {
  * Add a directory full of images
  *
  * @param $base string
- * @return array
+ * @return array|string[]
  */
 function add_dir($base) {
     $results = array();
@@ -1222,7 +1222,7 @@ function add_dir($base) {
         $tags = path_to_tags($short_path);
         $result = "$short_path (".str_replace(" ", ", ", $tags).")... ";
         try {
-            add_image($full_path, $filename, Tag::explode($tags));
+            add_image($full_path, $filename, $tags);
             $result .= "ok";
         }
         catch(UploadException $ex) {
@@ -1250,7 +1250,7 @@ function add_image($tmpname, $filename, $tags) {
     $metadata = array();
     $metadata['filename'] = $pathinfo['basename'];
     $metadata['extension'] = $pathinfo['extension'];
-    $metadata['tags'] = $tags;
+    $metadata['tags'] = Tag::explode($tags);
     $metadata['source'] = null;
     $event = new DataUploadEvent($tmpname, $metadata);
     send_event($event);

--- a/ext/bulk_add_csv/main.php
+++ b/ext/bulk_add_csv/main.php
@@ -73,7 +73,7 @@ class BulkAddCSV extends Extension {
 		$metadata = array();
 		$metadata['filename'] = $pathinfo['basename'];
 		$metadata['extension'] = $pathinfo['extension'];
-		$metadata['tags'] = $tags;
+		$metadata['tags'] = Tag::explode($tags);
 		$metadata['source'] = $source;
 		$event = new DataUploadEvent($tmpname, $metadata);
 		send_event($event);
@@ -126,7 +126,7 @@ class BulkAddCSV extends Extension {
 			$list .= "<br>".html_escape("$shortpath (".str_replace(" ", ", ", $tags).")... ");
 			if (file_exists($csvdata[0]) && is_file($csvdata[0])) {
 				try{
-					$this->add_image($fullpath, $pathinfo["basename"], Tag::explode($tags), $source, $rating, $thumbfile);
+					$this->add_image($fullpath, $pathinfo["basename"], $tags, $source, $rating, $thumbfile);
 					$list .= "ok\n";
 				}
 				catch(Exception $ex) {

--- a/ext/cron_uploader/main.php
+++ b/ext/cron_uploader/main.php
@@ -304,6 +304,10 @@ class CronUploader extends Extension {
 
 	/**
 	 * Generate the necessary DataUploadEvent for a given image and tags.
+	 *
+	 * @param string $tmpname
+	 * @param string $filename
+	 * @param string $tags
 	 */
 	private function add_image($tmpname, $filename, $tags) {
 		assert ( file_exists ( $tmpname ) );
@@ -315,7 +319,7 @@ class CronUploader extends Extension {
 		$metadata = array();
 		$metadata ['filename'] = $pathinfo ['basename'];
 		$metadata ['extension'] = $pathinfo ['extension'];
-		$metadata ['tags'] = ""; // = $tags; doesn't work when not logged in here
+		$metadata ['tags'] = array(""); // = $tags; doesn't work when not logged in here
 		$metadata ['source'] = null;
 		$event = new DataUploadEvent ( $tmpname, $metadata );
 		send_event ( $event );

--- a/ext/cron_uploader/main.php
+++ b/ext/cron_uploader/main.php
@@ -319,7 +319,7 @@ class CronUploader extends Extension {
 		$metadata = array();
 		$metadata ['filename'] = $pathinfo ['basename'];
 		$metadata ['extension'] = $pathinfo ['extension'];
-		$metadata ['tags'] = array(""); // = $tags; doesn't work when not logged in here
+		$metadata ['tags'] = array(); // = $tags; doesn't work when not logged in here
 		$metadata ['source'] = null;
 		$event = new DataUploadEvent ( $tmpname, $metadata );
 		send_event ( $event );

--- a/ext/handle_flash/main.php
+++ b/ext/handle_flash/main.php
@@ -37,7 +37,7 @@ class FlashFileHandler extends DataHandlerExtension {
 		$image->hash	  = $metadata['hash'];
 		$image->filename  = $metadata['filename'];
 		$image->ext       = $metadata['extension'];
-		$image->tag_array = $metadata['tags'];
+		$image->tag_array = is_array($metadata['tags']) ? $metadata['tags'] : Tag::explode($metadata['tags']);
 		$image->source    = $metadata['source'];
 
 		$info = getimagesize($filename);

--- a/ext/handle_ico/main.php
+++ b/ext/handle_ico/main.php
@@ -67,7 +67,7 @@ class IcoFileHandler extends Extension {
 		$image->hash      = $metadata['hash'];
 		$image->filename  = $metadata['filename'];
 		$image->ext       = $metadata['extension'];
-		$image->tag_array = $metadata['tags'];
+		$image->tag_array = is_array($metadata['tags']) ? $metadata['tags'] : Tag::explode($metadata['tags']);
 		$image->source    = $metadata['source'];
 
 		return $image;

--- a/ext/handle_mp3/main.php
+++ b/ext/handle_mp3/main.php
@@ -43,7 +43,7 @@ class MP3FileHandler extends DataHandlerExtension {
 		$image->filename = $metadata['filename'];
 
 		$image->ext       = $metadata['extension'];
-		$image->tag_array = $metadata['tags'];
+		$image->tag_array = is_array($metadata['tags']) ? $metadata['tags'] : Tag::explode($metadata['tags']);
 		$image->source    = $metadata['source'];
 
 		return $image;

--- a/ext/handle_pixel/main.php
+++ b/ext/handle_pixel/main.php
@@ -35,7 +35,7 @@ class PixelFileHandler extends DataHandlerExtension {
 		$image->hash      = $metadata['hash'];
 		$image->filename  = (($pos = strpos($metadata['filename'],'?')) !== false) ? substr($metadata['filename'],0,$pos) : $metadata['filename'];
 		$image->ext       = (($pos = strpos($metadata['extension'],'?')) !== false) ? substr($metadata['extension'],0,$pos) : $metadata['extension'];
-		$image->tag_array = $metadata['tags'];
+		$image->tag_array = is_array($metadata['tags']) ? $metadata['tags'] : Tag::explode($metadata['tags']);
 		$image->source    = $metadata['source'];
 
 		return $image;

--- a/ext/handle_svg/main.php
+++ b/ext/handle_svg/main.php
@@ -75,7 +75,7 @@ class SVGFileHandler extends Extension {
 		$image->hash      = $metadata['hash'];
 		$image->filename  = $metadata['filename'];
 		$image->ext       = $metadata['extension'];
-		$image->tag_array = $metadata['tags'];
+		$image->tag_array = is_array($metadata['tags']) ? $metadata['tags'] : Tag::explode($metadata['tags']);
 		$image->source    = $metadata['source'];
 
 		return $image;

--- a/ext/handle_video/main.php
+++ b/ext/handle_video/main.php
@@ -170,7 +170,7 @@ class VideoFileHandler extends DataHandlerExtension {
 		$image->filesize  = $metadata['size'];
 		$image->hash      = $metadata['hash'];
 		$image->filename  = $metadata['filename'];
-		$image->tag_array = $metadata['tags'];
+		$image->tag_array = is_array($metadata['tags']) ? $metadata['tags'] : Tag::explode($metadata['tags']);
 		$image->source    = $metadata['source'];
 
 		return $image;

--- a/ext/oekaki/main.php
+++ b/ext/oekaki/main.php
@@ -31,7 +31,7 @@ class Oekaki extends Extension {
 						$metadata = array();
 						$metadata['filename'] = 'oekaki.png';
 						$metadata['extension'] = $pathinfo['extension'];
-						$metadata['tags'] = 'oekaki tagme';
+						$metadata['tags'] = Tag::explode('oekaki tagme');
 						$metadata['source'] = null;
 						$duev = new DataUploadEvent($tmpname, $metadata);
 						send_event($duev);

--- a/ext/ouroboros_api/main.php
+++ b/ext/ouroboros_api/main.php
@@ -536,7 +536,8 @@ class OuroborosAPI extends Extension
             if (!is_null($img)) {
                 $handler = $config->get_string("upload_collision_handler");
                 if($handler == "merge") {
-                    $merged = array_merge(Tag::explode($post->tags), $img->get_tag_array());
+                    $postTags = is_array($post->tags) ? $post->tags : Tag::explode($post->tags);
+                    $merged = array_merge($postTags, $img->get_tag_array());
                     send_event(new TagSetEvent($img, $merged));
 
                     // This is really the only thing besides tags we should care

--- a/ext/ouroboros_api/main.php
+++ b/ext/ouroboros_api/main.php
@@ -500,7 +500,7 @@ class OuroborosAPI extends Extension
             }
         }
         $meta = array();
-        $meta['tags'] = $post->tags;
+        $meta['tags'] = Tag::explode($post->tags);
         $meta['source'] = $post->source;
         if (defined('ENABLED_EXTS')) {
             if (strstr(ENABLED_EXTS, 'rating') !== false) {

--- a/ext/ouroboros_api/main.php
+++ b/ext/ouroboros_api/main.php
@@ -500,7 +500,7 @@ class OuroborosAPI extends Extension
             }
         }
         $meta = array();
-        $meta['tags'] = Tag::explode($post->tags);
+        $meta['tags'] = is_array($post->tags) ? $post->tags : Tag::explode($post->tags);
         $meta['source'] = $post->source;
         if (defined('ENABLED_EXTS')) {
             if (strstr(ENABLED_EXTS, 'rating') !== false) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -132,7 +132,7 @@ abstract class ShimmiePHPUnitTestCase extends \PHPUnit_Framework_TestCase {
 	// post things
 	/**
 	 * @param string $filename
-	 * @param string|string[] $tags
+	 * @param string $tags
 	 * @return int
 	 */
 	protected function post_image($filename, $tags) {


### PR DESCRIPTION
This pull-request is somewhat related to the following issues/bug/pull-requests:
#575,  #610, #611, #612 

We should be more consistent and should ensure that `metadata['tags']` is always an array, in order to prevent issues like the previously mentioned bugs.