### PR TITLE
Media extension

### DIFF
--- a/core/basethemelet.php
+++ b/core/basethemelet.php
@@ -58,7 +58,7 @@ class BaseThemelet
             $tsize = get_thumbnail_size($image->width, $image->height);
         } else {
             //Use max thumbnail size if using thumbless filetype
-            $tsize = get_thumbnail_size($config->get_int('thumb_width'), $config->get_int('thumb_height'));
+            $tsize = get_thumbnail_size($config->get_int(ImageConfig::THUMB_WIDTH), $config->get_int(ImageConfig::THUMB_WIDTH));
         }
 
         $custom_classes = "";

--- a/core/event.php
+++ b/core/event.php
@@ -191,6 +191,8 @@ class CommandEvent extends Event
                     $user = User::by_name($args[++$i]);
                     if (is_null($user)) {
                         die("Unknown user");
+                    } else {
+                        send_event(new UserLoginEvent($user));
                     }
                     break;
                 case '-q':

--- a/core/imageboard/image.php
+++ b/core/imageboard/image.php
@@ -463,7 +463,7 @@ class Image
      */
     public function get_image_link(): string
     {
-        return $this->get_link('image_ilink', '_images/$hash/$id%20-%20$tags.$ext', 'image/$id.$ext');
+        return $this->get_link(ImageConfig::ILINK, '_images/$hash/$id%20-%20$tags.$ext', 'image/$id.$ext');
     }
 
     /**
@@ -480,8 +480,8 @@ class Image
     public function get_thumb_link(): string
     {
         global $config;
-        $ext = $config->get_string("thumb_type");
-        return $this->get_link('image_tlink', '_thumbs/$hash/thumb.'.$ext, 'thumb/$id.'.$ext);
+        $ext = $config->get_string(ImageConfig::THUMB_TYPE);
+        return $this->get_link(ImageConfig::TLINK, '_thumbs/$hash/thumb.'.$ext, 'thumb/$id.'.$ext);
     }
 
     /**
@@ -512,7 +512,7 @@ class Image
     public function get_tooltip(): string
     {
         global $config;
-        $tt = $this->parse_link_template($config->get_string('image_tip'), "no_escape");
+        $tt = $this->parse_link_template($config->get_string(ImageConfig::TIP), "no_escape");
 
         // Removes the size tag if the file is an mp3
         if ($this->ext === 'mp3') {

--- a/core/imageboard/image.php
+++ b/core/imageboard/image.php
@@ -54,6 +54,19 @@ class Image
     /** @var boolean */
     public $locked = false;
 
