### PR TITLE
Minor danbooru2 theme fixes

### DIFF
--- a/themes/danbooru2/index.theme.php
+++ b/themes/danbooru2/index.theme.php
@@ -7,31 +7,15 @@ class CustomIndexTheme extends IndexTheme
      */
     public function display_page(Page $page, array $images)
     {
-        global $config;
-
-        if (count($this->search_terms) == 0) {
-            $query = null;
-            $page_title = $config->get_string(SetupConfig::TITLE);
-        } else {
-            $search_string = implode(' ', $this->search_terms);
-            $query = url_escape($search_string);
-            $page_title = html_escape($search_string);
-        }
+        $this->display_page_header($page, $images);
 
         $nav = $this->build_navigation($this->page_number, $this->total_pages, $this->search_terms);
-        $page->set_title($page_title);
-        $page->set_heading($page_title);
         $page->add_block(new Block("Search", $nav, "left", 0));
+
         if (count($images) > 0) {
-            if ($query) {
-                $page->add_block(new Block("Images", $this->build_table($images, "search=$query"), "main", 10));
-                $this->display_paginator($page, "post/list/$query", null, $this->page_number, $this->total_pages);
-            } else {
-                $page->add_block(new Block("Images", $this->build_table($images, null), "main", 10));
-                $this->display_paginator($page, "post/list", null, $this->page_number, $this->total_pages);
-            }
+            $this->display_page_images($page, $images);
         } else {
-            $page->add_block(new Block("No Images Found", "No images were found to match the search criteria"));
+            $this->display_error(404, "No Images Found", "No images were found to match the search criteria");
         }
     }
 

--- a/themes/danbooru2/layout.class.php
+++ b/themes/danbooru2/layout.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
 * Name: Danbooru 2 Theme
-* Author: Bzchan <bzchan@animemahou.com>, updated by Daniel Oaks <danneh@danneh.net>
+* Author: Bzchan <bzchan@animemahou.com>, updated by Daniel Oaks <daniel@danieloaks.net>
 * Link: https://code.shishnet.org/shimmie2/
 * License: GPLv2
 * Description: This is a simple theme changing the css to make shimme

--- a/themes/danbooru2/style.css
+++ b/themes/danbooru2/style.css
@@ -16,22 +16,21 @@ margin:0;
 padding:0 1rem 0 2rem;
 }
 HEADER ul#navbar li {
+margin:0;
+}
+HEADER ul#navbar li a {
 display:inline-block;
 margin:0 0.15rem;
 padding:0.4rem 0.6rem;
 }
-HEADER ul#navbar li:first-child {
-margin-left: -0.6rem;
-}
 HEADER ul#navbar li:first-child a {
+margin-left: -0.6rem;
 color: #FF3333;
 font-weight: bold;
 }
-HEADER ul#navbar li.current-page {
+HEADER ul#navbar li a.current-page {
 background-color:#EEEEFF;
 border-radius:0.2rem 0.2rem 0 0;
-}
-HEADER ul#navbar li.current-page a {
 font-weight:bold;
 }
 HEADER ul#subnavbar {


### PR DESCRIPTION
Just updates some stuff with the danbooru2 theme, basically:

Before, when you searched for a term, the result image links were a bit mangled. e.g. if I searched for the term 'wings', the result link would be `http://192.168.0.252:8123/index.php?q=/post/view/81search=wings`, dodgy because the image ID `81search=etc` doesn't exist (the stock theme returns `/post/view/81#search=wings` as expected). I've just made this theme do what the default theme does here and it works a lot better without any regressions or other breakages from what I can see.

Header didn't properly make the top parent link 'tab' blue, now it does so and makes the theme feel a bit nicer to use. What the header now looks like with this change applied:
<img width="547" alt="Screen Shot 2019-09-16 at 11 12 36 am" src="https://user-images.githubusercontent.com/251281/64930304-051aec80-d873-11e9-9740-d95d1d497ac9.png">
<img width="550" alt="Screen Shot 2019-09-16 at 11 12 42 am" src="https://user-images.githubusercontent.com/251281/64930306-05b38300-d873-11e9-8835-fec7abfd2012.png">
