### PR TITLE
Only show 'Tags' block when there's a tag to put in it

### DIFF
--- a/ext/tag_list/theme.php
+++ b/ext/tag_list/theme.php
@@ -118,7 +118,9 @@ class TagListTheme extends Themelet
         }
 
         if ($config->get_string('tag_list_image_type')=="tags") {
-            $page->add_block(new Block("Tags", $main_html, "left", 10));
+            if ($main_html != null) {
+                $page->add_block(new Block("Tags", $main_html, "left", 10));
+            }
         } else {
             $page->add_block(new Block("Related Tags", $main_html, "left", 10));
         }


### PR DESCRIPTION
When you're using the `tag_categories` extension, you can get a case where the only tags that are shown are all in the category blocks and the main **Tags** block is empty, which looks weird. Seems like it's better to leave it out if that's the case, so that's what this change does \o/