### PR TITLE
Fix postgres testing

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         mkdir -p data/config
         if [[ "${{ matrix.database }}" == "pgsql" ]]; then
-            sudo apt update && sudo apt-get install -y postgresql postgresql-client ;
+            sudo systemctl start postgresql ;
             psql --version ;
             sudo -u postgres psql -c "SELECT set_config('log_statement', 'all', false);" -U postgres ;
             sudo -u postgres psql -c "CREATE USER shimmie WITH PASSWORD 'shimmie';" -U postgres ;


### PR DESCRIPTION
Looks like github updated their default container, so now it contains
postgres and postgres-client by default - we just need to manually
launch the installed-but-disabled daemon