### PR TITLE
Added 2 missing block ids on post/view

### DIFF
--- a/ext/relationships/theme.php
+++ b/ext/relationships/theme.php
@@ -8,7 +8,7 @@ class RelationshipsTheme extends Themelet
 
         if ($image->parent_id !== null) {
             $a = "<a href='".make_link("post/view/".$image->parent_id)."'>parent post</a>";
-            $page->add_block(new Block(null, "This post belongs to a $a.", "main", 5, "ImageRelationships"));
+            $page->add_block(new Block(null, "This post belongs to a $a.", "main", 5, "ImageHasParent"));
         }
 
         if (bool_escape($image->has_children)) {
@@ -21,7 +21,7 @@ class RelationshipsTheme extends Themelet
             }
             $html = rtrim($html, ", ").").";
 
-            $page->add_block(new Block(null, $html, "main", 6));
+            $page->add_block(new Block(null, $html, "main", 6, "ImageHasChildren"));
         }
     }
 

--- a/ext/relationships/theme.php
+++ b/ext/relationships/theme.php
@@ -8,7 +8,7 @@ class RelationshipsTheme extends Themelet
 
         if ($image->parent_id !== null) {
             $a = "<a href='".make_link("post/view/".$image->parent_id)."'>parent post</a>";
-            $page->add_block(new Block(null, "This post belongs to a $a.", "main", 5));
+            $page->add_block(new Block(null, "This post belongs to a $a.", "main", 5, "ImageRelationships"));
         }
 
         if (bool_escape($image->has_children)) {

--- a/ext/view/theme.php
+++ b/ext/view/theme.php
@@ -23,7 +23,7 @@ class ViewImageTheme extends Themelet
         $page->set_title("Post {$image->id}: ".$image->get_tag_list());
         $page->set_heading(html_escape($image->get_tag_list()));
         $page->add_block(new Block("Navigation", $this->build_navigation($image), "left", 0));
-        $page->add_block(new Block(null, $this->build_info($image, $editor_parts), "main", 20));
+        $page->add_block(new Block(null, $this->build_info($image, $editor_parts), "main", 20, "ImageInfo"));
         //$page->add_block(new Block(null, $this->build_pin($image), "main", 11));
 
         $query = $this->get_query();


### PR DESCRIPTION
Small change. There's probably more to add and I will push those on this same PR if I find them.
I'm working on a custom theme with responsive design and I needed to be able to easily select those unidentified blocks.