### PR TITLE
Cron upload changes

### DIFF
--- a/core/util.php
+++ b/core/util.php
@@ -281,14 +281,20 @@ function manual_include(string $fname): ?string
 function path_to_tags(string $path): string
 {
     $matches = [];
-    if (preg_match("/\d+ - (.*)\.([a-zA-Z]+)/", basename($path), $matches)) {
+	$tags = "";
+    if(preg_match("/\d+ - (.*)\.([a-zA-Z0-9]+)/", basename($path), $matches)) {
         $tags = $matches[1];
-    } else {
-        $tags = dirname($path);
-        $tags = str_replace("/", " ", $tags);
-        $tags = str_replace("__", " ", $tags);
-        $tags = trim($tags);
-    }
+	}
+	
+	$dir_tags = dirname($path);
+	$dir_tags = str_replace("/", " ", $dir_tags);
+	$dir_tags = str_replace("__", " ", $dir_tags);
+	$dir_tags = trim($dir_tags);
+	if ($dir_tags != "") {
+		$tags = trim($tags)." ".trim($dir_tags);
+	}
+	$tags = trim ( $tags );
+	
     return $tags;
 }
 

--- a/ext/cron_uploader/main.php
+++ b/ext/cron_uploader/main.php
@@ -273,6 +273,11 @@ class CronUploader extends Extension
                 $this->move_uploaded($img[0], $img[1], false);
             } catch (Exception $e) {
                 $this->move_uploaded($img[0], $img[1], true);
+                if (strpos($e->getMessage(), 'SQLSTATE') !== false) {
+                    // Postgres invalidates the transaction if there is an SQL error, 
+                    // so all subsequence transactions will fail.
+                    break;
+                }
             }
         }
         

--- a/ext/cron_uploader/main.php
+++ b/ext/cron_uploader/main.php
@@ -289,16 +289,23 @@ class CronUploader extends Extension
         // Create
         $newDir = $this->root_dir;
         
-        // Determine which dir to move to
-        if ($corrupt) {
-            // Move to corrupt dir
-            $newDir .= "/failed_to_upload/";
-            $info = "ERROR: Image was not uploaded.";
-        } else {
-            $newDir .= "/uploaded/";
-            $info = "Image successfully uploaded. ";
-        }
-        
+        $relativeDir = dirname(substr($path, strlen($this->root_dir) + 7));
+
+		// Determine which dir to move to
+		if ($corrupt) {
+			// Move to corrupt dir
+			$newDir .= "/failed_to_upload/".$relativeDir;
+			$info = "ERROR: Image was not uploaded.";
+		}
+		else {
+			$newDir .= "/uploaded/".$relativeDir;
+			$info = "Image successfully uploaded. ";
+		}
+		$newDir = str_replace ( "//", "/", $newDir."/" );
+
+        if (!is_dir($newDir)) 
+            mkdir ( $newDir, 0775, true );
+
         // move file to correct dir
         rename($path, $newDir.$filename);
         


### PR DESCRIPTION
Changes path-to-tag to merge path tags and filename tags.
Changes cron upload to mirror the subdir structure on output.
Changes the path-to-tag regexp to allow extensions with numbers.
Added early escape to the cron upload process when a transaction-invalidating error occurs.