### PR TITLE
Fix dirname(NULL) error in get_base_href

### DIFF
--- a/core/polyfills.php
+++ b/core/polyfills.php
@@ -391,7 +391,7 @@ function get_base_href(): string
         return BASE_HREF;
     }
     $possible_vars = ['SCRIPT_NAME', 'PHP_SELF', 'PATH_INFO', 'ORIG_PATH_INFO'];
-    $ok_var = null;
+    $ok_var = "";
     foreach ($possible_vars as $var) {
         if (isset($_SERVER[$var]) && substr($_SERVER[$var], -4) === '.php') {
             $ok_var = $_SERVER[$var];


### PR DESCRIPTION
So this is an issue that only just started happening. A few days ago in git master, nope. Today in git master, this error is sprinkled through my docker logs on almost every page grab:

```
[Sat Mar 28 00:55:54 2020] PHP Fatal error:  Uncaught TypeError: dirname() expects parameter 1 to be string, null given in /app/core/polyfills.php:402
Stack trace:
#0 /app/core/polyfills.php(402): dirname(NULL)
#1 /app/ext/autocomplete/theme.php(7): get_base_href()
#2 /app/ext/autocomplete/main.php(67): AutoCompleteTheme->build_autocomplete(Object(Page))
#3 /app/core/send_event.php(113): AutoComplete->onPageRequest(Object(PageRequestEvent))
#4 /app/index.php(95): send_event(Object(PageRequestEvent))
#5 /app/tests/router.php(33): require_once('/app/index.php')
#6 {main}
  thrown in /app/core/polyfills.php on line 402


  [Sat Mar 28 00:56:06 2020] PHP Fatal error:  Uncaught TypeError: dirname() expects parameter 1 to be string, null given in /app/core/polyfills.php:402
Stack trace:
#0 /app/core/polyfills.php(402): dirname(NULL)
#1 /app/core/urls.php(34): get_base_href()
#2 /app/ext/et/main.php(32): make_link('system_info')
#3 /app/core/send_event.php(113): ET->onUserBlockBuilding(Object(UserBlockBuildingEvent))
#4 /app/ext/user/main.php(372): send_event(Object(UserBlockBuildingEvent))
#5 /app/ext/user/main.php(99): UserPage->show_user_info()
#6 /app/core/send_event.php(113): UserPage->onPageRequest(Object(PageRequestEvent))
#7 /app/index.php(95): send_event(Object(PageRequestEvent))
#8 /app/tests/router.php(33): require_once('/app/index.php')
#9 {main}
  thrown in /app/core/polyfills.php on line 402
```

This seems to fix it but I don't know enough about PHP to know if this is the _right_ way to fix it
¯\\\_(ツ)\_/¯

**edit:** for reference, the path to my install is http://localhost:8123/index.php?q=/post/list , 100% standard docker install on my macOS machine.