### PR TITLE
More tag category integration

### DIFF
--- a/ext/tag_categories/main.php
+++ b/ext/tag_categories/main.php
@@ -127,12 +127,12 @@ class TagCategories extends Extension
         return $tc_keyed_dict;
     }
 
-    public function getTagHtml(string $tag, $tag_category_dict, string $extra_text = '')
+    public function getTagHtml(string $h_tag, $tag_category_dict, string $extra_text = '')
     {
-        $h_tag_no_underscores = str_replace("_", " ", $tag);
+        $h_tag_no_underscores = str_replace("_", " ", $h_tag);
 
         // we found a tag, see if it's valid!
-        $h_tag_split = explode(':', $tag, 2);
+        $h_tag_split = explode(':', $h_tag, 2);
         if ((count($h_tag_split) > 1) and array_key_exists($h_tag_split[0], $tag_category_dict)) {
             $category = $h_tag_split[0];
             $h_tag = $h_tag_split[1];

--- a/ext/tag_categories/main.php
+++ b/ext/tag_categories/main.php
@@ -127,6 +127,27 @@ class TagCategories extends Extension
         return $tc_keyed_dict;
     }
 
+    public function getTagHtml(string $tag, $tag_category_dict, string $extra_text = '')
+    {
+        $h_tag_no_underscores = str_replace("_", " ", $tag);
+
+        // we found a tag, see if it's valid!
+        $h_tag_split = explode(':', $tag, 2);
+        if ((count($h_tag_split) > 1) and array_key_exists($h_tag_split[0], $tag_category_dict)) {
+            $category = $h_tag_split[0];
+            $h_tag = $h_tag_split[1];
+            $tag_category_css = ' tag_category_'.$category;
+            $tag_category_style = 'style="color:'.html_escape($tag_category_dict[$category]['color']).';" ';
+            $h_tag_no_underscores = str_replace("_", " ", $h_tag);
+
+            $h_tag_no_underscores = '<span class="'.$tag_category_css.'" '.$tag_category_style.'>'.$h_tag_no_underscores.$extra_text.'</span>';
+        } else {
+            $h_tag_no_underscores .= $extra_text;
+        }
+
+        return $h_tag_no_underscores;
+    }
+
     public function page_update()
     {
         global $user, $database;

--- a/ext/tag_list/main.php
+++ b/ext/tag_list/main.php
@@ -288,6 +288,10 @@ class TagList extends Extension
         if ($config->get_bool(TagListConfig::PAGES)) {
             $html .= $this->build_az();
         }
+        if (class_exists('TagCategories')) {
+            $this->tagcategories = new TagCategories;
+            $tag_category_dict = $this->tagcategories->getKeyedDict();
+        }
         foreach ($tag_data as $row) {
             $h_tag = html_escape($row['tag']);
             $size = sprintf("%.2f", (float)$row['scaled']);
@@ -296,6 +300,9 @@ class TagList extends Extension
                 $size = 0.5;
             }
             $h_tag_no_underscores = str_replace("_", " ", $h_tag);
+            if (class_exists('TagCategories')) {
+                $h_tag_no_underscores = $this->tagcategories->getTagHtml(html_escape($h_tag), $tag_category_dict);
+            }
             $html .= "&nbsp;<a style='font-size: ${size}em' href='$link'>$h_tag_no_underscores</a>&nbsp;\n";
         }
 
@@ -347,6 +354,11 @@ class TagList extends Extension
         */
         mb_internal_encoding('UTF-8');
 
+        if (class_exists('TagCategories')) {
+            $this->tagcategories = new TagCategories;
+            $tag_category_dict = $this->tagcategories->getKeyedDict();
+        }
+
         $lastLetter = "";
         # postres utf8 string sort ignores punctuation, so we get "aza, a-zb, azc"
         # which breaks down into "az, a-, az" :(
@@ -361,7 +373,10 @@ class TagList extends Extension
             }
             $link = $this->theme->tag_link($tag);
             $h_tag = html_escape($tag);
-            $html .= "<a href='$link'>$h_tag&nbsp;($count)</a>\n";
+            if (class_exists('TagCategories')) {
+                $h_tag = $this->tagcategories->getTagHtml($h_tag, $tag_category_dict, "&nbsp;($count)");
+            }
+            $html .= "<a href='$link'>$h_tag</a>\n";
         }
 
         if (SPEED_HAX) {

--- a/ext/tag_list/main.php
+++ b/ext/tag_list/main.php
@@ -301,7 +301,7 @@ class TagList extends Extension
             }
             $h_tag_no_underscores = str_replace("_", " ", $h_tag);
             if (class_exists('TagCategories')) {
-                $h_tag_no_underscores = $this->tagcategories->getTagHtml(html_escape($h_tag), $tag_category_dict);
+                $h_tag_no_underscores = $this->tagcategories->getTagHtml($h_tag, $tag_category_dict);
             }
             $html .= "&nbsp;<a style='font-size: ${size}em' href='$link'>$h_tag_no_underscores</a>&nbsp;\n";
         }


### PR DESCRIPTION
When tag categories are enabled, the tag map and alphabetic list are now both coloured as expected, e.g.:
<img width="549" alt="Screen Shot 2020-03-23 at 3 07 41 pm" src="https://user-images.githubusercontent.com/251281/77283438-152af180-6d18-11ea-8b3a-2e9b95da0824.png">

<img width="333" alt="Screen Shot 2020-03-23 at 3 06 06 pm" src="https://user-images.githubusercontent.com/251281/77283358-e01e9f00-6d17-11ea-8b3a-e60b23666406.png">