### PR TITLE
fixing "12 hours ago" error when using SQLite

### DIFF
--- a/core/dbengine.php
+++ b/core/dbengine.php
@@ -125,7 +125,7 @@ function _unix_timestamp($date)
 }
 function _now()
 {
-    return date("Y-m-d h:i:s");
+    return date("Y-m-d H:i:s");
 }
 function _floor($a)
 {


### PR DESCRIPTION
Shimmie sends date data as 12-hours format to SQLite. I assume that's why "about 12 hours ago" error occurs when you upload images or submit a comment between 12:00:01 to 23:59:59.