### PR TITLE
Add missing escaping of ffmpeg shell command during video thumbnail generation

### DIFF
--- a/ext/handle_video/main.php
+++ b/ext/handle_video/main.php
@@ -111,7 +111,7 @@ class VideoFileHandler extends DataHandlerExtension {
 				else
 				{
 					$scale = 'scale="' . escapeshellarg("if(gt(a,{$w}/{$h}),{$w},-1)") . ':' . escapeshellarg("if(gt(a,{$w}/{$h}),-1,{$h})") . '"';
-					$cmd = "{$ffmpeg} -y -i {$inname} -vf {$scale} -ss 00:00:00.0 -f image2 -vframes 1 {$outname}";
+					$cmd = escapeshellcmd("{$ffmpeg} -y -i {$inname} -vf {$scale} -ss 00:00:00.0 -f image2 -vframes 1 {$outname}");
 				}
 
 				exec($cmd, $output, $returnValue);


### PR DESCRIPTION
When generating video thumbnails, the exec() call to ffmpeg is currently only escaped in the case where the "ignore video scale" configuration is set to true. In the "else" branch, the raw command is executed (!).