### PR TITLE
Extend Wiki integration a bit

### DIFF
--- a/ext/wiki/main.php
+++ b/ext/wiki/main.php
@@ -96,10 +96,30 @@ class WikiPage
     }
 }
 
+abstract class WikiConfig
+{
+    const TAG_SHORTWIKIS = "shortwikis_on_tags";
+}
+
 class Wiki extends Extension
 {
     /** @var WikiTheme */
     protected $theme;
+
+    public function onInitExt(InitExtEvent $event)
+    {
+        global $config;
+        $config->set_default_bool(WikiConfig::TAG_SHORTWIKIS, false);
+    }
+
+    // Add a block to the Board Config / Setup
+    public function onSetupBuilding(SetupBuildingEvent $event)
+    {
+        $sb = new SetupBlock("Wiki");
+        $sb->add_bool_option(WikiConfig::TAG_SHORTWIKIS, "Show shortwiki entry when searching for a single tag: ");
+
+        $event->panel->add_block($sb);
+    }
 
     public function onDatabaseUpgrade(DatabaseUpgradeEvent $event)
     {

--- a/ext/wiki/theme.php
+++ b/ext/wiki/theme.php
@@ -25,11 +25,19 @@ class WikiTheme extends Themelet
             $tfe->formatted .= "<p>(<a href='".make_link("wiki/wiki:sidebar", "edit=on")."'>Edit</a>)";
         }
 
+        // see if title is a category'd tag
+        $title_html = html_escape($wiki_page->title);
+        if (class_exists('TagCategories')) {
+            $this->tagcategories = new TagCategories;
+            $tag_category_dict = $this->tagcategories->getKeyedDict();
+            $title_html = $this->tagcategories->getTagHtml($title_html, $tag_category_dict);
+        }
+
         $page->set_title(html_escape($wiki_page->title));
         $page->set_heading(html_escape($wiki_page->title));
         $page->add_block(new NavBlock());
         $page->add_block(new Block("Wiki Index", $tfe->formatted, "left", 20));
-        $page->add_block(new Block(html_escape($wiki_page->title), $this->create_display_html($wiki_page)));
+        $page->add_block(new Block($title_html, $this->create_display_html($wiki_page)));
     }
 
     public function display_page_editor(Page $page, WikiPage $wiki_page)

--- a/themes/danbooru/index.theme.php
+++ b/themes/danbooru/index.theme.php
@@ -7,6 +7,8 @@ class CustomIndexTheme extends IndexTheme
      */
     public function display_page(Page $page, array $images)
     {
+        $this->display_shortwiki($page);
+
         global $config;
 
         if (count($this->search_terms) == 0) {

--- a/themes/danbooru/style.css
+++ b/themes/danbooru/style.css
@@ -87,6 +87,12 @@ margin:auto;
 text-align:center;
 width:256px;
 }
+#short-wiki-description {
+padding:0 1.5em;
+}
+#short-wiki-description h2 {
+padding-bottom:0.2em;
+}
 FOOTER {
 clear:both;
 color:#CCCCCC;

--- a/themes/danbooru2/index.theme.php
+++ b/themes/danbooru2/index.theme.php
@@ -7,6 +7,8 @@ class CustomIndexTheme extends IndexTheme
      */
     public function display_page(Page $page, array $images)
     {
+        $this->display_shortwiki($page);
+
         $this->display_page_header($page, $images);
 
         $nav = $this->build_navigation($this->page_number, $this->total_pages, $this->search_terms);

--- a/themes/danbooru2/style.css
+++ b/themes/danbooru2/style.css
@@ -99,6 +99,13 @@ border-top:medium none;
 text-align:center;
 font-size:0.75em;
 }
+#short-wiki-description {
+padding:0 2em;
+font-size:1.2em;
+}
+#short-wiki-description h2 {
+padding-bottom:0.2em;
+}
 FOOTER {
 clear:both;
 border-top:solid 1px #E7E7F7;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -148,6 +148,13 @@ ARTICLE TABLE {
 *                     specific page types                        *
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#short-wiki-description > .blockbody {
+	padding-bottom: 15px;
+}
+#short-wiki-description h2 {
+	margin: 0 0 0.4em;
+}
+
 #pagelist {
 	margin-top: 32px;
 }

--- a/themes/futaba/style.css
+++ b/themes/futaba/style.css
@@ -84,6 +84,14 @@ TABLE.tag_list>TBODY>TR>TD:after {
 *                     specific page types                        *
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#short-wiki-description > .blockbody {
+	padding-bottom: 15px;
+	font-size: 1.1em;
+}
+#short-wiki-description h2 {
+	margin: 0 0 0.4em;
+}
+
 .doubledash {
 	color: #D9BFB7;
 	vertical-align: top;

--- a/themes/warm/style.css
+++ b/themes/warm/style.css
@@ -170,6 +170,13 @@ ARTICLE TABLE {
 *                     specific page types                        *
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#short-wiki-description > .blockbody {
+	padding-bottom: 15px;
+}
+#short-wiki-description h2 {
+	margin: 0 0 0.4em;
+}
+
 #pagelist {
 	margin-top: 32px;
 }


### PR DESCRIPTION
This colours wiki titles using tag categories, and also adds 'shortwiki' entries when viewing a single tag.

On some image board software, when you're only searching for a single tag it'll show you a short blurb about that tag. How this works in Shimmie with this PR is that you enable the _"Show shortwiki entry when searching for a single tag"_ checkbox in the board settings screen, then click on a tag. If no entry exists yet it'll just show you the title with a link to setup an entry. If an entry does exist it'll show you that plus the first line of that entry (just splits on newline and grabs the first line).

Here's how it shows up on the Danbooru2 and Default themes:
<img width="1234" alt="Screen Shot 2020-03-23 at 10 47 51 pm" src="https://user-images.githubusercontent.com/251281/77318671-2ba56d00-6d59-11ea-8b54-9346d5a95347.png">
<img width="1376" alt="Screen Shot 2020-03-23 at 10 47 44 pm" src="https://user-images.githubusercontent.com/251281/77318663-28aa7c80-6d59-11ea-9bc6-a5242808751c.png">
