### PR TITLE
Fix child=any search not working

### DIFF
--- a/ext/relationships/main.php
+++ b/ext/relationships/main.php
@@ -83,7 +83,7 @@ class Relationships extends Extension
             }
         } elseif (preg_match("/^child[=|:](any|none)$/", $event->term, $matches)) {
             $not = ($matches[1] == "any" ? "=" : "!=");
-            $event->add_querylet(new Querylet("images.has_children $not :true", ["true"=>true]));
+            $event->add_querylet(new Querylet("images.has_children $not :true", ["true"=>"Y"]));
         }
     }
 


### PR DESCRIPTION
Correct me if I'm wrong with this change, please.
But I found out child=none search was working, so I assumed there was an error in the check. This fixed it for me.