+    /** @var boolean */
+    public $lossless = null;
+
+    /** @var boolean */
+    public $video = null;
+
+    /** @var boolean */
+    public $audio = null;
+
+    /** @var int */
+    public $length = null;
+
+
     /**
      * One will very rarely construct an image directly, more common
      * would be to use Image::by_id, Image::by_hash, etc.

--- a/core/imageboard/misc.php
+++ b/core/imageboard/misc.php
@@ -178,6 +178,11 @@ function create_image_thumb(string $hash, string $type, string $engine = null) {
         $engine = $config->get_string(ImageConfig::THUMB_ENGINE);
     }
 
+    $output_format = $config->get_string(ImageConfig::THUMB_TYPE);
+    if($output_format=="webp") {
+        $output_format = Media::WEBP_LOSSY;
+    }
+
     send_event(new MediaResizeEvent(
         $engine,
         $inname,
@@ -186,7 +191,7 @@ function create_image_thumb(string $hash, string $type, string $engine = null) {
         $tsize[0],
         $tsize[1],
         false,
-        $config->get_string(ImageConfig::THUMB_TYPE),
+        $output_format,
         $config->get_int(ImageConfig::THUMB_QUALITY),
         true,
         $config->get_bool('thumb_upscale', false)

--- a/core/imageboard/misc.php
+++ b/core/imageboard/misc.php
@@ -194,3 +194,21 @@ function create_image_thumb(string $hash, string $type, string $engine = null) {
 }
 
 
+const TIME_UNITS = ["s"=>60,"m"=>60,"h"=>24,"d"=>365,"y"=>PHP_INT_MAX];
+function format_milliseconds(int $input): string
+{
+    $output = "";
+
+    $remainder = floor($input / 1000);
+
+    foreach (TIME_UNITS AS $unit=>$conversion) {
+        $count = $remainder % $conversion;
+        $remainder = floor($remainder / $conversion);
+        if($count==0&&$remainder<1) {
+            break;
+        }
+        $output = "$count".$unit." ".$output;
+    }
+
+    return trim($output);
+}

--- a/core/imageboard/misc.php
+++ b/core/imageboard/misc.php
@@ -95,7 +95,6 @@ function get_extension_from_mime(String $file_path): String
     throw new UploadException("Could not determine file mime type: ".$file_path);
 }
 
-
 /**
  * Given a full size pair of dimensions, return a pair scaled down to fit
  * into the configured thumbnail square, with ratio intact.
@@ -179,7 +178,7 @@ function create_image_thumb(string $hash, string $type, string $engine = null) {
         $engine = $config->get_string(ImageConfig::THUMB_ENGINE);
     }
 
-    send_event(new GraphicResizeEvent(
+    send_event(new MediaResizeEvent(
         $engine,
         $inname,
         $type,

--- a/core/imageboard/misc.php
+++ b/core/imageboard/misc.php
@@ -125,24 +125,31 @@ function get_thumbnail_size(int $orig_width, int $orig_height, bool $use_dpi_sca
     }
 
 
-    if ($use_dpi_scaling) {
-        $max_size = get_thumbnail_max_size_scaled();
-        $max_width  = $max_size[0];
-        $max_height = $max_size[1];
+    if($use_dpi_scaling) {
+        list($max_width, $max_height) = get_thumbnail_max_size_scaled();
     } else {
-        $max_width = $config->get_int('thumb_width');
-        $max_height = $config->get_int('thumb_height');
+        $max_width = $config->get_int(ImageConfig::THUMB_WIDTH);
+        $max_height = $config->get_int(ImageConfig::THUMB_HEIGHT);
     }
 
-    $xscale = ($max_height / $orig_height);
-    $yscale = ($max_width / $orig_width);
-    $scale = ($xscale < $yscale) ? $xscale : $yscale;
+    $output = get_scaled_by_aspect_ratio($orig_width, $orig_height, $max_width, $max_height);
 
-    if ($scale > 1 && $config->get_bool('thumb_upscale')) {
+    if ($output[2] > 1 && $config->get_bool('thumb_upscale')) {
         return [(int)$orig_width, (int)$orig_height];
     } else {
-        return [(int)($orig_width*$scale), (int)($orig_height*$scale)];
+        return $output;
     }
+
+}
+
+function get_scaled_by_aspect_ratio(int $original_width, int $original_height, int $max_width, int $max_height) : array
+{
+    $xscale = ($max_width/ $original_width);
+    $yscale = ($max_height/ $original_height);
+
+    $scale = ($yscale < $xscale) ? $yscale : $xscale ;
+
+    return [(int)($original_width*$scale), (int)($original_height*$scale), $scale];
 }
 
 /**
@@ -154,355 +161,37 @@ function get_thumbnail_max_size_scaled(): array
 {
     global $config;
 
-    $scaling = $config->get_int("thumb_scaling");
-    $max_width  = $config->get_int('thumb_width') * ($scaling/100);
-    $max_height = $config->get_int('thumb_height') * ($scaling/100);
+    $scaling = $config->get_int(ImageConfig::THUMB_SCALING);
+    $max_width  = $config->get_int(ImageConfig::THUMB_WIDTH) * ($scaling/100);
+    $max_height = $config->get_int(ImageConfig::THUMB_HEIGHT) * ($scaling/100);
     return [$max_width, $max_height];
 }
 
-/**
- * Creates a thumbnail file using ImageMagick's convert command.
- *
- * @param $hash
- * @param string $input_type Optional, allows specifying the input format. Usually not necessary.
- * @return bool true is successful, false if not.
- */
-function create_thumbnail_convert($hash, $input_type = ""): bool
-{
+
+function create_image_thumb(string $hash, string $type, string $engine = null) {
     global $config;
 
     $inname  = warehouse_path(Image::IMAGE_DIR, $hash);
     $outname = warehouse_path(Image::THUMBNAIL_DIR, $hash);
+    $tsize = get_thumbnail_max_size_scaled();
 
-    $q = $config->get_int("thumb_quality");
-    $convert = $config->get_string("thumb_convert_path");
-
-    if ($convert==null||$convert=="") {
-        return false;
+    if(empty($engine)) {
+        $engine = $config->get_string(ImageConfig::THUMB_ENGINE);
     }
 
-    //  ffff imagemagick fails sometimes, not sure why
-    //$format = "'%s' '%s[0]' -format '%%[fx:w] %%[fx:h]' info:";
-    //$cmd = sprintf($format, $convert, $inname);
-    //$size = shell_exec($cmd);
-    //$size = explode(" ", trim($size));
-    list($w, $h) = get_thumbnail_max_size_scaled();
-
-
-    // running the call with cmd.exe requires quoting for our paths
-    $type = $config->get_string('thumb_type');
-
-    $options = "";
-    if (!$config->get_bool('thumb_upscale')) {
-        $options .= "\>";
-    }
-
-    $bg = "black";
-    if ($type=="webp") {
-        $bg = "none";
-    }
-    if (!empty($input_type)) {
-        $input_type = $input_type.":";
-    }
-    $format = '"%s" -flatten -strip -thumbnail %ux%u%s -quality %u -background %s %s"%s[0]"  %s:"%s" 2>&1';
-    $cmd = sprintf($format, $convert, $w, $h, $options, $q, $bg, $input_type, $inname, $type, $outname);
-    $cmd = str_replace("\"convert\"", "convert", $cmd); // quotes are only needed if the path to convert contains a space; some other times, quotes break things, see github bug #27
-    exec($cmd, $output, $ret);
-    if ($ret!=0) {
-        log_warning('imageboard/misc', "Generating thumbnail with command `$cmd`, returns $ret, outputting ".implode("\r\n", $output));
-    } else {
-        log_debug('imageboard/misc', "Generating thumbnail with command `$cmd`, returns $ret");
-    }
-
-    if ($config->get_bool("thumb_optim", false)) {
-        exec("jpegoptim $outname", $output, $ret);
-    }
-
-    return true;
+    send_event(new GraphicResizeEvent(
+        $engine,
+        $inname,
+        $type,
+        $outname,
+        $tsize[0],
+        $tsize[1],
+        false,
+        $config->get_string(ImageConfig::THUMB_TYPE),
+        $config->get_int(ImageConfig::THUMB_QUALITY),
+        true,
+        $config->get_bool('thumb_upscale', false)
+    ));
 }
 
-/**
- * Creates a thumbnail using ffmpeg.
- *
- * @param $hash
- * @return bool true if successful, false if not.
- */
-function create_thumbnail_ffmpeg($hash): bool
-{
-    global $config;
 
-    $ffmpeg = $config->get_string("thumb_ffmpeg_path");
-    if ($ffmpeg==null||$ffmpeg=="") {
-        return false;
-    }
-
-    $inname  = warehouse_path(Image::IMAGE_DIR, $hash);
-    $outname = warehouse_path(Image::THUMBNAIL_DIR, $hash);
-
-    $orig_size = video_size($inname);
-    $scaled_size = get_thumbnail_size($orig_size[0], $orig_size[1], true);
-    
-    $codec = "mjpeg";
-    $quality = $config->get_int("thumb_quality");
-    if ($config->get_string("thumb_type")=="webp") {
-        $codec = "libwebp";
-    } else {
-        // mjpeg quality ranges from 2-31, with 2 being the best quality.
-        $quality = floor(31 - (31 * ($quality/100)));
-        if ($quality<2) {
-            $quality = 2;
-        }
-    }
-
-    $args = [
-        escapeshellarg($ffmpeg),
-        "-y", "-i", escapeshellarg($inname),
-        "-vf", "thumbnail,scale={$scaled_size[0]}:{$scaled_size[1]}",
-        "-f", "image2",
-        "-vframes", "1",
-        "-c:v", $codec,
-        "-q:v", $quality,
-        escapeshellarg($outname),
-    ];
-
-    $cmd = escapeshellcmd(implode(" ", $args));
-
-    exec($cmd, $output, $ret);
-
-    if ((int)$ret == (int)0) {
-        log_debug('imageboard/misc', "Generating thumbnail with command `$cmd`, returns $ret");
-        return true;
-    } else {
-        log_error('imageboard/misc', "Generating thumbnail with command `$cmd`, returns $ret");
-        return false;
-    }
-}
-
-/**
- * Determines the dimensions of a video file using ffmpeg.
- *
- * @param string $filename
- * @return array [width, height]
- */
-function video_size(string $filename): array
-{
-    global $config;
-    $ffmpeg = $config->get_string("thumb_ffmpeg_path");
-    $cmd = escapeshellcmd(implode(" ", [
-        escapeshellarg($ffmpeg),
-        "-y", "-i", escapeshellarg($filename),
-        "-vstats"
-    ]));
-    $output = shell_exec($cmd . " 2>&1");
-    // error_log("Getting size with `$cmd`");
-
-    $regex_sizes = "/Video: .* ([0-9]{1,4})x([0-9]{1,4})/";
-    if (preg_match($regex_sizes, $output, $regs)) {
-        if (preg_match("/displaymatrix: rotation of (90|270).00 degrees/", $output)) {
-            $size = [$regs[2], $regs[1]];
-        } else {
-            $size = [$regs[1], $regs[2]];
-        }
-    } else {
-        $size = [1, 1];
-    }
-    log_debug('imageboard/misc', "Getting video size with `$cmd`, returns $output -- $size[0], $size[1]");
-    return $size;
-}
-
-/**
- * Check Memory usage limits
- *
- * Old check:   $memory_use = (filesize($image_filename)*2) + ($width*$height*4) + (4*1024*1024);
- * New check:   $memory_use = $width * $height * ($bits_per_channel) * channels * 2.5
- *
- * It didn't make sense to compute the memory usage based on the NEW size for the image. ($width*$height*4)
- * We need to consider the size that we are GOING TO instead.
- *
- * The factor of 2.5 is simply a rough guideline.
- * http://stackoverflow.com/questions/527532/reasonable-php-memory-limit-for-image-resize
- *
- * @param array $info The output of getimagesize() for the source file in question.
- * @return int The number of bytes an image resize operation is estimated to use.
- */
-function calc_memory_use(array $info): int
-{
-    if (isset($info['bits']) && isset($info['channels'])) {
-        $memory_use = ($info[0] * $info[1] * ($info['bits'] / 8) * $info['channels'] * 2.5) / 1024;
-    } else {
-        // If we don't have bits and channel info from the image then assume default values
-        // of 8 bits per color and 4 channels (R,G,B,A) -- ie: regular 24-bit color
-        $memory_use = ($info[0] * $info[1] * 1 * 4 * 2.5) / 1024;
-    }
-    return (int)$memory_use;
-}
-
-/**
- * Performs a resize operation on an image file using GD.
- *
- * @param String $image_filename The source file to be resized.
- * @param array $info The output of getimagesize() for the source file.
- * @param int $new_width
- * @param int $new_height
- * @param string $output_filename
- * @param string|null $output_type If set to null, the output file type will be automatically determined via the $info parameter. Otherwise an exception will be thrown.
- * @param int $output_quality Defaults to 80.
- * @throws ImageResizeException
- * @throws InsufficientMemoryException if the estimated memory usage exceeds the memory limit.
- */
-function image_resize_gd(
-    String $image_filename,
-    array $info,
-    int $new_width,
-    int $new_height,
-    string $output_filename,
-    string $output_type=null,
-    int $output_quality = 80
-) {
-    $width = $info[0];
-    $height = $info[1];
-
-    if ($output_type==null) {
-        /* If not specified, output to the same format as the original image */
-        switch ($info[2]) {
-            case IMAGETYPE_GIF:   $output_type = "gif";    break;
-            case IMAGETYPE_JPEG:  $output_type = "jpeg";   break;
-            case IMAGETYPE_PNG:   $output_type = "png";    break;
-            case IMAGETYPE_WEBP:  $output_type = "webp";   break;
-            case IMAGETYPE_BMP:   $output_type = "bmp";    break;
-            default: throw new ImageResizeException("Failed to save the new image - Unsupported image type.");
-        }
-    }
-
-    $memory_use = calc_memory_use($info);
-    $memory_limit = get_memory_limit();
-    if ($memory_use > $memory_limit) {
-        throw new InsufficientMemoryException("The image is too large to resize given the memory limits. ($memory_use > $memory_limit)");
-    }
-
-    $image = imagecreatefromstring(file_get_contents($image_filename));
-    $image_resized = imagecreatetruecolor($new_width, $new_height);
-    try {
-        if ($image===false) {
-            throw new ImageResizeException("Could not load image: ".$image_filename);
-        }
-        if ($image_resized===false) {
-            throw new ImageResizeException("Could not create output image with dimensions $new_width c $new_height ");
-        }
-
-        // Handle transparent images
-        switch ($info[2]) {
-            case IMAGETYPE_GIF:
-                $transparency = imagecolortransparent($image);
-                $palletsize = imagecolorstotal($image);
-
-                // If we have a specific transparent color
-                if ($transparency >= 0 && $transparency < $palletsize) {
-                    // Get the original image's transparent color's RGB values
-                    $transparent_color = imagecolorsforindex($image, $transparency);
-
-                    // Allocate the same color in the new image resource
-                    $transparency = imagecolorallocate($image_resized, $transparent_color['red'], $transparent_color['green'], $transparent_color['blue']);
-                    if ($transparency===false) {
-                        throw new ImageResizeException("Unable to allocate transparent color");
-                    }
-                    
-                    // Completely fill the background of the new image with allocated color.
-                    if (imagefill($image_resized, 0, 0, $transparency)===false) {
-                        throw new ImageResizeException("Unable to fill new image with transparent color");
-                    }
-
-                    // Set the background color for new image to transparent
-                    imagecolortransparent($image_resized, $transparency);
-                }
-                break;
-            case IMAGETYPE_PNG:
-            case IMAGETYPE_WEBP:
-                //
-                // More info here:  http://stackoverflow.com/questions/279236/how-do-i-resize-pngs-with-transparency-in-php
-                //
-                if (imagealphablending($image_resized, false)===false) {
-                    throw new ImageResizeException("Unable to disable image alpha blending");
-                }
-                if (imagesavealpha($image_resized, true)===false) {
-                    throw new ImageResizeException("Unable to enable image save alpha");
-                }
-                $transparent_color = imagecolorallocatealpha($image_resized, 255, 255, 255, 127);
-                if ($transparent_color===false) {
-                    throw new ImageResizeException("Unable to allocate transparent color");
-                }
-                if (imagefilledrectangle($image_resized, 0, 0, $new_width, $new_height, $transparent_color)===false) {
-                    throw new ImageResizeException("Unable to fill new image with transparent color");
-                }
-                break;
-        }
-        
-        // Actually resize the image.
-        if (imagecopyresampled(
-            $image_resized,
-            $image,
-            0,
-            0,
-            0,
-            0,
-            $new_width,
-            $new_height,
-            $width,
-            $height
-            )===false) {
-            throw new ImageResizeException("Unable to copy resized image data to new image");
-        }
-
-
-        switch ($output_type) {
-            case "bmp":
-                $result = imagebmp($image_resized, $output_filename, true);
-                break;
-            case "webp":
-                $result = imagewebp($image_resized, $output_filename, $output_quality);
-                break;
-            case "jpg":
-            case "jpeg":
-                $result = imagejpeg($image_resized, $output_filename, $output_quality);
-                break;
-            case "png":
-                $result = imagepng($image_resized, $output_filename, 9);
-                break;
-            case "gif":
-                $result = imagegif($image_resized, $output_filename);
-                break;
-            default:
-                throw new ImageResizeException("Failed to save the new image - Unsupported image type: $output_type");
-        }
-        if ($result==false) {
-            throw new ImageResizeException("Failed to save the new image, function returned false when saving type: $output_type");
-        }
-    } finally {
-        imagedestroy($image);
-        imagedestroy($image_resized);
-    }
-}
-
-/**
- * Determines if a file is an animated gif.
- *
- * @param String $image_filename The path of the file to check.
- * @return bool true if the file is an animated gif, false if it is not.
- */
-function is_animated_gif(String $image_filename)
-{
-    $is_anim_gif = 0;
-    if (($fh = @fopen($image_filename, 'rb'))) {
-        //check if gif is animated (via http://www.php.net/manual/en/function.imagecreatefromgif.php#104473)
-        while (!feof($fh) && $is_anim_gif < 2) {
-            $chunk = fread($fh, 1024 * 100);
-            $is_anim_gif += preg_match_all('#\x00\x21\xF9\x04.{4}\x00(\x2C|\x21)#s', $chunk, $matches);
-        }
-    }
-    return ($is_anim_gif == 0);
-}
-
-function image_to_id(Image $image): int
-{
-    return $image->id;
-}

--- a/core/sys_config.php
+++ b/core/sys_config.php
@@ -40,7 +40,7 @@ _d("SEARCH_ACCEL", false);   // boolean  use search accelerator
 _d("WH_SPLITS", 1);          // int      how many levels of subfolders to put in the warehouse
 _d("VERSION", '2.7-beta');   // string   shimmie version
 _d("TIMEZONE", null);        // string   timezone
-_d("CORE_EXTS", "bbcode,user,mail,upload,image,view,handle_pixel,ext_manager,setup,upgrade,handle_404,handle_static,comment,tag_list,index,tag_edit,alias_editor,graphics"); // extensions to always enable
+_d("CORE_EXTS", "bbcode,user,mail,upload,image,view,handle_pixel,ext_manager,setup,upgrade,handle_404,handle_static,comment,tag_list,index,tag_edit,alias_editor,media"); // extensions to always enable
 _d("EXTRA_EXTS", "");        // string   optional extra extensions
 _d("BASE_URL", null);        // string   force a specific base URL (default is auto-detect)
 _d("MIN_PHP_VERSION", '7.1');// string   minimum supported PHP version

--- a/core/sys_config.php
+++ b/core/sys_config.php
@@ -40,7 +40,7 @@ _d("SEARCH_ACCEL", false);   // boolean  use search accelerator
 _d("WH_SPLITS", 1);          // int      how many levels of subfolders to put in the warehouse
 _d("VERSION", '2.7-beta');   // string   shimmie version
 _d("TIMEZONE", null);        // string   timezone
-_d("CORE_EXTS", "bbcode,user,mail,upload,image,view,handle_pixel,ext_manager,setup,upgrade,handle_404,handle_static,comment,tag_list,index,tag_edit,alias_editor,media"); // extensions to always enable
+_d("CORE_EXTS", "bbcode,user,mail,upload,image,view,handle_pixel,ext_manager,setup,upgrade,handle_404,handle_static,comment,tag_list,index,tag_edit,alias_editor,user_config,media"); // extensions to always enable
 _d("EXTRA_EXTS", "");        // string   optional extra extensions
 _d("BASE_URL", null);        // string   force a specific base URL (default is auto-detect)
 _d("MIN_PHP_VERSION", '7.1');// string   minimum supported PHP version

--- a/core/sys_config.php
+++ b/core/sys_config.php
@@ -40,7 +40,7 @@ _d("SEARCH_ACCEL", false);   // boolean  use search accelerator
 _d("WH_SPLITS", 1);          // int      how many levels of subfolders to put in the warehouse
 _d("VERSION", '2.7-beta');   // string   shimmie version
 _d("TIMEZONE", null);        // string   timezone
-_d("CORE_EXTS", "bbcode,user,mail,upload,image,view,handle_pixel,ext_manager,setup,upgrade,handle_404,handle_static,comment,tag_list,index,tag_edit,alias_editor"); // extensions to always enable
+_d("CORE_EXTS", "bbcode,user,mail,upload,image,view,handle_pixel,ext_manager,setup,upgrade,handle_404,handle_static,comment,tag_list,index,tag_edit,alias_editor,graphics"); // extensions to always enable
 _d("EXTRA_EXTS", "");        // string   optional extra extensions
 _d("BASE_URL", null);        // string   force a specific base URL (default is auto-detect)
 _d("MIN_PHP_VERSION", '7.1');// string   minimum supported PHP version

--- a/core/util.php
+++ b/core/util.php
@@ -79,7 +79,7 @@ function get_memory_limit(): int
 
     // thumbnail generation requires lots of memory
     $default_limit = 8*1024*1024;	// 8 MB of memory is PHP's default.
-    $shimmie_limit = parse_shorthand_int($config->get_int(GraphicsConfig::MEM_LIMIT));
+    $shimmie_limit = parse_shorthand_int($config->get_int(MediaConfig::MEM_LIMIT));
 
     if ($shimmie_limit < 3*1024*1024) {
         // we aren't going to fit, override

--- a/core/util.php
+++ b/core/util.php
@@ -79,7 +79,7 @@ function get_memory_limit(): int
 
     // thumbnail generation requires lots of memory
     $default_limit = 8*1024*1024;	// 8 MB of memory is PHP's default.
-    $shimmie_limit = parse_shorthand_int($config->get_int("thumb_mem_limit"));
+    $shimmie_limit = parse_shorthand_int($config->get_int(GraphicsConfig::MEM_LIMIT));
 
     if ($shimmie_limit < 3*1024*1024) {
         // we aren't going to fit, override

--- a/ext/danbooru_api/main.php
+++ b/ext/danbooru_api/main.php
@@ -105,6 +105,7 @@ class DanbooruApi extends Extension
             } else {
                 $user = User::by_id($config->get_int("anon_id", 0));
             }
+            send_event(new UserLoginEvent($user));
         }
     }
 

--- a/ext/et/main.php
+++ b/ext/et/main.php
@@ -52,14 +52,17 @@ class ET extends Extension
         $info['sys_disk']    = to_shorthand_int(disk_total_space("./") - disk_free_space("./")) . " / " .
                                to_shorthand_int(disk_total_space("./"));
         $info['sys_server']  = isset($_SERVER["SERVER_SOFTWARE"]) ? $_SERVER["SERVER_SOFTWARE"] : 'unknown';
-        
-        $info['thumb_engine']	= $config->get_string("thumb_engine");
-        $info['thumb_quality']	= $config->get_int('thumb_quality');
-        $info['thumb_width']	= $config->get_int('thumb_width');
-        $info['thumb_height']	= $config->get_int('thumb_height');
-        $info['thumb_scaling']	= $config->get_int('thumb_scaling');
-        $info['thumb_type']	    = $config->get_string('thumb_type');
-        $info['thumb_mem']		= $config->get_int("thumb_mem_limit");
+
+        $info[GraphicsConfig::FFMPEG_PATH]	= $config->get_string(GraphicsConfig::FFMPEG_PATH);
+        $info[GraphicsConfig::CONVERT_PATH]	= $config->get_string(GraphicsConfig::CONVERT_PATH);
+        $info[GraphicsConfig::MEM_LIMIT]	= $config->get_int(GraphicsConfig::MEM_LIMIT);
+
+        $info[ImageConfig::THUMB_ENGINE]	= $config->get_string(ImageConfig::THUMB_ENGINE);
+        $info[ImageConfig::THUMB_QUALITY]	= $config->get_int(ImageConfig::THUMB_QUALITY);
+        $info[ImageConfig::THUMB_WIDTH]	= $config->get_int(ImageConfig::THUMB_WIDTH);
+        $info[ImageConfig::THUMB_HEIGHT]	= $config->get_int(ImageConfig::THUMB_HEIGHT);
+        $info[ImageConfig::THUMB_SCALING]	= $config->get_int(ImageConfig::THUMB_SCALING);
+        $info[ImageConfig::THUMB_TYPE]	    = $config->get_string(ImageConfig::THUMB_TYPE);
 
         $info['stat_images']   = $database->get_one("SELECT COUNT(*) FROM images");
         $info['stat_comments'] = $database->get_one("SELECT COUNT(*) FROM comments");

--- a/ext/et/main.php
+++ b/ext/et/main.php
@@ -53,9 +53,9 @@ class ET extends Extension
                                to_shorthand_int(disk_total_space("./"));
         $info['sys_server']  = isset($_SERVER["SERVER_SOFTWARE"]) ? $_SERVER["SERVER_SOFTWARE"] : 'unknown';
 
-        $info[GraphicsConfig::FFMPEG_PATH]	= $config->get_string(GraphicsConfig::FFMPEG_PATH);
-        $info[GraphicsConfig::CONVERT_PATH]	= $config->get_string(GraphicsConfig::CONVERT_PATH);
-        $info[GraphicsConfig::MEM_LIMIT]	= $config->get_int(GraphicsConfig::MEM_LIMIT);
+        $info[MediaConfig::FFMPEG_PATH]	= $config->get_string(MediaConfig::FFMPEG_PATH);
+        $info[MediaConfig::CONVERT_PATH]	= $config->get_string(MediaConfig::CONVERT_PATH);
+        $info[MediaConfig::MEM_LIMIT]	= $config->get_int(MediaConfig::MEM_LIMIT);
 
         $info[ImageConfig::THUMB_ENGINE]	= $config->get_string(ImageConfig::THUMB_ENGINE);
         $info[ImageConfig::THUMB_QUALITY]	= $config->get_int(ImageConfig::THUMB_QUALITY);

--- a/ext/et/theme.php
+++ b/ext/et/theme.php
@@ -35,14 +35,16 @@ Database: {$info['sys_db']}
 Server: {$info['sys_server']}
 Disk use: {$info['sys_disk']}
 
+Graphics System:
+Memory Limit: {$info[GraphicsConfig::MEM_LIMIT]}
+
 Thumbnail Generation:
-Engine: {$info['thumb_engine']}
-Type: {$info['thumb_type']}
-Memory: {$info['thumb_mem']}
-Quality: {$info['thumb_quality']}
-Width: {$info['thumb_width']}
-Height: {$info['thumb_height']}
-Scaling: {$info['thumb_scaling']}
+Engine: {$info[ImageConfig::THUMB_ENGINE]}
+Type: {$info[ImageConfig::THUMB_TYPE]}
+Quality: {$info[ImageConfig::THUMB_QUALITY]}
+Width: {$info[ImageConfig::THUMB_WIDTH]}
+Height: {$info[ImageConfig::THUMB_HEIGHT]}
+Scaling: {$info[ImageConfig::THUMB_SCALING]}
 
 Shimmie stats:
 Images: {$info['stat_images']}

--- a/ext/et/theme.php
+++ b/ext/et/theme.php
@@ -35,8 +35,8 @@ Database: {$info['sys_db']}
 Server: {$info['sys_server']}
 Disk use: {$info['sys_disk']}
 
-Graphics System:
-Memory Limit: {$info[GraphicsConfig::MEM_LIMIT]}
+Media System:
+Memory Limit: {$info[MediaConfig::MEM_LIMIT]}
 
 Thumbnail Generation:
 Engine: {$info[ImageConfig::THUMB_ENGINE]}

--- a/ext/graphics/main.php
+++ b/ext/graphics/main.php
@@ -1,0 +1,808 @@
+<?php
+/*
+ * Name: Graphics
+ * Author: Matthew Barbour <matthew@darkholme.net>
+ * Description: Provides common functions and settings used for graphic operations.
+ * License: MIT
+ * Version: 1.0
+ */
+
+/*
+* This is used by the graphics code when there is an error
+*/
+
+use FFMpeg\FFMpeg;
+
+abstract class GraphicsConfig
+{
+    const FFMPEG_PATH = "graphics_ffmpeg_path";
+    const FFPROBE_PATH = "graphics_ffprobe_path";
+    const CONVERT_PATH = "graphics_convert_path";
+    const VERSION = "ext_graphics_version";
+    const MEM_LIMIT =  'graphics_mem_limit';
+
+}
+
+class GraphicsException extends SCoreException
+{
+}
+
+class GraphicResizeEvent extends Event
+{
+    public $engine;
+    public $input_path;
+    public $input_type;
+    public $output_path;
+    public $target_format;
+    public $target_width;
+    public $target_height;
+    public $target_quality;
+    public $minimize;
+    public $ignore_aspect_ratio;
+    public $allow_upscale;
+
+    public function __construct(String $engine, string $input_path, string $input_type, string $output_path,
+                                int $target_width, int $target_height,
+                                bool $ignore_aspect_ratio = false,
+                                string $target_format = null,
+                                int $target_quality = 80,
+                                bool $minimize = false,
+                                bool $allow_upscale = true)
+    {
+        assert(in_array($engine, Graphics::GRAPHICS_ENGINES));
+        $this->engine = $engine;
+        $this->input_path = $input_path;
+        $this->input_type = $input_type;
+        $this->output_path = $output_path;
+        $this->target_height = $target_height;
+        $this->target_width = $target_width;
+        $this->target_format = $target_format;
+        $this->target_quality = $target_quality;
+        $this->minimize = $minimize;
+        $this->ignore_aspect_ratio = $ignore_aspect_ratio;
+        $this->allow_upscale = $allow_upscale;
+    }
+}
+
+class Graphics extends Extension
+{
+    const WEBP_LOSSY = "webp-lossy";
+    const WEBP_LOSSLESS = "webp-lossless";
+
+    const FFMPEG_ENGINE = "ffmpeg";
+    const GD_ENGINE = "gd";
+    const IMAGICK_ENGINE = "convert";
+
+    const GRAPHICS_ENGINES = [
+        self::GD_ENGINE,
+        self::FFMPEG_ENGINE,
+        self::IMAGICK_ENGINE
+    ];
+
+    const IMAGE_GRAPHICS_ENGINES = [
+        "GD" => self::GD_ENGINE,
+        "ImageMagick" => self::IMAGICK_ENGINE,
+    ];
+
+    const ENGINE_INPUT_SUPPORT = [
+        self::GD_ENGINE => [
+            "bmp",
+            "gif",
+            "jpg",
+            "png",
+            "webp",
+        ],
+        self::IMAGICK_ENGINE => [
+            "bmp",
+            "gif",
+            "jpg",
+            "png",
+            "psd",
+            "tiff",
+            "webp",
+            "ico",
+        ],
+        self::FFMPEG_ENGINE => [
+            "avi",
+            "mkv",
+            "webm",
+            "mp4",
+            "mov",
+            "flv"
+        ]
+    ];
+
+    const ENGINE_OUTPUT_SUPPORT = [
+        self::GD_ENGINE => [
+            "gif",
+            "jpg",
+            "png",
+            "webp",
+            self::WEBP_LOSSY,
+        ],
+        self::IMAGICK_ENGINE => [
+            "gif",
+            "jpg",
+            "png",
+            "webp",
+            self::WEBP_LOSSY,
+            self::WEBP_LOSSLESS,
+        ],
+        self::FFMPEG_ENGINE => [
+
+        ]
+    ];
+
+    const LOSSLESS_FORMATS = [
+        self::WEBP_LOSSLESS,
+        "png",
+    ];
+
+    const ALPHA_FORMATS = [
+        self::WEBP_LOSSLESS,
+        self::WEBP_LOSSY,
+        "png",
+    ];
+
+    const FORMAT_ALIASES = [
+        "tif" => "tiff",
+        "jpeg" => "jpg",
+    ];
+
+
+    static function imagick_available(): bool
+    {
+        return extension_loaded("imagick");
+    }
+
+    /**
+     * High priority just so that it can be early in the settings
+     */
+    public function get_priority(): int
+    {
+        return 30;
+    }
+
+    public function onInitExt(InitExtEvent $event)
+    {
+        global $config;
+        $config->set_default_string(GraphicsConfig::FFPROBE_PATH, 'ffprobe');
+
+
+        if ($config->get_int(GraphicsConfig::VERSION) < 1) {
+            $current_value = $config->get_string("thumb_ffmpeg_path");
+            if(!empty($current_value)) {
+                $config->set_string(GraphicsConfig::FFMPEG_PATH, $current_value);
+            } elseif ($ffmpeg = shell_exec((PHP_OS == 'WINNT' ? 'where' : 'which') . ' ffmpeg')) {
+                //ffmpeg exists in PATH, check if it's executable, and if so, default to it instead of static
+                if (is_executable(strtok($ffmpeg, PHP_EOL))) {
+                    $config->set_default_string(GraphicsConfig::FFMPEG_PATH, 'ffmpeg');
+                }
+            } else {
+                $config->set_default_string(GraphicsConfig::FFMPEG_PATH, '');
+            }
+
+            $current_value = $config->get_string("thumb_convert_path");
+            if(!empty($current_value)) {
+                $config->set_string(GraphicsConfig::CONVERT_PATH, $current_value);
+            } elseif ($convert = shell_exec((PHP_OS == 'WINNT' ? 'where' : 'which') . ' convert')) {
+                //ffmpeg exists in PATH, check if it's executable, and if so, default to it instead of static
+                if (is_executable(strtok($convert, PHP_EOL))) {
+                    $config->set_default_string(GraphicsConfig::CONVERT_PATH, 'convert');
+                }
+            } else {
+                $config->set_default_string(GraphicsConfig::CONVERT_PATH, '');
+            }
+
+            $current_value = $config->get_int("thumb_mem_limit");
+            if(!empty($current_value)) {
+                $config->set_int(GraphicsConfig::MEM_LIMIT, $current_value);
+            }
+
+
+
+
+            $config->set_int(GraphicsConfig::VERSION, 1);
+            log_info("graphics", "extension installed");
+        }
+    }
+
+    public function onSetupBuilding(SetupBuildingEvent $event)
+    {
+        $sb = new SetupBlock("Graphics");
+
+//        if (self::imagick_available()) {
+//            try {
+//                $image = new Imagick(realpath('tests/favicon.png'));
+//                $image->clear();
+//                $sb->add_label("ImageMagick detected");
+//            } catch (ImagickException $e) {
+//                $sb->add_label("<b style='color:red'>ImageMagick not detected</b>");
+//            }
+//        } else {
+            $sb->add_text_option(GraphicsConfig::CONVERT_PATH, "convert command: ");
+//        }
+
+        $sb->add_text_option(GraphicsConfig::FFMPEG_PATH, "<br/>ffmpeg command: ");
+
+        $sb->add_shorthand_int_option(GraphicsConfig::MEM_LIMIT, "<br />Max memory use: ");
+
+        $event->panel->add_block($sb);
+
+    }
+
+    /**
+     * @param GraphicResizeEvent $event
+     * @throws GraphicsException
+     * @throws InsufficientMemoryException
+     */
+    public function onGraphicResize(GraphicResizeEvent $event)
+    {
+        switch ($event->engine) {
+            case self::GD_ENGINE:
+                $info = getimagesize($event->input_path);
+                if ($info === false) {
+                    throw new GraphicsException("getimagesize failed for " . $event->input_path);
+                }
+
+                self::image_resize_gd(
+                    $event->input_path,
+                    $info,
+                    $event->target_width,
+                    $event->target_height,
+                    $event->output_path,
+                    $event->target_format,
+                    $event->ignore_aspect_ratio,
+                    $event->target_quality,
+                    $event->allow_upscale);
+
+                break;
+            case self::IMAGICK_ENGINE:
+//                if (self::imagick_available()) {
+//                } else {
+                    self::image_resize_convert(
+                        $event->input_path,
+                        $event->input_type,
+                        $event->target_width,
+                        $event->target_height,
+                        $event->output_path,
+                        $event->target_format,
+                        $event->ignore_aspect_ratio,
+                        $event->target_quality,
+                        $event->minimize,
+                        $event->allow_upscale);
+                //}
+                break;
+            default:
+                throw new GraphicsException("Engine not supported for resize: " . $event->engine);
+        }
+
+        // TODO: Get output optimization tools working better
+//        if ($config->get_bool("thumb_optim", false)) {
+//            exec("jpegoptim $outname", $output, $ret);
+//        }
+    }
+
+    /**
+     * Check Memory usage limits
+     *
+     * Old check:   $memory_use = (filesize($image_filename)*2) + ($width*$height*4) + (4*1024*1024);
+     * New check:   $memory_use = $width * $height * ($bits_per_channel) * channels * 2.5
+     *
+     * It didn't make sense to compute the memory usage based on the NEW size for the image. ($width*$height*4)
+     * We need to consider the size that we are GOING TO instead.
+     *
+     * The factor of 2.5 is simply a rough guideline.
+     * http://stackoverflow.com/questions/527532/reasonable-php-memory-limit-for-image-resize
+     *
+     * @param array $info The output of getimagesize() for the source file in question.
+     * @return int The number of bytes an image resize operation is estimated to use.
+     */
+    static function calc_memory_use(array $info): int
+    {
+        if (isset($info['bits']) && isset($info['channels'])) {
+            $memory_use = ($info[0] * $info[1] * ($info['bits'] / 8) * $info['channels'] * 2.5) / 1024;
+        } else {
+            // If we don't have bits and channel info from the image then assume default values
+            // of 8 bits per color and 4 channels (R,G,B,A) -- ie: regular 24-bit color
+            $memory_use = ($info[0] * $info[1] * 1 * 4 * 2.5) / 1024;
+        }
+        return (int)$memory_use;
+    }
+
+
+    /**
+     * Creates a thumbnail using ffmpeg.
+     *
+     * @param $hash
+     * @return bool true if successful, false if not.
+     * @throws GraphicsException
+     */
+    static function create_thumbnail_ffmpeg($hash): bool
+    {
+        global $config;
+
+        $ffmpeg = $config->get_string(GraphicsConfig::FFMPEG_PATH);
+        if ($ffmpeg == null || $ffmpeg == "") {
+            throw new GraphicsException("ffmpeg command configured");
+        }
+
+        $inname = warehouse_path(Image::IMAGE_DIR, $hash);
+        $outname = warehouse_path(Image::THUMBNAIL_DIR, $hash);
+
+        $orig_size = self::video_size($inname);
+        $scaled_size = get_thumbnail_size($orig_size[0], $orig_size[1], true);
+
+        $codec = "mjpeg";
+        $quality = $config->get_int(ImageConfig::THUMB_QUALITY);
+        if ($config->get_string(ImageConfig::THUMB_TYPE) == "webp") {
+            $codec = "libwebp";
+        } else {
+            // mjpeg quality ranges from 2-31, with 2 being the best quality.
+            $quality = floor(31 - (31 * ($quality / 100)));
+            if ($quality < 2) {
+                $quality = 2;
+            }
+        }
+
+        $args = [
+            escapeshellarg($ffmpeg),
+            "-y", "-i", escapeshellarg($inname),
+            "-vf", "thumbnail,scale={$scaled_size[0]}:{$scaled_size[1]}",
+            "-f", "image2",
+            "-vframes", "1",
+            "-c:v", $codec,
+            "-q:v", $quality,
+            escapeshellarg($outname),
+        ];
+
+        $cmd = escapeshellcmd(implode(" ", $args));
+
+        exec($cmd, $output, $ret);
+
+        if ((int)$ret == (int)0) {
+            log_debug('graphics', "Generating thumbnail with command `$cmd`, returns $ret");
+            return true;
+        } else {
+            log_error('graphics', "Generating thumbnail with command `$cmd`, returns $ret");
+            return false;
+        }
+    }
+
+    public static function determine_ext(String $format): String
+    {
+        $format = self::normalize_format($format);
+        switch ($format) {
+            case self::WEBP_LOSSLESS:
+            case self::WEBP_LOSSY:
+                return "webp";
+            default:
+                return $format;
+        }
+    }
+
+//    private static function image_save_imagick(Imagick $image, string $path, string $format, int $output_quality = 80, bool $minimize)
+//    {
+//        switch ($format) {
+//            case "png":
+//                $result = $image->setOption('png:compression-level', 9);
+//                if ($result !== true) {
+//                    throw new GraphicsException("Could not set png compression option");
+//                }
+//                break;
+//            case Graphics::WEBP_LOSSLESS:
+//                $result = $image->setOption('webp:lossless', true);
+//                if ($result !== true) {
+//                    throw new GraphicsException("Could not set lossless webp option");
+//                }
+//                break;
+//            default:
+//                $result = $image->setImageCompressionQuality($output_quality);
+//                if ($result !== true) {
+//                    throw new GraphicsException("Could not set compression quality for $path to $output_quality");
+//                }
+//                break;
+//        }
+//
+//        if (self::supports_alpha($format)) {
+//            $result = $image->setImageBackgroundColor(new \ImagickPixel('transparent'));
+//        } else {
+//            $result = $image->setImageBackgroundColor(new \ImagickPixel('black'));
+//        }
+//        if ($result !== true) {
+//            throw new GraphicsException("Could not set background color");
+//        }
+//
+//
+//        if ($minimize) {
+//            $profiles = $image->getImageProfiles("icc", true);
+//            $result = $image->stripImage();
+//            if ($result !== true) {
+//                throw new GraphicsException("Could not strip information from image");
+//            }
+//            if (!empty($profiles)) {
+//                $image->profileImage("icc", $profiles['icc']);
+//            }
+//        }
+//
+//        $ext = self::determine_ext($format);
+//
+//        $result = $image->writeImage($ext . ":" . $path);
+//        if ($result !== true) {
+//            throw new GraphicsException("Could not write image to $path");
+//        }
+//    }
+
+//    public static function image_resize_imagick(
+//        String $input_path,
+//        String $input_type,
+//        int $new_width,
+//        int $new_height,
+//        string $output_filename,
+//        string $output_type = null,
+//        bool $ignore_aspect_ratio = false,
+//        int $output_quality = 80,
+//        bool $minimize = false,
+//        bool $allow_upscale = true
+//    ): void
+//    {
+//        global $config;
+//
+//        if (!empty($input_type)) {
+//            $input_type = self::determine_ext($input_type);
+//        }
+//
+//        try {
+//            $image = new Imagick($input_type . ":" . $input_path);
+//            try {
+//                $result = $image->flattenImages();
+//                if ($result !== true) {
+//                    throw new GraphicsException("Could not flatten image $input_path");
+//                }
+//
+//                $height = $image->getImageHeight();
+//                $width = $image->getImageWidth();
+//                if (!$allow_upscale &&
+//                    ($new_width > $width || $new_height > $height)) {
+//                    $new_height = $height;
+//                    $new_width = $width;
+//                }
+//
+//                $result = $image->resizeImage($new_width, $new_width, Imagick::FILTER_LANCZOS, 0, !$ignore_aspect_ratio);
+//                if ($result !== true) {
+//                    throw new GraphicsException("Could not perform image resize on $input_path");
+//                }
+//
+//
+//                if (empty($output_type)) {
+//                    $output_type = $input_type;
+//                }
+//
+//                self::image_save_imagick($image, $output_filename, $output_type, $output_quality);
+//
+//            } finally {
+//                $image->destroy();
+//            }
+//        } catch (ImagickException $e) {
+//            throw new GraphicsException("Error while resizing with Imagick: " . $e->getMessage(), $e->getCode(), $e);
+//        }
+//    }
+
+
+    public static function image_resize_convert(
+        String $input_path,
+        String $input_type,
+        int $new_width,
+        int $new_height,
+        string $output_filename,
+        string $output_type = null,
+        bool $ignore_aspect_ratio = false,
+        int $output_quality = 80,
+        bool $minimize = false,
+        bool $allow_upscale = true
+    ): void
+    {
+        global $config;
+
+        $convert = $config->get_string(GraphicsConfig::CONVERT_PATH);
+
+        if ($convert == null || $convert == "") {
+            throw new GraphicsException("convert command not configured");
+        }
+
+        if (empty($output_type)) {
+            $output_type = $input_type;
+        }
+
+        $bg = "black";
+        if (self::supports_alpha($output_type)) {
+            $bg = "none";
+        }
+        if (!empty($input_type)) {
+            $input_type = $input_type . ":";
+        }
+        $args = "";
+        if ($minimize) {
+            $args = " -strip -thumbnail";
+        }
+
+        $resize_args = "";
+        if (!$allow_upscale) {
+            $resize_args .= "\>";
+        }
+        if ($ignore_aspect_ratio) {
+            $resize_args .= "\!";
+        }
+
+        $format = '"%s" -flatten %s %ux%u%s -quality %u -background %s %s"%s[0]"  %s:"%s" 2>&1';
+        $cmd = sprintf($format, $convert, $args, $new_width, $new_height, $resize_args, $output_quality, $bg, $input_type, $input_path, $output_type, $output_filename);
+        $cmd = str_replace("\"convert\"", "convert", $cmd); // quotes are only needed if the path to convert contains a space; some other times, quotes break things, see github bug #27
+        exec($cmd, $output, $ret);
+        if ($ret != 0) {
+            throw new GraphicsException("Resizing image with command `$cmd`, returns $ret, outputting " . implode("\r\n", $output));
+        } else {
+            log_debug('graphics', "Generating thumbnail with command `$cmd`, returns $ret");
+        }
+    }
+
+    /**
+     * Performs a resize operation on an image file using GD.
+     *
+     * @param String $image_filename The source file to be resized.
+     * @param array $info The output of getimagesize() for the source file.
+     * @param int $new_width
+     * @param int $new_height
+     * @param string $output_filename
+     * @param string|null $output_type If set to null, the output file type will be automatically determined via the $info parameter. Otherwise an exception will be thrown.
+     * @param int $output_quality Defaults to 80.
+     * @throws GraphicsException
+     * @throws InsufficientMemoryException if the estimated memory usage exceeds the memory limit.
+     */
+    public static function image_resize_gd(
+        String $image_filename,
+        array $info,
+        int $new_width,
+        int $new_height,
+        string $output_filename,
+        string $output_type = null,
+        bool $ignore_aspect_ratio = false,
+        int $output_quality = 80,
+        bool $allow_upscale = true
+    )
+    {
+        $width = $info[0];
+        $height = $info[1];
+
+        if ($output_type == null) {
+            /* If not specified, output to the same format as the original image */
+            switch ($info[2]) {
+                case IMAGETYPE_GIF:
+                    $output_type = "gif";
+                    break;
+                case IMAGETYPE_JPEG:
+                    $output_type = "jpeg";
+                    break;
+                case IMAGETYPE_PNG:
+                    $output_type = "png";
+                    break;
+                case IMAGETYPE_WEBP:
+                    $output_type = "webp";
+                    break;
+                case IMAGETYPE_BMP:
+                    $output_type = "bmp";
+                    break;
+                default:
+                    throw new GraphicsException("Failed to save the new image - Unsupported image type.");
+            }
+        }
+
+        $memory_use = self::calc_memory_use($info);
+        $memory_limit = get_memory_limit();
+        if ($memory_use > $memory_limit) {
+            throw new InsufficientMemoryException("The image is too large to resize given the memory limits. ($memory_use > $memory_limit)");
+        }
+
+        if (!$ignore_aspect_ratio) {
+            list($new_width, $new_height) = get_scaled_by_aspect_ratio($width, $height, $new_width, $new_height);
+        }
+        if (!$allow_upscale &&
+            ($new_width > $width || $new_height > $height)) {
+            $new_height = $height;
+            $new_width = $width;
+        }
+
+        $image = imagecreatefromstring(file_get_contents($image_filename));
+        $image_resized = imagecreatetruecolor($new_width, $new_height);
+        try {
+            if ($image === false) {
+                throw new GraphicsException("Could not load image: " . $image_filename);
+            }
+            if ($image_resized === false) {
+                throw new GraphicsException("Could not create output image with dimensions $new_width c $new_height ");
+            }
+
+            // Handle transparent images
+            switch ($info[2]) {
+                case IMAGETYPE_GIF:
+                    $transparency = imagecolortransparent($image);
+                    $pallet_size = imagecolorstotal($image);
+
+                    // If we have a specific transparent color
+                    if ($transparency >= 0 && $transparency < $pallet_size) {
+                        // Get the original image's transparent color's RGB values
+                        $transparent_color = imagecolorsforindex($image, $transparency);
+
+                        // Allocate the same color in the new image resource
+                        $transparency = imagecolorallocate($image_resized, $transparent_color['red'], $transparent_color['green'], $transparent_color['blue']);
+                        if ($transparency === false) {
+                            throw new GraphicsException("Unable to allocate transparent color");
+                        }
+
+                        // Completely fill the background of the new image with allocated color.
+                        if (imagefill($image_resized, 0, 0, $transparency) === false) {
+                            throw new GraphicsException("Unable to fill new image with transparent color");
+                        }
+
+                        // Set the background color for new image to transparent
+                        imagecolortransparent($image_resized, $transparency);
+                    }
+                    break;
+                case IMAGETYPE_PNG:
+                case IMAGETYPE_WEBP:
+                    //
+                    // More info here:  http://stackoverflow.com/questions/279236/how-do-i-resize-pngs-with-transparency-in-php
+                    //
+                    if (imagealphablending($image_resized, false) === false) {
+                        throw new GraphicsException("Unable to disable image alpha blending");
+                    }
+                    if (imagesavealpha($image_resized, true) === false) {
+                        throw new GraphicsException("Unable to enable image save alpha");
+                    }
+                    $transparent_color = imagecolorallocatealpha($image_resized, 255, 255, 255, 127);
+                    if ($transparent_color === false) {
+                        throw new GraphicsException("Unable to allocate transparent color");
+                    }
+                    if (imagefilledrectangle($image_resized, 0, 0, $new_width, $new_height, $transparent_color) === false) {
+                        throw new GraphicsException("Unable to fill new image with transparent color");
+                    }
+                    break;
+            }
+
+            // Actually resize the image.
+            if (imagecopyresampled(
+                    $image_resized,
+                    $image,
+                    0,
+                    0,
+                    0,
+                    0,
+                    $new_width,
+                    $new_height,
+                    $width,
+                    $height
+                ) === false) {
+                throw new GraphicsException("Unable to copy resized image data to new image");
+            }
+
+            switch ($output_type) {
+                case "bmp":
+                    $result = imagebmp($image_resized, $output_filename, true);
+                    break;
+                case "webp":
+                case Graphics::WEBP_LOSSY:
+                    $result = imagewebp($image_resized, $output_filename, $output_quality);
+                    break;
+                case "jpg":
+                case "jpeg":
+                    $result = imagejpeg($image_resized, $output_filename, $output_quality);
+                    break;
+                case "png":
+                    $result = imagepng($image_resized, $output_filename, 9);
+                    break;
+                case "gif":
+                    $result = imagegif($image_resized, $output_filename);
+                    break;
+                default:
+                    throw new GraphicsException("Failed to save the new image - Unsupported image type: $output_type");
+            }
+            if ($result === false) {
+                throw new GraphicsException("Failed to save the new image, function returned false when saving type: $output_type");
+            }
+        } finally {
+            @imagedestroy($image);
+            @imagedestroy($image_resized);
+        }
+    }
+
+    /**
+     * Determines if a file is an animated gif.
+     *
+     * @param String $image_filename The path of the file to check.
+     * @return bool true if the file is an animated gif, false if it is not.
+     */
+    public static function is_animated_gif(String $image_filename)
+    {
+        $is_anim_gif = 0;
+        if (($fh = @fopen($image_filename, 'rb'))) {
+            //check if gif is animated (via http://www.php.net/manual/en/function.imagecreatefromgif.php#104473)
+            while (!feof($fh) && $is_anim_gif < 2) {
+                $chunk = fread($fh, 1024 * 100);
+                $is_anim_gif += preg_match_all('#\x00\x21\xF9\x04.{4}\x00(\x2C|\x21)#s', $chunk, $matches);
+            }
+        }
+        return ($is_anim_gif == 0);
+    }
+
+    public static function supports_alpha(string $format)
+    {
+        return in_array(self::normalize_format($format), self::ALPHA_FORMATS);
+    }
+
+    public static function is_input_supported($engine, $format): bool
+    {
+        $format = self::normalize_format($format);
+        if (!in_array($format, Graphics::ENGINE_INPUT_SUPPORT[$engine])) {
+            return false;
+        }
+        return true;
+    }
+
+    public static function is_output_supported($engine, $format): bool
+    {
+        $format = self::normalize_format($format);
+        if (!in_array($format, Graphics::ENGINE_OUTPUT_SUPPORT[$engine])) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Checks if a format (normally a file extension) is a variant name of another format (ie, jpg and jpeg).
+     * If one is found, then the maine name that the Graphics extension will recognize is returned,
+     * otherwise the incoming format is returned.
+     *
+     * @param $format
+     * @return string|null The format name that the graphics extension will recognize.
+     */
+    static public function normalize_format($format): ?string
+    {
+        if (array_key_exists($format, Graphics::FORMAT_ALIASES)) {
+            return self::FORMAT_ALIASES[$format];
+        }
+        return $format;
+    }
+
+
+    /**
+     * Determines the dimensions of a video file using ffmpeg.
+     *
+     * @param string $filename
+     * @return array [width, height]
+     */
+    static public function video_size(string $filename): array
+    {
+        global $config;
+        $ffmpeg = $config->get_string(GraphicsConfig::FFMPEG_PATH);
+        $cmd = escapeshellcmd(implode(" ", [
+            escapeshellarg($ffmpeg),
+            "-y", "-i", escapeshellarg($filename),
+            "-vstats"
+        ]));
+        $output = shell_exec($cmd . " 2>&1");
+        // error_log("Getting size with `$cmd`");
+
+        $regex_sizes = "/Video: .* ([0-9]{1,4})x([0-9]{1,4})/";
+        if (preg_match($regex_sizes, $output, $regs)) {
+            if (preg_match("/displaymatrix: rotation of (90|270).00 degrees/", $output)) {
+                $size = [$regs[2], $regs[1]];
+            } else {
+                $size = [$regs[1], $regs[2]];
+            }
+        } else {
+            $size = [1, 1];
+        }
+        log_debug('graphics', "Getting video size with `$cmd`, returns $output -- $size[0], $size[1]");
+        return $size;
+    }
+
+}

--- a/ext/graphics/main.php
+++ b/ext/graphics/main.php
@@ -37,15 +37,15 @@ abstract class GraphicsEngine {
             "jpg",
             "png",
             "webp",
-            self::WEBP_LOSSY,
+            Graphics::WEBP_LOSSY,
         ],
         GraphicsEngine::IMAGICK => [
             "gif",
             "jpg",
             "png",
             "webp",
-            self::WEBP_LOSSY,
-            self::WEBP_LOSSLESS,
+            Graphics::WEBP_LOSSY,
+            Graphics::WEBP_LOSSLESS,
         ],
         GraphicsEngine::FFMPEG => [
 

--- a/ext/graphics/main.php
+++ b/ext/graphics/main.php
@@ -19,7 +19,7 @@ abstract class GraphicsConfig
     const FFPROBE_PATH = "graphics_ffprobe_path";
     const CONVERT_PATH = "graphics_convert_path";
     const VERSION = "ext_graphics_version";
-    const MEM_LIMIT =  'graphics_mem_limit';
+    const MEM_LIMIT = 'graphics_mem_limit';
 
 }
 
@@ -167,40 +167,36 @@ class Graphics extends Extension
     {
         global $config;
         $config->set_default_string(GraphicsConfig::FFPROBE_PATH, 'ffprobe');
+        $config->set_default_int(GraphicsConfig::MEM_LIMIT, parse_shorthand_int('8MB'));
+        $config->set_default_string(GraphicsConfig::FFMPEG_PATH, '');
+        $config->set_default_string(GraphicsConfig::CONVERT_PATH, '');
 
 
         if ($config->get_int(GraphicsConfig::VERSION) < 1) {
             $current_value = $config->get_string("thumb_ffmpeg_path");
-            if(!empty($current_value)) {
+            if (!empty($current_value)) {
                 $config->set_string(GraphicsConfig::FFMPEG_PATH, $current_value);
             } elseif ($ffmpeg = shell_exec((PHP_OS == 'WINNT' ? 'where' : 'which') . ' ffmpeg')) {
                 //ffmpeg exists in PATH, check if it's executable, and if so, default to it instead of static
                 if (is_executable(strtok($ffmpeg, PHP_EOL))) {
                     $config->set_default_string(GraphicsConfig::FFMPEG_PATH, 'ffmpeg');
                 }
-            } else {
-                $config->set_default_string(GraphicsConfig::FFMPEG_PATH, '');
             }
 
             $current_value = $config->get_string("thumb_convert_path");
-            if(!empty($current_value)) {
+            if (!empty($current_value)) {
                 $config->set_string(GraphicsConfig::CONVERT_PATH, $current_value);
             } elseif ($convert = shell_exec((PHP_OS == 'WINNT' ? 'where' : 'which') . ' convert')) {
                 //ffmpeg exists in PATH, check if it's executable, and if so, default to it instead of static
                 if (is_executable(strtok($convert, PHP_EOL))) {
                     $config->set_default_string(GraphicsConfig::CONVERT_PATH, 'convert');
                 }
-            } else {
-                $config->set_default_string(GraphicsConfig::CONVERT_PATH, '');
             }
 
             $current_value = $config->get_int("thumb_mem_limit");
-            if(!empty($current_value)) {
+            if (!empty($current_value)) {
                 $config->set_int(GraphicsConfig::MEM_LIMIT, $current_value);
             }
-
-
-
 
             $config->set_int(GraphicsConfig::VERSION, 1);
             log_info("graphics", "extension installed");
@@ -220,7 +216,7 @@ class Graphics extends Extension
 //                $sb->add_label("<b style='color:red'>ImageMagick not detected</b>");
 //            }
 //        } else {
-            $sb->add_text_option(GraphicsConfig::CONVERT_PATH, "convert command: ");
+        $sb->add_text_option(GraphicsConfig::CONVERT_PATH, "convert command: ");
 //        }
 
         $sb->add_text_option(GraphicsConfig::FFMPEG_PATH, "<br/>ffmpeg command: ");
@@ -260,17 +256,17 @@ class Graphics extends Extension
             case self::IMAGICK_ENGINE:
 //                if (self::imagick_available()) {
 //                } else {
-                    self::image_resize_convert(
-                        $event->input_path,
-                        $event->input_type,
-                        $event->target_width,
-                        $event->target_height,
-                        $event->output_path,
-                        $event->target_format,
-                        $event->ignore_aspect_ratio,
-                        $event->target_quality,
-                        $event->minimize,
-                        $event->allow_upscale);
+                self::image_resize_convert(
+                    $event->input_path,
+                    $event->input_type,
+                    $event->target_width,
+                    $event->target_height,
+                    $event->output_path,
+                    $event->target_format,
+                    $event->ignore_aspect_ratio,
+                    $event->target_quality,
+                    $event->minimize,
+                    $event->allow_upscale);
                 //}
                 break;
             default:

--- a/ext/graphics/main.php
+++ b/ext/graphics/main.php
@@ -11,8 +11,6 @@
 * This is used by the graphics code when there is an error
 */
 
-use FFMpeg\FFMpeg;
-
 abstract class GraphicsConfig
 {
     const FFMPEG_PATH = "graphics_ffmpeg_path";
@@ -169,7 +167,7 @@ class Graphics extends Extension
         $config->set_default_string(GraphicsConfig::FFPROBE_PATH, 'ffprobe');
         $config->set_default_int(GraphicsConfig::MEM_LIMIT, parse_shorthand_int('8MB'));
         $config->set_default_string(GraphicsConfig::FFMPEG_PATH, '');
-        $config->set_default_string(GraphicsConfig::CONVERT_PATH, '');
+        $config->set_default_string(GraphicsConfig::CONVERT_PATH, 'convert');
 
 
         if ($config->get_int(GraphicsConfig::VERSION) < 1) {

--- a/ext/graphics/theme.php
+++ b/ext/graphics/theme.php
@@ -1,6 +1,0 @@
-<?php
-
-class GraphicsTheme extends Themelet
-{
-
-}

--- a/ext/graphics/theme.php
+++ b/ext/graphics/theme.php
@@ -1,0 +1,6 @@
+<?php
+
+class GraphicsTheme extends Themelet
+{
+
+}

--- a/ext/handle_flash/main.php
+++ b/ext/handle_flash/main.php
@@ -12,7 +12,7 @@ class FlashFileHandler extends DataHandlerExtension
     {
         global $config;
 
-        if (!Graphics::create_thumbnail_ffmpeg($hash)) {
+        if (!Media::create_thumbnail_ffmpeg($hash)) {
             copy("ext/handle_flash/thumb.jpg", warehouse_path(Image::THUMBNAIL_DIR, $hash));
         }
         return true;

--- a/ext/handle_flash/main.php
+++ b/ext/handle_flash/main.php
@@ -8,6 +8,26 @@
 
 class FlashFileHandler extends DataHandlerExtension
 {
+
+    public function onMediaCheckProperties(MediaCheckPropertiesEvent $event)
+    {
+        switch ($event->ext) {
+            case "swf":
+                $event->lossless = true;
+                $event->video = true;
+
+                $info = getimagesize($event->file_name);
+                if (!$info) {
+                    return null;
+                }
+
+                $event->width = $info[0];
+                $event->height = $info[1];
+
+                break;
+        }
+    }
+
     protected function create_thumb(string $hash, string $type): bool
     {
         global $config;
@@ -35,13 +55,7 @@ class FlashFileHandler extends DataHandlerExtension
         $image->tag_array = is_array($metadata['tags']) ? $metadata['tags'] : Tag::explode($metadata['tags']);
         $image->source    = $metadata['source'];
 
-        $info = getimagesize($filename);
-        if (!$info) {
-            return null;
-        }
 
-        $image->width = $info[0];
-        $image->height = $info[1];
 
         return $image;
     }

--- a/ext/handle_flash/main.php
+++ b/ext/handle_flash/main.php
@@ -12,7 +12,7 @@ class FlashFileHandler extends DataHandlerExtension
     {
         global $config;
 
-        if (!create_thumbnail_ffmpeg($hash)) {
+        if (!Graphics::create_thumbnail_ffmpeg($hash)) {
             copy("ext/handle_flash/thumb.jpg", warehouse_path(Image::THUMBNAIL_DIR, $hash));
         }
         return true;

--- a/ext/handle_ico/main.php
+++ b/ext/handle_ico/main.php
@@ -56,6 +56,12 @@ class IcoFileHandler extends DataHandlerExtension
 
     protected function create_thumb(string $hash, string $type): bool
     {
-        return create_thumbnail_convert($hash, $type);
+        try {
+            create_image_thumb($hash, $type, Graphics::IMAGICK_ENGINE);
+            return true;
+        } catch (GraphicsException $e) {
+            log_warning("handle_ico", "Could not generate thumbnail. " . $e->getMessage());
+            return false;
+        }
     }
 }

--- a/ext/handle_ico/main.php
+++ b/ext/handle_ico/main.php
@@ -57,9 +57,9 @@ class IcoFileHandler extends DataHandlerExtension
     protected function create_thumb(string $hash, string $type): bool
     {
         try {
-            create_image_thumb($hash, $type, GraphicsEngine::IMAGICK);
+            create_image_thumb($hash, $type, MediaEngine::IMAGICK);
             return true;
-        } catch (GraphicsException $e) {
+        } catch (MediaException $e) {
             log_warning("handle_ico", "Could not generate thumbnail. " . $e->getMessage());
             return false;
         }

--- a/ext/handle_ico/main.php
+++ b/ext/handle_ico/main.php
@@ -57,7 +57,7 @@ class IcoFileHandler extends DataHandlerExtension
     protected function create_thumb(string $hash, string $type): bool
     {
         try {
-            create_image_thumb($hash, $type, Graphics::IMAGICK_ENGINE);
+            create_image_thumb($hash, $type, GraphicsEngine::IMAGICK);
             return true;
         } catch (GraphicsException $e) {
             log_warning("handle_ico", "Could not generate thumbnail. " . $e->getMessage());

--- a/ext/handle_ico/main.php
+++ b/ext/handle_ico/main.php
@@ -10,6 +10,29 @@ class IcoFileHandler extends DataHandlerExtension
     const SUPPORTED_EXTENSIONS = ["ico", "ani", "cur"];
 
 
+    public function onMediaCheckProperties(MediaCheckPropertiesEvent $event)
+    {
+        if(in_array($event->ext, self::SUPPORTED_EXTENSIONS)) {
+            $event->lossless = true;
+            $event->video = false;
+            $event->audio = false;
+
+            $fp = fopen($event->file_name, "r");
+            try {
+                unpack("Snull/Stype/Scount", fread($fp, 6));
+                $subheader = unpack("Cwidth/Cheight/Ccolours/Cnull/Splanes/Sbpp/Lsize/loffset", fread($fp, 16));
+            } finally {
+                fclose($fp);
+            }
+
+            $width = $subheader['width'];
+            $height = $subheader['height'];
+            $event->width = $width == 0 ? 256 : $width;
+            $event->height = $height == 0 ? 256 : $height;
+        }
+    }
+
+
     protected function supported_ext(string $ext): bool
     {
         return in_array(strtolower($ext), self::SUPPORTED_EXTENSIONS);
@@ -18,20 +41,6 @@ class IcoFileHandler extends DataHandlerExtension
     protected function create_image_from_data(string $filename, array $metadata)
     {
         $image = new Image();
-
-
-        $fp = fopen($filename, "r");
-        try {
-            unpack("Snull/Stype/Scount", fread($fp, 6));
-            $subheader = unpack("Cwidth/Cheight/Ccolours/Cnull/Splanes/Sbpp/Lsize/loffset", fread($fp, 16));
-        } finally {
-            fclose($fp);
-        }
-
-        $width = $subheader['width'];
-        $height = $subheader['height'];
-        $image->width = $width == 0 ? 256 : $width;
-        $image->height = $height == 0 ? 256 : $height;
 
         $image->filesize = $metadata['size'];
         $image->hash = $metadata['hash'];

--- a/ext/handle_mp3/main.php
+++ b/ext/handle_mp3/main.php
@@ -7,6 +7,19 @@
 
 class MP3FileHandler extends DataHandlerExtension
 {
+    public function onMediaCheckProperties(MediaCheckPropertiesEvent $event)
+    {
+        switch ($event->ext) {
+            case "mp3":
+                $event->audio = true;
+                $event->video = false;
+                $event->lossless = false;
+                break;
+        }
+        // TODO: Buff out audio format support, length scanning
+
+    }
+
     protected function create_thumb(string $hash, string $type): bool
     {
         copy("ext/handle_mp3/thumb.jpg", warehouse_path(Image::THUMBNAIL_DIR, $hash));
@@ -36,6 +49,7 @@ class MP3FileHandler extends DataHandlerExtension
         $image->ext       = $metadata['extension'];
         $image->tag_array = is_array($metadata['tags']) ? $metadata['tags'] : Tag::explode($metadata['tags']);
         $image->source    = $metadata['source'];
+
 
         return $image;
     }

--- a/ext/handle_pixel/main.php
+++ b/ext/handle_pixel/main.php
@@ -69,7 +69,6 @@ class PixelFileHandler extends DataHandlerExtension
             imagestring($thumb, 5, 10, 24, "Image Too Large :(", $black);
             return true;
         } catch (Exception $e) {
-            throw $e;
             log_error("handle_pixel", "Error while creating thumbnail: ".$e->getMessage());
             return false;
         }

--- a/ext/handle_pixel/main.php
+++ b/ext/handle_pixel/main.php
@@ -99,6 +99,7 @@ class PixelFileHandler extends DataHandlerExtension
             imagestring($thumb, 5, 10, 24, "Image Too Large :(", $black);
             return true;
         } catch (Exception $e) {
+            throw $e;
             log_error("handle_pixel", "Error while creating thumbnail: ".$e->getMessage());
             return false;
         }

--- a/ext/handle_pixel/main.php
+++ b/ext/handle_pixel/main.php
@@ -69,6 +69,7 @@ class PixelFileHandler extends DataHandlerExtension
             imagestring($thumb, 5, 10, 24, "Image Too Large :(", $black);
             return true;
         } catch (Exception $e) {
+            throw $e;
             log_error("handle_pixel", "Error while creating thumbnail: ".$e->getMessage());
             return false;
         }

--- a/ext/handle_pixel/main.php
+++ b/ext/handle_pixel/main.php
@@ -99,7 +99,6 @@ class PixelFileHandler extends DataHandlerExtension
             imagestring($thumb, 5, 10, 24, "Image Too Large :(", $black);
             return true;
         } catch (Exception $e) {
-            throw $e;
             log_error("handle_pixel", "Error while creating thumbnail: ".$e->getMessage());
             return false;
         }

--- a/ext/handle_pixel/theme.php
+++ b/ext/handle_pixel/theme.php
@@ -7,7 +7,7 @@ class PixelFileHandlerTheme extends Themelet
         global $config;
 
         $u_ilink = $image->get_image_link();
-        if ($config->get_bool("image_show_meta") && function_exists("exif_read_data")) {
+        if ($config->get_bool(ImageConfig::SHOW_META) && function_exists(ImageIO::EXIF_READ_FUNCTION)) {
             # FIXME: only read from jpegs?
             $exif = @exif_read_data($image->get_image_filename(), 0, true);
             if ($exif) {

--- a/ext/handle_svg/main.php
+++ b/ext/handle_svg/main.php
@@ -36,7 +36,7 @@ class SVGFileHandler extends DataHandlerExtension
     protected function create_thumb(string $hash, string $type): bool
     {
         try {
-            create_image_thumb($hash, $type, Graphics::IMAGICK_ENGINE);
+            create_image_thumb($hash, $type, GraphicsEngine::IMAGICK);
             return true;
         } catch (GraphicsException $e) {
             log_warning("handle_svg", "Could not generate thumbnail. " . $e->getMessage());

--- a/ext/handle_svg/main.php
+++ b/ext/handle_svg/main.php
@@ -36,9 +36,9 @@ class SVGFileHandler extends DataHandlerExtension
     protected function create_thumb(string $hash, string $type): bool
     {
         try {
-            create_image_thumb($hash, $type, GraphicsEngine::IMAGICK);
+            create_image_thumb($hash, $type, MediaEngine::IMAGICK);
             return true;
-        } catch (GraphicsException $e) {
+        } catch (MediaException $e) {
             log_warning("handle_svg", "Could not generate thumbnail. " . $e->getMessage());
             copy("ext/handle_svg/thumb.jpg", warehouse_path(Image::THUMBNAIL_DIR, $hash));
             return false;

--- a/ext/handle_svg/main.php
+++ b/ext/handle_svg/main.php
@@ -10,6 +10,24 @@ use enshrined\svgSanitize\Sanitizer;
 
 class SVGFileHandler extends DataHandlerExtension
 {
+
+    public function onMediaCheckProperties(MediaCheckPropertiesEvent $event)
+    {
+        switch ($event->ext) {
+            case "svg":
+                $event->lossless = true;
+                $event->video = false;
+                $event->audio = false;
+
+                $msp = new MiniSVGParser($event->file_name);
+                $event->width = $msp->width;
+                $event->height = $msp->height;
+
+                break;
+        }
+    }
+
+
     public function onDataUpload(DataUploadEvent $event)
     {
         if ($this->supported_ext($event->type) && $this->check_contents($event->tmpname)) {
@@ -81,10 +99,6 @@ class SVGFileHandler extends DataHandlerExtension
     protected function create_image_from_data(string $filename, array $metadata): Image
     {
         $image = new Image();
-
-        $msp = new MiniSVGParser($filename);
-        $image->width = $msp->width;
-        $image->height = $msp->height;
 
         $image->filesize  = $metadata['size'];
         $image->hash      = $metadata['hash'];

--- a/ext/handle_svg/main.php
+++ b/ext/handle_svg/main.php
@@ -35,10 +35,14 @@ class SVGFileHandler extends DataHandlerExtension
 
     protected function create_thumb(string $hash, string $type): bool
     {
-        if (!create_thumbnail_convert($hash)) {
+        try {
+            create_image_thumb($hash, $type, Graphics::IMAGICK_ENGINE);
+            return true;
+        } catch (GraphicsException $e) {
+            log_warning("handle_svg", "Could not generate thumbnail. " . $e->getMessage());
             copy("ext/handle_svg/thumb.jpg", warehouse_path(Image::THUMBNAIL_DIR, $hash));
+            return false;
         }
-        return true;
     }
 
     public function onDisplayingImage(DisplayingImageEvent $event)

--- a/ext/handle_video/main.php
+++ b/ext/handle_video/main.php
@@ -53,7 +53,7 @@ class VideoFileHandler extends DataHandlerExtension
      */
     protected function create_thumb(string $hash, string $type): bool
     {
-        return Graphics::create_thumbnail_ffmpeg($hash);
+        return Media::create_thumbnail_ffmpeg($hash);
     }
 
     protected function supported_ext(string $ext): bool
@@ -65,7 +65,7 @@ class VideoFileHandler extends DataHandlerExtension
     {
         $image = new Image();
 
-        $size = Graphics::video_size($filename);
+        $size = Media::video_size($filename);
         $image->width  = $size[0];
         $image->height = $size[1];
         

--- a/ext/handle_video/theme.php
+++ b/ext/handle_video/theme.php
@@ -13,6 +13,15 @@ class VideoFileHandlerTheme extends Themelet
         $loop = $config->get_bool("video_playback_loop");
         $player = make_link('vendor/bower-asset/mediaelement/build/flashmediaelement.swf');
 
+        $width="auto";
+        if($image->width>1) {
+            $width = $image->width."px";
+        }
+        $height="auto";
+        if($image->height>1) {
+            $height = $image->height."px";
+        }
+
         $html = "Video not playing? <a href='$ilink'>Click here</a> to download the file.<br/>";
 
         //Browser media format support: https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats
@@ -48,7 +57,8 @@ class VideoFileHandlerTheme extends Themelet
                 $loop     = ($loop ? ' loop' : '');
 
                 $html .= "
-					<video controls class='shm-main-image' id='main_image' alt='main image' poster='$thumb_url' {$autoplay} {$loop} style='max-width: 100%'>
+					<video controls class='shm-main-image' id='main_image' alt='main image' poster='$thumb_url' {$autoplay} {$loop} 
+					style='height: $height; width: $width; max-width: 100%'>
 						<source src='{$ilink}' type='{$supportedExts[$ext]}'>
 
 						<!-- If browser doesn't support filetype, fallback to flash -->

--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -41,8 +41,8 @@ class ImageIO extends Extension
 
 
     const THUMBNAIL_ENGINES = [
-        'Built-in GD' => GraphicsEngine::GD,
-        'ImageMagick' => GraphicsEngine::IMAGICK
+        'Built-in GD' => MediaEngine::GD,
+        'ImageMagick' => MediaEngine::IMAGICK
     ];
 
     const THUMBNAIL_TYPES = [

--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -348,7 +348,8 @@ class ImageIO extends Extension
         }
 
         $duplicate = Image::by_hash($image->hash);
-        if(!is_null($duplicate)) {
+
+        if(!is_null($duplicate) && $duplicate->id!=$id) {
             $error = "Image <a href='" . make_link("post/view/{$duplicate->id}") . "'>{$duplicate->id}</a> " .
                 "already has hash {$image->hash}:<p>" . $this->theme->build_thumb_html($duplicate);
             throw new ImageReplaceException($error);

--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -41,8 +41,8 @@ class ImageIO extends Extension
 
 
     const THUMBNAIL_ENGINES = [
-        'Built-in GD' => Graphics::GD_ENGINE,
-        'ImageMagick' => Graphics::IMAGICK_ENGINE
+        'Built-in GD' => GraphicsEngine::GD,
+        'ImageMagick' => GraphicsEngine::IMAGICK
     ];
 
     const THUMBNAIL_TYPES = [

--- a/ext/media/main.php
+++ b/ext/media/main.php
@@ -781,7 +781,9 @@ class Media extends Extension
 
         $args = " -flatten ";
         if ($minimize) {
-            $args = " -strip -thumbnail";
+            $args .= " -strip -thumbnail";
+        } else {
+            $args .= " -resize";
         }
 
         $resize_args = "";
@@ -803,7 +805,7 @@ class Media extends Extension
 
         $output_ext = self::determine_ext($output_type);
 
-        $format = '"%s"  %s -resize %ux%u%s -quality %u -background %s %s"%s[0]"  %s:"%s" 2>&1';
+        $format = '"%s"  %s %ux%u%s -quality %u -background %s %s"%s[0]"  %s:"%s" 2>&1';
         $cmd = sprintf($format, $convert, $args, $new_width, $new_height, $resize_args, $output_quality, $bg, $input_type, $input_path, $output_ext, $output_filename);
         $cmd = str_replace("\"convert\"", "convert", $cmd); // quotes are only needed if the path to convert contains a space; some other times, quotes break things, see github bug #27
         exec($cmd, $output, $ret);

--- a/ext/media/main.php
+++ b/ext/media/main.php
@@ -428,7 +428,7 @@ class Media extends Extension
     {
         $matches = [];
 
-        if (preg_match(self::SEARCH_TERM_REGEX, strtolower($event->term), $matches) && $event->parse) {
+        if (preg_match(self::CONTENT_SEARCH_TERM_REGEX, strtolower($event->term), $matches) && $event->parse) {
             // Nothing to save, just helping filter out reserved tags
         }
 

--- a/ext/media/main.php
+++ b/ext/media/main.php
@@ -280,13 +280,17 @@ class Media extends Extension
 //                $sb->add_label("<b style='color:red'>ImageMagick not detected</b>");
 //            }
 //        } else {
-        $sb->add_text_option(MediaConfig::CONVERT_PATH, "convert command: ");
+        $sb->start_table();
+        $sb->add_table_header("Commands");
+
+        $sb->add_text_option(MediaConfig::CONVERT_PATH, "convert", true);
 //        }
 
-        $sb->add_text_option(MediaConfig::FFMPEG_PATH, "<br/>ffmpeg command: ");
-        $sb->add_text_option(MediaConfig::FFPROBE_PATH, "<br/>ffprobe command: ");
+        $sb->add_text_option(MediaConfig::FFMPEG_PATH, "<br/>ffmpeg", true);
+        $sb->add_text_option(MediaConfig::FFPROBE_PATH, "<br/>ffprobe", true);
 
-        $sb->add_shorthand_int_option(MediaConfig::MEM_LIMIT, "<br />Max memory use: ");
+        $sb->add_shorthand_int_option(MediaConfig::MEM_LIMIT, "<br />Mem limit: ", true);
+        $sb->end_table();
 
         $event->panel->add_block($sb);
 

--- a/ext/media/main.php
+++ b/ext/media/main.php
@@ -416,7 +416,7 @@ class Media extends Extension
         if (preg_match(self::CONTENT_SEARCH_TERM_REGEX, $event->term, $matches)) {
             $positive = $matches[1];
             $field = $matches[2];
-            $event->add_querylet(new Querylet("$field = " . $database->scoreql_to_sql($positive != "-" ? "SCORE_BOOL_Y" : "SCORE_BOOL_N")));
+            $event->add_querylet(new Querylet("$field = " . $database->scoreql_to_sql($positive != "-" ? SCORE::BOOL_Y : SCORE::BOOL_N)));
         }
     }
 

--- a/ext/media/theme.php
+++ b/ext/media/theme.php
@@ -1,0 +1,6 @@
+<?php
+
+class MediaTheme extends Themelet
+{
+
+}

--- a/ext/media/theme.php
+++ b/ext/media/theme.php
@@ -8,13 +8,14 @@ class MediaTheme extends Themelet
 
         $html = "Use this to force scanning for media properties.";
         $html .= make_form(make_link("admin/media_rescan"));
-        $html .= "<select name='media_rescan_type'><option value=''>All</option>";
+        $html .= "<table class='form'>";
+        $html .= "<tr><th>Image Type</th><td><select name='media_rescan_type'><option value=''>All</option>";
         foreach ($types as $type) {
             $html .= "<option value='".$type["ext"]."'>".$type["ext"]." (".$type["count"].")</option>";
         }
-        $html .= "</select><br/>";
-        $html .= "<input type='submit' value='Scan Media Information'>";
-        $html .= "</form>\n";
+        $html .= "</select></td></tr>";
+        $html .= "<tr><td colspan='2'><input type='submit' value='Scan Media Information'></td></tr>";
+        $html .= "</table></form>\n";
         $page->add_block(new Block("Media Tools", $html));
     }
 

--- a/ext/media/theme.php
+++ b/ext/media/theme.php
@@ -2,5 +2,29 @@
 
 class MediaTheme extends Themelet
 {
+    public function display_form(array $types)
+    {
+        global $page, $database;
 
+        $html = "Use this to force scanning for media properties.";
+        $html .= make_form(make_link("admin/media_rescan"));
+        $html .= "<select name='media_rescan_type'><option value=''>All</option>";
+        foreach ($types as $type) {
+            $html .= "<option value='".$type["ext"]."'>".$type["ext"]." (".$type["count"].")</option>";
+        }
+        $html .= "</select><br/>";
+        $html .= "<input type='submit' value='Scan Media Information'>";
+        $html .= "</form>\n";
+        $page->add_block(new Block("Media Tools", $html));
+    }
+
+    public function get_buttons_html(int $image_id): string
+    {
+        return "
+			".make_form(make_link("media_rescan/"))."
+			<input type='hidden' name='image_id' value='$image_id'>
+			<input type='submit' value='Scan Media Properties'>
+			</form>
+		";
+    }
 }

--- a/ext/ouroboros_api/main.php
+++ b/ext/ouroboros_api/main.php
@@ -779,6 +779,7 @@ class OuroborosAPI extends Extension
             } else {
                 $user = User::by_id($config->get_int("anon_id", 0));
             }
+            send_event(new UserLoginEvent($user));
         } elseif (isset($_COOKIE[$config->get_string('cookie_prefix', 'shm') . '_' . 'session']) &&
             isset($_COOKIE[$config->get_string('cookie_prefix', 'shm') . '_' . 'user'])
         ) {
@@ -791,6 +792,7 @@ class OuroborosAPI extends Extension
             } else {
                 $user = User::by_id($config->get_int("anon_id", 0));
             }
+            send_event(new UserLoginEvent($user));
         }
     }
 

--- a/ext/ouroboros_api/main.php
+++ b/ext/ouroboros_api/main.php
@@ -231,8 +231,8 @@ class _SafeOuroborosImage
         $this->has_notes = false;
 
         // thumb
-        $this->preview_height = $config->get_int('thumb_height');
-        $this->preview_width = $config->get_int('thumb_width');
+        $this->preview_height = $config->get_int(ImageConfig::THUMB_HEIGHT);
+        $this->preview_width = $config->get_int(ImageConfig::THUMB_WIDTH);
         $this->preview_url = make_http($img->get_thumb_link());
 
         // sample (use the full image here)
@@ -481,8 +481,8 @@ class OuroborosAPI extends Extension
     protected function postCreate(OuroborosPost $post, string $md5 = '')
     {
         global $config;
-        $handler = $config->get_string("upload_collision_handler");
-        if (!empty($md5) && !($handler == 'merge')) {
+        $handler = $config->get_string(ImageConfig::UPLOAD_COLLISION_HANDLER);
+        if (!empty($md5) && !($handler == ImageConfig::COLLISION_MERGE)) {
             $img = Image::by_hash($md5);
             if (!is_null($img)) {
                 $this->sendResponse(420, self::ERROR_POST_CREATE_DUPE);
@@ -524,8 +524,8 @@ class OuroborosAPI extends Extension
         if (!empty($meta['hash'])) {
             $img = Image::by_hash($meta['hash']);
             if (!is_null($img)) {
-                $handler = $config->get_string("upload_collision_handler");
-                if ($handler == "merge") {
+                $handler = $config->get_string(ImageConfig::UPLOAD_COLLISION_HANDLER);
+                if ($handler == ImageConfig::COLLISION_MERGE) {
                     $postTags = is_array($post->tags) ? $post->tags : Tag::explode($post->tags);
                     $merged = array_merge($postTags, $img->get_tag_array());
                     send_event(new TagSetEvent($img, $merged));

--- a/ext/report_image/theme.php
+++ b/ext/report_image/theme.php
@@ -46,7 +46,7 @@ class ReportImageTheme extends Themelet
 			";
         }
 
-        $thumb_width = $config->get_int("thumb_width");
+        $thumb_width = $config->get_int(ImageConfig::THUMB_WIDTH);
         $html = "
 			<table id='reportedimage' class='zebra'>
 				<thead><td width='$thumb_width'>Image</td><td>Reason</td><td width='128'>Action</td></thead>

--- a/ext/resize/main.php
+++ b/ext/resize/main.php
@@ -49,7 +49,7 @@ class ResizeImage extends Extension
     {
         global $user, $config;
         if ($user->is_admin() && $config->get_bool(ResizeConfig::ENABLED)
-            && $this->can_resize_format($event->image->ext)) {
+            && $this->can_resize_format($event->image->ext, $event->image->lossless)) {
             /* Add a link to resize the image */
             $event->add_part($this->theme->get_resize_html($event->image));
         }
@@ -83,7 +83,7 @@ class ResizeImage extends Extension
         $image_obj = Image::by_id($event->image_id);
 
         if ($config->get_bool(ResizeConfig::UPLOAD) == true
-                && $this->can_resize_format($event->type)) {
+                && $this->can_resize_format($event->type, $image_obj->lossless)) {
             $width = $height = 0;
 
             if ($config->get_int(ResizeConfig::DEFAULT_WIDTH) !== 0) {
@@ -170,7 +170,7 @@ class ResizeImage extends Extension
         }
     }
 
-    private function can_resize_format($format): bool
+    private function can_resize_format($format, ?bool $lossless): bool
     {
         global $config;
         $engine = $config->get_string(ResizeConfig::ENGINE);

--- a/ext/resize/main.php
+++ b/ext/resize/main.php
@@ -40,7 +40,7 @@ class ResizeImage extends Extension
         global $config;
         $config->set_default_bool(ResizeConfig::ENABLED, true);
         $config->set_default_bool(ResizeConfig::UPLOAD, false);
-        $config->set_default_string(ResizeConfig::ENGINE, GraphicsEngine::GD);
+        $config->set_default_string(ResizeConfig::ENGINE, MediaEngine::GD);
         $config->set_default_int(ResizeConfig::DEFAULT_WIDTH, 0);
         $config->set_default_int(ResizeConfig::DEFAULT_HEIGHT, 0);
     }
@@ -174,8 +174,8 @@ class ResizeImage extends Extension
     {
         global $config;
         $engine = $config->get_string(ResizeConfig::ENGINE);
-        return Graphics::is_input_supported($engine, $format)
-                && Graphics::is_output_supported($engine, $format);
+        return Media::is_input_supported($engine, $format)
+                && Media::is_output_supported($engine, $format);
     }
 
 
@@ -205,8 +205,8 @@ class ResizeImage extends Extension
             throw new ImageResizeException("Unable to save temporary image file.");
         }
 
-        send_event(new GraphicResizeEvent(
-            GraphicsEngine::GD,
+        send_event(new MediaResizeEvent(
+            MediaEngine::GD,
             $image_filename,
             $image_obj->ext,
             $tmp_filename,

--- a/ext/resize/main.php
+++ b/ext/resize/main.php
@@ -40,7 +40,7 @@ class ResizeImage extends Extension
         global $config;
         $config->set_default_bool(ResizeConfig::ENABLED, true);
         $config->set_default_bool(ResizeConfig::UPLOAD, false);
-        $config->set_default_string(ResizeConfig::ENGINE, Graphics::GD_ENGINE);
+        $config->set_default_string(ResizeConfig::ENGINE, GraphicsEngine::GD);
         $config->set_default_int(ResizeConfig::DEFAULT_WIDTH, 0);
         $config->set_default_int(ResizeConfig::DEFAULT_HEIGHT, 0);
     }
@@ -206,7 +206,7 @@ class ResizeImage extends Extension
         }
 
         send_event(new GraphicResizeEvent(
-            Graphics::GD_ENGINE,
+            GraphicsEngine::GD,
             $image_filename,
             $image_obj->ext,
             $tmp_filename,

--- a/ext/resize/theme.php
+++ b/ext/resize/theme.php
@@ -9,8 +9,8 @@ class ResizeImageTheme extends Themelet
     {
         global $config;
 
-        $default_width = $config->get_int('resize_default_width');
-        $default_height = $config->get_int('resize_default_height');
+        $default_width = $config->get_int(ResizeConfig::DEFAULT_WIDTH);
+        $default_height = $config->get_int(ResizeConfig::DEFAULT_HEIGHT);
 
         if (!$default_width) {
             $default_width = $image->width;

--- a/ext/rotate/main.php
+++ b/ext/rotate/main.php
@@ -130,7 +130,7 @@ class RotateImage extends Extension
 
         $info = getimagesize($image_filename);
         
-        $memory_use =calc_memory_use($info);
+        $memory_use = Graphics::calc_memory_use($info);
         $memory_limit = get_memory_limit();
         
         if ($memory_use > $memory_limit) {

--- a/ext/rotate/main.php
+++ b/ext/rotate/main.php
@@ -130,7 +130,7 @@ class RotateImage extends Extension
 
         $info = getimagesize($image_filename);
         
-        $memory_use = Graphics::calc_memory_use($info);
+        $memory_use = Media::calc_memory_use($info);
         $memory_limit = get_memory_limit();
         
         if ($memory_use > $memory_limit) {

--- a/ext/rule34/main.php
+++ b/ext/rule34/main.php
@@ -30,7 +30,7 @@ class Rule34 extends Extension
     public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event)
     {
         global $config;
-        $image_link = $config->get_string('image_ilink');
+        $image_link = $config->get_string(ImageConfig::ILINK);
         $url0 = $event->image->parse_link_template($image_link, "url_escape", 0);
         $url1 = $event->image->parse_link_template($image_link, "url_escape", 1);
         $html = "<tr><th>Links</th><td><a href='$url0'>Image Only</a> (<a href='$url1'>Backup Server</a>)</td></tr>";

--- a/ext/setup/test.php
+++ b/ext/setup/test.php
@@ -39,6 +39,6 @@ class SetupTest extends ShimmiePHPUnitTestCase
         $this->log_in_as_admin();
         $this->get_page('setup/advanced');
         $this->assert_title("Shimmie Setup");
-        $this->assert_text("thumb_quality");
+        $this->assert_text(ImageConfig::THUMB_QUALITY);
     }
 }

--- a/ext/transcode/main.php
+++ b/ext/transcode/main.php
@@ -66,7 +66,7 @@ class TranscodeImage extends Extension
         global $config;
         $config->set_default_bool(TranscodeConfig::ENABLED, true);
         $config->set_default_bool(TranscodeConfig::UPLOAD, false);
-        $config->set_default_string(TranscodeConfig::ENGINE, Graphics::GD_ENGINE);
+        $config->set_default_string(TranscodeConfig::ENGINE, GraphicsEngine::GD);
         $config->set_default_int(TranscodeConfig::QUALITY, 80);
 
         foreach (array_values(self::INPUT_FORMATS) as $format) {
@@ -100,7 +100,7 @@ class TranscodeImage extends Extension
         $sb->add_bool_option(TranscodeConfig::UPLOAD, "Transcode on upload: ", true);
         $sb->add_choice_option(TranscodeConfig::ENGINE,  Graphics::IMAGE_GRAPHICS_ENGINES, "Engine", true);
         foreach (self::INPUT_FORMATS as $display=>$format) {
-            if (in_array($format, Graphics::ENGINE_INPUT_SUPPORT[$engine])) {
+            if (in_array($format, GraphicsEngine::INPUT_SUPPORT[$engine])) {
                 $outputs = $this->get_supported_output_formats($engine, $format);
                 $sb->add_choice_option(TranscodeConfig::UPLOAD_PREFIX.$format, $outputs, "$display", true);
             }
@@ -289,7 +289,7 @@ class TranscodeImage extends Extension
         if (!$this->can_convert_format($engine, $source_format)) {
             throw new ImageTranscodeException("Engine $engine does not support input format $source_format");
         }
-        if (!in_array($target_format, Graphics::ENGINE_OUTPUT_SUPPORT[$engine])) {
+        if (!in_array($target_format, GraphicsEngine::OUTPUT_SUPPORT[$engine])) {
             throw new ImageTranscodeException("Engine $engine does not support output format $target_format");
         }
 

--- a/ext/transcode/main.php
+++ b/ext/transcode/main.php
@@ -98,7 +98,7 @@ class TranscodeImage extends Extension
         $sb->start_table();
         $sb->add_bool_option(TranscodeConfig::ENABLED, "Allow transcoding images: ", true);
         $sb->add_bool_option(TranscodeConfig::UPLOAD, "Transcode on upload: ", true);
-        $sb->add_choice_option(TranscodeConfig::ENGINE,  Media::IMAGE__MEDIA_ENGINES, "Engine", true);
+        $sb->add_choice_option(TranscodeConfig::ENGINE,  Media::IMAGE_MEDIA_ENGINES, "Engine", true);
         foreach (self::INPUT_FORMATS as $display=>$format) {
             if (in_array($format, MediaEngine::INPUT_SUPPORT[$engine])) {
                 $outputs = $this->get_supported_output_formats($engine, $format);

--- a/ext/transcode/script.js
+++ b/ext/transcode/script.js
@@ -1,0 +1,11 @@
+function transcodeSubmit(e) {
+    var format = document.getElementById('transcode_format').value;
+    if(format!="webp-lossless" && format != "png") {
+        var lossless = document.getElementById('image_lossless');
+        if(lossless!=null && lossless.value=='1') {
+            return confirm('You are about to transcode from a lossless format to a lossy format. Lossless formats compress with no quality loss, but converting to a lossy format always results in quality loss, and it will lose more quality every time it is done again on the same image. Are you sure you want to perform this transcode?');
+        } else {
+            return confirm('Converting to a lossy format always results in quality loss, and it will lose more quality every time it is done again on the same image. Are you sure you want to perform this transcode?');
+        }
+    }
+}

--- a/ext/transcode/theme.php
+++ b/ext/transcode/theme.php
@@ -10,8 +10,10 @@ class TranscodeImageTheme extends Themelet
         global $config;
 
         $html = "
-			".make_form(make_link("transcode/{$image->id}"), 'POST')."
+			".make_form(make_link("transcode/{$image->id}"), 'POST', false, "",
+                "return transcodeSubmit()")."
                 <input type='hidden' name='image_id' value='{$image->id}'>
+                <input type='hidden' id='image_lossless' name='image_lossless' value='{$image->lossless}'>
                 ".$this->get_transcode_picker_html($options)."
 				<br><input id='transcodebutton' type='submit' value='Transcode'>
 			</form>

--- a/ext/upgrade/main.php
+++ b/ext/upgrade/main.php
@@ -13,7 +13,6 @@ class Upgrade extends Extension
     {
         global $config, $database;
 
-
         if ($config->get_bool("in_upgrade")) {
             return;
         }
@@ -164,8 +163,6 @@ class Upgrade extends Extension
             }
             // SQLite doesn't support altering existing columns? This seems like a problem?
 
-
-
             log_info("upgrade", "Database at version 16");
             $config->set_bool("in_upgrade", false);
         }
@@ -223,8 +220,6 @@ class Upgrade extends Extension
             log_info("upgrade", "Database at version 17");
             $config->set_bool("in_upgrade", false);
         }
-
-
 
     }
 

--- a/ext/upgrade/main.php
+++ b/ext/upgrade/main.php
@@ -13,6 +13,7 @@ class Upgrade extends Extension
     {
         global $config, $database;
 
+
         if ($config->get_bool("in_upgrade")) {
             return;
         }
@@ -163,6 +164,8 @@ class Upgrade extends Extension
             }
             // SQLite doesn't support altering existing columns? This seems like a problem?
 
+
+
             log_info("upgrade", "Database at version 16");
             $config->set_bool("in_upgrade", false);
         }
@@ -208,13 +211,13 @@ class Upgrade extends Extension
 
             $database->commit(); // Each of these commands could hit a lot of data, combining them into one big transaction would not be a good idea.
             log_info("upgrade", "Setting predictable media values for known file types");
-            $database->execute("UPDATE images SET lossless = true, video = true WHERE ext IN ('swf')");
-            $database->execute("UPDATE images SET lossless = false, video = false, audio = true WHERE ext IN ('mp3')");
-            $database->execute("UPDATE images SET lossless = false, video = false, audio = false WHERE ext IN ('jpg','jpeg')");
-            $database->execute("UPDATE images SET lossless = true, video = false, audio = false WHERE ext IN ('ico','ani','cur','png','svg')");
-            $database->execute("UPDATE images SET lossless = true, audio = false WHERE ext IN ('gif')");
-            $database->execute("UPDATE images SET audio = false WHERE ext IN ('webp')");
-            $database->execute("UPDATE images SET lossless = false, video = true WHERE ext IN ('flv','mp4','m4v','ogv','webm')");
+            $database->execute($database->scoreql_to_sql("UPDATE images SET lossless = SCORE_BOOL_Y, video = SCORE_BOOL_Y WHERE ext IN ('swf')"));
+            $database->execute($database->scoreql_to_sql("UPDATE images SET lossless = SCORE_BOOL_N, video = SCORE_BOOL_N, audio = SCORE_BOOL_Y WHERE ext IN ('mp3')"));
+            $database->execute($database->scoreql_to_sql("UPDATE images SET lossless = SCORE_BOOL_N, video = SCORE_BOOL_N, audio = SCORE_BOOL_N WHERE ext IN ('jpg','jpeg')"));
+            $database->execute($database->scoreql_to_sql("UPDATE images SET lossless = SCORE_BOOL_Y, video = SCORE_BOOL_N, audio = SCORE_BOOL_N WHERE ext IN ('ico','ani','cur','png','svg')"));
+            $database->execute($database->scoreql_to_sql("UPDATE images SET lossless = SCORE_BOOL_Y, audio = SCORE_BOOL_N WHERE ext IN ('gif')"));
+            $database->execute($database->scoreql_to_sql("UPDATE images SET audio = SCORE_BOOL_N WHERE ext IN ('webp')"));
+            $database->execute($database->scoreql_to_sql("UPDATE images SET lossless = SCORE_BOOL_N, video = SCORE_BOOL_Y WHERE ext IN ('flv','mp4','m4v','ogv','webm')"));
 
 
             log_info("upgrade", "Database at version 17");

--- a/ext/user/theme.php
+++ b/ext/user/theme.php
@@ -243,14 +243,9 @@ class UserPageTheme extends Themelet
         $page->add_block(new NavBlock());
         $page->add_block(new Block("Stats", join("<br>", $stats), "main", 10));
 
-        if (!$user->is_anonymous()) {
-            if ($user->id == $duser->id || $user->can("edit_user_info")) {
-                $page->add_block(new Block("Options", $this->build_options($duser), "main", 60));
-            }
-        }
     }
 
-    protected function build_options(User $duser)
+    public function build_options(User $duser, UserOptionsBuildingEvent $event)
     {
         global $config, $user;
         $html = "";
@@ -266,7 +261,7 @@ class UserPageTheme extends Themelet
 						<tfoot><tr><td colspan='2'><input type='Submit' value='Set'></td></tr></tfoot>
 					</table>
 				</form>
-				";
+				</p>";
             }
 
             $html .= "
@@ -285,7 +280,7 @@ class UserPageTheme extends Themelet
 					</tfoot>
 				</table>
 			</form>
-
+            </p>
 			<p>".make_form(make_link("user_admin/change_email"))."
 				<input type='hidden' name='id' value='{$duser->id}'>
 				<table class='form'>
@@ -294,7 +289,7 @@ class UserPageTheme extends Themelet
 					<tfoot><tr><td colspan='2'><input type='Submit' value='Set'></td></tr></tfoot>
 				</table>
 			</form>
-			";
+			</p>";
 
             $i_user_id = int_escape($duser->id);
 
@@ -316,7 +311,7 @@ class UserPageTheme extends Themelet
 							<tfoot><tr><td><input type='submit' value='Set'></td></tr></tfoot>
 						</table>
 					</form>
-				";
+				</p>";
             }
 
             if ($user->can("delete_user")) {
@@ -337,8 +332,12 @@ class UserPageTheme extends Themelet
 							</tfoot>
 						</table>
 					</form>
-				";
+				</p>";
             }
+            foreach ($event->parts as $part) {
+                $html .= $part;
+            }
+
         }
         return $html;
     }

--- a/ext/user_config/main.php
+++ b/ext/user_config/main.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * Name: User-specific settings
+ * Author: Matthew Barbour <matthew@darkholme.net>
+ * Description: Provides system-wide support for user-specific settings
+ * Visibility: admin
+ */
+
+/** @var $user_config Config */
+global $user_config;
+
+
+// The user object doesn't exist until after database setup operations and the first wave of InitExtEvents,
+// so we can't reliably access this data until then. This event is triggered by the system after all of that is done.
+class InitUserConfigEvent extends Event
+{
+    public $user;
+    public $user_config;
+
+    public function __construct(User $user, Config $user_config)
+    {
+        $this->user = $user;
+        $this->user_config = $user_config;
+    }
+}
+
+class UserConfig extends Extension
+{
+    private const VERSION = "ext_user_config_version";
+
+    public function onInitExt(InitExtEvent $event)
+    {
+        global $config;
+
+        if ($config->get_int(self::VERSION,0)<1) {
+            $this->install();
+        }
+    }
+
+    public function onUserLogin(UserLoginEvent $event)
+    {
+        global $database, $user_config;
+
+        $user_config = new DatabaseConfig($database, "user_config", "user_id", $event->user->id);
+        send_event(new InitUserConfigEvent($event->user, $user_config));
+    }
+
+    private function install(): void
+    {
+        global $config, $database;
+
+        if ($config->get_int(self::VERSION,0) < 1) {
+
+            log_info("upgrade", "Adding user config table");
+
+            $database->create_table("user_config", "
+                user_id INTEGER NOT NULL,
+                name VARCHAR(128) NOT NULL,
+                value TEXT,
+                PRIMARY KEY (user_id, name),
+			    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+		    ");
+            $database->execute("CREATE INDEX user_config_user_id_idx ON user_config(user_id)");
+
+            $config->set_int(self::VERSION, 1);
+        }
+    }
+
+
+    // This needs to happen before any other events, but after db upgrade
+    public function get_priority(): int
+    {
+        return 6;
+    }
+}

--- a/index.php
+++ b/index.php
@@ -89,8 +89,10 @@ $_tracer->begin($_SERVER["REQUEST_URI"] ?? "No Request");
 
 try {
 
+
     // start the page generation waterfall
     $user = _get_user();
+    send_event(new UserLoginEvent($user));
     if (PHP_SAPI === 'cli' || PHP_SAPI == 'phpdbg') {
         send_event(new CommandEvent($argv));
     } else {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -133,6 +133,7 @@ abstract class ShimmiePHPUnitTestCase extends \PHPUnit\Framework\TestCase
         global $user;
         $user = User::by_name('demo');
         $this->assertNotNull($user);
+        send_event(new UserLoginEvent($user));
     }
 
     protected function log_in_as_user()
@@ -140,6 +141,7 @@ abstract class ShimmiePHPUnitTestCase extends \PHPUnit\Framework\TestCase
         global $user;
         $user = User::by_name('test');
         $this->assertNotNull($user);
+        send_event(new UserLoginEvent($user));
     }
 
     protected function log_out()
@@ -147,6 +149,7 @@ abstract class ShimmiePHPUnitTestCase extends \PHPUnit\Framework\TestCase
         global $user, $config;
         $user = User::by_id($config->get_int("anon_id", 0));
         $this->assertNotNull($user);
+        send_event(new UserLoginEvent($user));
     }
 
     // post things

--- a/themes/danbooru/view.theme.php
+++ b/themes/danbooru/view.theme.php
@@ -18,6 +18,7 @@ class CustomViewImageTheme extends ViewImageTheme
         $h_owner = html_escape($image->get_owner()->name);
         $h_ownerlink = "<a href='".make_link("user/$h_owner")."'>$h_owner</a>";
         $h_ip = html_escape($image->owner_ip);
+        $h_type = html_escape($image->get_mime_type());
         $h_date = autodate($image->posted);
         $h_filesize = to_shorthand_int($image->filesize);
 
@@ -31,7 +32,12 @@ class CustomViewImageTheme extends ViewImageTheme
 		<br>Posted: $h_date by $h_ownerlink
 		<br>Size: {$image->width}x{$image->height}
 		<br>Filesize: $h_filesize
-		";
+		<br>Type: $h_type";
+
+        if($image->length!=null) {
+            $h_length = format_milliseconds($image->length);
+            $html .= "<br/>Length: $h_length";
+        }
 
         if (!is_null($image->source)) {
             $h_source = html_escape($image->source);

--- a/themes/danbooru2/view.theme.php
+++ b/themes/danbooru2/view.theme.php
@@ -17,6 +17,7 @@ class CustomViewImageTheme extends ViewImageTheme
         $h_owner = html_escape($image->get_owner()->name);
         $h_ownerlink = "<a href='".make_link("user/$h_owner")."'>$h_owner</a>";
         $h_ip = html_escape($image->owner_ip);
+        $h_type = html_escape($image->get_mime_type());
         $h_date = autodate($image->posted);
         $h_filesize = to_shorthand_int($image->filesize);
 
@@ -30,7 +31,14 @@ class CustomViewImageTheme extends ViewImageTheme
 		<br>Uploader: $h_ownerlink
 		<br>Date: $h_date
 		<br>Size: $h_filesize ({$image->width}x{$image->height})
+		<br>Type: $h_type
 		";
+
+        if($image->length!=null) {
+            $h_length = format_milliseconds($image->length);
+            $html .= "<br/>Length: $h_length";
+        }
+
 
         if (!is_null($image->source)) {
             $h_source = html_escape($image->source);

--- a/themes/lite/view.theme.php
+++ b/themes/lite/view.theme.php
@@ -34,6 +34,11 @@ class CustomViewImageTheme extends ViewImageTheme
 		<br>Filesize: $h_filesize
 		<br>Type: ".$h_type."
 		";
+        if($image->length!=null) {
+            $h_length = format_milliseconds($image->length);
+            $html .= "<br/>Length: $h_length";
+        }
+
 
         if (!is_null($image->source)) {
             $h_source = html_escape($image->source);

--- a/themes/lite/view.theme.php
+++ b/themes/lite/view.theme.php
@@ -18,6 +18,7 @@ class CustomViewImageTheme extends ViewImageTheme
         $h_owner = html_escape($image->get_owner()->name);
         $h_ownerlink = "<a href='".make_link("user/$h_owner")."'>$h_owner</a>";
         $h_ip = html_escape($image->owner_ip);
+        $h_type = html_escape($image->get_mime_type());
         $h_date = autodate($image->posted);
         $h_filesize = to_shorthand_int($image->filesize);
 
@@ -31,6 +32,7 @@ class CustomViewImageTheme extends ViewImageTheme
 		<br>Posted: $h_date by $h_ownerlink
 		<br>Size: {$image->width}x{$image->height}
 		<br>Filesize: $h_filesize
+		<br>Type: ".$h_type."
 		";
 
         if (!is_null($image->source)) {


### PR DESCRIPTION
With a lot of the changes I've made to allow thumbnailing for more formats and centralizing more imagemagick, GD, and ffmpeg functionality it didn't seem right that some settings required for them to work were from extensions that the user may or may not have enabled. So, I set up this extension and migrated the common ffmpeg and convert path settings into it. I set it as a default extension, so it's always enabled. All of the other extensions now look to this extension's settings for those values, and it will auto-migrate them from the old locations. 

I've also migrated the shared media functions (like image resizing and ffmpeg calls) into the extension as static functions and triggerable events. The ones that are still static functions will likely become events later, I want to see how some other work I'm doing turns out to see what the best implementation would be. I've also moved the engine/format support constant arrays to here from the transcode extension, since it makes since for them to be in a central location, and allows other extensions to have a supported file reference that can change dynamically based on the selected media engine. 