### PR TITLE
Fix SQLite underscore searching

### DIFF
--- a/core/imageboard/image.php
+++ b/core/imageboard/image.php
@@ -944,12 +944,16 @@ class Image
         $negative_tag_id_array = [];
 
         foreach ($tag_conditions as $tq) {
+            $sq = "
+                SELECT id
+                FROM tags
+                WHERE SCORE_STRNORM(tag) LIKE SCORE_STRNORM(:tag)
+            ";
+            if ($database->get_driver_name() === DatabaseDriver::SQLITE) {
+                $sq .= "ESCAPE '\\'";
+            }
             $tag_ids = $database->get_col(
-                $database->scoreql_to_sql("
-					SELECT id
-					FROM tags
-					WHERE SCORE_STRNORM(tag) LIKE SCORE_STRNORM(:tag)
-				"),
+                $database->scoreql_to_sql($sq),
                 ["tag" => Tag::sqlify($tq->tag)]
             );
 

--- a/core/imageboard/tag.php
+++ b/core/imageboard/tag.php
@@ -103,6 +103,10 @@ class Tag
 
     public static function sqlify(string $term): string
     {
+        global $database;
+        if ($database->get_driver_name() === DatabaseDriver::SQLITE) {
+            $term = str_replace('\\', '\\\\', $term);
+        }
         $term = str_replace('_', '\_', $term);
         $term = str_replace('%', '\%', $term);
         $term = str_replace('*', '%', $term);


### PR DESCRIPTION
In SQLite, tags that contain underscores (e.g. `character:Some_Person`) can't be searched. The issue is that SQLite specifically decides to not use `\` escaping that `Tag::sqlify` applies ([this page](https://www.sqlite.org/lang_expr.html) says _"C-style escapes using the backslash character are not supported because they are not standard SQL."_).

This PR adds the appropriate `ESCAPE` clause and also makes `Tag::sqlify` escape backslashes properly, have only tested with SQLite so not sure whether the `sqlify` part of these changes would also be appropriate for MySQL/etc… have been testing this out by changing tag names in the db directly so if shimmie specifically disallows `\` from tag names then feel free to let me know and I'll rip that part out \o/