### PR TITLE
Enabled rating extension for pgsql

### DIFF
--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -37,7 +37,7 @@ class RatingSetEvent extends Event
 
 class Ratings extends Extension
 {
-    protected $db_support = ['mysql'];  // ?
+    protected $db_support = ['mysql','pgsql'];  // ?
 
     public function get_priority(): int
     {


### PR DESCRIPTION
I ran some tests, all the SQL works fine against pgsql. individual and bulk ratings works, and setting the different rating user levels. Resolves #649 