### PR TITLE
Fix Dockerfile script not being marked as executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN echo '=== Installing ===' && mkdir -p data/config && echo "<?php \$dsn = \"s
     echo '=== Unit Tests ===' && ./vendor/bin/phpunit --configuration tests/phpunit.xml && \
     echo '=== Coverage ===' && ./vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-text && \
     echo '=== Cleaning ===' && rm -rf data
+RUN chmod +x /app/tests/docker-init.sh
 CMD "/app/tests/docker-init.sh"


### PR DESCRIPTION
The default Dockerfile doesn't build for me, it always dies on calling that init script. This just explicitly marks the init script as executable before calling it which resolves the build issue on my end.