### PR TITLE
Fix danbooru themes with new strict types

### DIFF
--- a/themes/danbooru/themelet.class.php
+++ b/themes/danbooru/themelet.class.php
@@ -45,7 +45,7 @@ class Themelet extends BaseThemelet
 
         $pages = [];
         foreach (range($start, $end) as $i) {
-            $pages[] = $this->gen_page_link_block($base_url, $query, $i, $current_page, $i);
+            $pages[] = $this->gen_page_link_block($base_url, $query, $i, $current_page, (string)$i);
         }
         $pages_html = implode(" ", $pages);
 

--- a/themes/danbooru2/themelet.class.php
+++ b/themes/danbooru2/themelet.class.php
@@ -45,7 +45,7 @@ class Themelet extends BaseThemelet
 
         $pages = [];
         foreach (range($start, $end) as $i) {
-            $pages[] = $this->gen_page_link_block($base_url, $query, $i, $current_page, $i);
+            $pages[] = $this->gen_page_link_block($base_url, $query, $i, $current_page, (string)$i);
         }
         $pages_html = implode(" ", $pages);
 


### PR DESCRIPTION
The strict type changes broke the danbooru and danbooru2 themes, this PR just adds the same small change that exists in the base theme so these are fixed too. I'm not super familiar with the way themes work these days so if there's a better way to do this just let me know, thanks!