### PR TITLE
[WIP] JSON-RPC API proof of concept

### DIFF
--- a/ext/autocomplete/main.php
+++ b/ext/autocomplete/main.php
@@ -28,6 +28,16 @@ class AutoComplete extends Extension
         $this->theme->build_autocomplete($page);
     }
 
+    public function onApiRequest(ApiRequestEvent $event)
+    {
+        if ($event->method == "autocomplete") {
+            $event->result = $this->complete(
+                $event->params->search ?? "",
+                $event->params->limit ?? 0,
+            );
+        }
+    }
+
     private function complete(string $search, int $limit): array
     {
         global $cache, $database;

--- a/ext/json_rpc/info.php
+++ b/ext/json_rpc/info.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+class JsonRpcInfo extends ExtensionInfo
+{
+    public const KEY = "json_rpc";
+
+    public $key = self::KEY;
+    public $name = "JSON RPC API";
+    public $url = self::SHIMMIE_URL;
+    public $authors = self::SHISH_AUTHOR;
+    public $license = self::LICENSE_GPLV2;
+    public $description = "An entry point for a JSON RPC interface";
+}

--- a/ext/json_rpc/main.php
+++ b/ext/json_rpc/main.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+class ApiRequestEvent extends Event
+{
+    public $method;  // string
+    public $params;  // array|object
+    public $id;  // int|string
+    public $result;  // any
+
+    public function __construct(string $method, $params, $id)
+    {
+        parent::__construct();
+        $this->method = $method;
+        $this->params = $params;
+        $this->id = $id;
+        $this->result = null;
+    }
+
+    public static function from_array(array $req)
+    {
+        $method = $req["method"];
+        $params = $req["params"] ?? [];
+        $id = $req["id"];
+        return new ApiRequestEvent($method, $params, $id);
+    }
+}
+
+class JsonRpc extends Extension
+{
+    public function onPageRequest(PageRequestEvent $event)
+    {
+        global $page;
+        if ($event->page_matches("api/json")) {
+            $page->set_mode(PageMode::DATA);
+            $in = json_decode(file_get_contents('php://input'), true);
+
+            // $in is a request
+            if (array_key_exists("jsonrpc", $in)) {
+                $out = $this->get_response($in);
+                if (!is_null($out)) {
+                    $page->set_data(json_encode($out));
+                }
+            }
+            // assume $in is a list of requests
+            else {
+                $out = [];
+                foreach ($in as $req) {
+                    $res = $this->get_response($req);
+                    if (!is_null($res)) {
+                        $out[] = $res;
+                    }
+                }
+                $page->set_data(json_encode($out));
+            }
+        }
+    }
+
+    public function onCommand(CommandEvent $event)
+    {
+        if ($event->cmd == "help") {
+            print "\tjson-rpc <method> <params>\n";
+            print "\t\teg 'json-rpc get-posts'\n\n";
+        }
+        if ($event->cmd == "json-rpc") {
+            print(json_encode($this->get_response([
+                "id" => 1,
+                "method" => $event->args[0],
+                "params" => json_decode($event->args[1] ?? "[]"),
+            ]), JSON_PRETTY_PRINT) . "\n");
+        }
+    }
+
+    private function get_response(array $req): ?array
+    {
+        $evt = ApiRequestEvent::from_array($req);
+        try {
+            send_event($evt);
+            if (is_null($evt->id)) {
+                return null;
+            }
+            return [
+                "jsonrpc" => "2.0",
+                "result" => $evt->result,
+                "id" => $evt->id,
+            ];
+        } catch (Throwable $e) {
+            return [
+                "jsonrpc" => "2.0",
+                "error" => [
+                    "code" => -1,
+                    "message" => $e->getMessage(),
+                    "data" => null,
+                ],
+                "id" => $evt->id,
+            ];
+        }
+    }
+
+    public function onApiRequest(ApiRequestEvent $event)
+    {
+        if ($event->method == "echo") {
+            $event->result = $event->params;
+        }
+    }
+}

--- a/ext/json_rpc/test.php
+++ b/ext/json_rpc/test.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+class JsonRpcTest extends ShimmiePHPUnitTestCase
+{
+    public function testEcho()
+    {
+        $evt = new ApiRequestEvent("echo", ["foo"=>"bar"], 1);
+        send_event($evt);
+        $this->assertEquals(1, $evt->id);
+        $this->assertEquals(["foo"=>"bar"], $evt->result);
+    }
+}


### PR DESCRIPTION
`POST` to `/api/json-rpc`, or command line `json-rpc <method> <params>`

Adding API support into existing extensions is pretty trivial, eg with the `autocomplete` extension already having a `complete(string $search, int $limit): array` function defined, we can add:

```
    public function onApiRequest(ApiRequestEvent $event) {
        if ($event->method == "autocomplete") {
            $event->result = $this->complete(
                $event->params->search ?? "",
                $event->params->limit ?? 0,
            );
        }
    }
```

A valid response:
```
$ php index.php json-rpc autocomplete '{"search": "a"}'
{
    "jsonrpc": "2.0",
    "result": {
        "angel": "1",
        "aaaa": "1"
    },
    "id": 1
}
```

An error:
```
$ php index.php json-rpc autocomplete '{"search": 42}'
{
    "jsonrpc": "2.0",
    "error": {
        "code": -1,
        "message": "Argument 1 passed to AutoComplete::complete() must be of the type string, int given, called in \/Users\/shish2k\/Projects\/shimmie2\/ext\/autocomplete\/main.php on line 36",
        "data": null
    },
    "id": 1
}
```

(If we wanted to populate the error's `code` or `data` fields, we could throw and catch `ApiException` objects?)