### PR TITLE
Standard HTML select code

### DIFF
--- a/core/basethemelet.php
+++ b/core/basethemelet.php
@@ -196,8 +196,9 @@ class BaseThemelet
      * Generates a <select> HTML template and sets up the given options.
      *
      * @param string $name The name attribute of <select>.
-     * @param array $options A pair of parameters for <option> tags. First one is value, second one is text. Example: ('optionA', 'Choose Option A').
-     * @param string $attributes Flags for <select>. Example: 'multiple required' becomes <select multiple required>
+     * @param array $options An array of pairs of parameters for <option> tags. First one is value, second one is text. Example: ('optionA', 'Choose Option A').
+     * @param bool $required Wether the <select> element is required.
+     * @param bool $multiple Wether the <select> element is multiple-choice.
      * @param bool $empty_option Whether the first option should be an empty one.
      * @param array $selected_options The values of options that should be pre-selected.
      */

--- a/core/basethemelet.php
+++ b/core/basethemelet.php
@@ -202,7 +202,7 @@ class BaseThemelet
      * @param bool $empty_option Whether the first option should be an empty one.
      * @param array $selected_options The values of options that should be pre-selected.
      */
-    protected function build_selector(string $name, array $options, bool $required=false, bool $multiple=false, bool $empty_option=false, array $selected_options=[]): string
+    protected function build_selector(string $name, array $options, bool $required=false, bool $multiple=false, bool $empty_option=false, array $selected_options=[]): HTMLElement
     {
         $attrs = [];
         if ($required) {
@@ -228,6 +228,6 @@ class BaseThemelet
             }
         }
 
-        return (string)$s;
+        return $s;
     }
 }

--- a/core/basethemelet.php
+++ b/core/basethemelet.php
@@ -191,4 +191,32 @@ class BaseThemelet
             ' >>'
         );
     }
+
+    /**
+     * Generates a <select> HTML template and sets up the given options.
+     *
+     * @param string $name The name attribute of <select>.
+     * @param array $options A pair of parameters for <option> tags. First one is value, second one is text. Example: ('optionA', 'Choose Option A').
+     * @param string $attributes Flags for <select>. Example: 'multiple required' becomes <select multiple required>
+     * @param bool $empty_option Whether the first option should be an empty one.
+     * @param array $selected_options The values of options that should be pre-selected.
+     */
+    protected function build_selector(string $name, array $options, string $attributes, bool $empty_option=false, array $selected_options=[]): string
+    {
+        $output = "<select name='" . $name . "' " . $attributes . ">";
+
+        if ($empty_option) {
+            $output .= "<option></option>";
+        }
+
+        foreach ($options as $value => $op) {
+            if (isset($selected_options) &&  in_array($value, $selected_options)) {
+                $output .= "<option value='" . $value . "' selected>" . $op . "</option>";
+            } else {
+                $output .= "<option value='" . $value . "' >" . $op . "</option>";
+            }
+        }
+
+        return $output . "</select>";
+    }
 }

--- a/core/basethemelet.php
+++ b/core/basethemelet.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{A,B,BR,IMG,emptyHTML};
+use function MicroHTML\{A,B,BR,IMG,OPTION,SELECT,emptyHTML};
 
 /**
  * Class BaseThemelet
@@ -201,22 +201,32 @@ class BaseThemelet
      * @param bool $empty_option Whether the first option should be an empty one.
      * @param array $selected_options The values of options that should be pre-selected.
      */
-    protected function build_selector(string $name, array $options, string $attributes="", bool $empty_option=false, array $selected_options=[]): string
+    protected function build_selector(string $name, array $options, bool $required=false, bool $multiple=false, bool $empty_option=false, array $selected_options=[]): string
     {
-        $output = "<select name='" . $name . "' " . $attributes . ">";
+        $attrs = [];
+        if ($required) {
+            $attrs["required"] = "";
+        }
+        if ($multiple) {
+            $name = $name . "[]";
+            $attrs["multiple"] = "";
+        }
+        $attrs["name"] = $name;
+
+        $s = SELECT($attrs);
 
         if ($empty_option) {
-            $output .= "<option></option>";
+            $s->appendChild(OPTION());
         }
 
         foreach ($options as $value => $op) {
             if (in_array($value, $selected_options)) {
-                $output .= "<option value='" . $value . "' selected>" . html_escape($op) . "</option>";
+                $s->appendChild(OPTION(["value"=>$value, "selected"=>""], $op));
             } else {
-                $output .= "<option value='" . $value . "' >" . html_escape($op) . "</option>";
+                $s->appendChild(OPTION(["value"=>$value], $op));
             }
         }
 
-        return $output . "</select>";
+        return (string)$s;
     }
 }

--- a/core/basethemelet.php
+++ b/core/basethemelet.php
@@ -210,7 +210,7 @@ class BaseThemelet
         }
 
         foreach ($options as $value => $op) {
-            if (isset($selected_options) &&  in_array($value, $selected_options)) {
+            if (in_array($value, $selected_options)) {
                 $output .= "<option value='" . $value . "' selected>" . $op . "</option>";
             } else {
                 $output .= "<option value='" . $value . "' >" . $op . "</option>";

--- a/core/basethemelet.php
+++ b/core/basethemelet.php
@@ -201,7 +201,7 @@ class BaseThemelet
      * @param bool $empty_option Whether the first option should be an empty one.
      * @param array $selected_options The values of options that should be pre-selected.
      */
-    protected function build_selector(string $name, array $options, string $attributes, bool $empty_option=false, array $selected_options=[]): string
+    protected function build_selector(string $name, array $options, string $attributes="", bool $empty_option=false, array $selected_options=[]): string
     {
         $output = "<select name='" . $name . "' " . $attributes . ">";
 
@@ -211,9 +211,9 @@ class BaseThemelet
 
         foreach ($options as $value => $op) {
             if (in_array($value, $selected_options)) {
-                $output .= "<option value='" . $value . "' selected>" . $op . "</option>";
+                $output .= "<option value='" . $value . "' selected>" . html_escape($op) . "</option>";
             } else {
-                $output .= "<option value='" . $value . "' >" . $op . "</option>";
+                $output .= "<option value='" . $value . "' >" . html_escape($op) . "</option>";
             }
         }
 

--- a/core/user.php
+++ b/core/user.php
@@ -7,6 +7,9 @@ namespace Shimmie2;
 use GQLA\Type;
 use GQLA\Field;
 use GQLA\Query;
+use MicroHTML\HTMLElement;
+
+use function MicroHTML\INPUT;
 
 function _new_user(array $row): User
 {
@@ -275,6 +278,13 @@ class User
     {
         $at = $this->get_auth_token();
         return '<input type="hidden" name="auth_token" value="'.$at.'">';
+    }
+
+    // Temporary? This should eventually become get_auth_html (probably with a different name?).
+    public function get_auth_microhtml(): HTMLElement
+    {
+        $at = $this->get_auth_token();
+        return INPUT(["type"=>"hidden", "name"=>"auth_token", "value"=>$at]);
     }
 
     public function check_auth_token(): bool

--- a/core/util.php
+++ b/core/util.php
@@ -754,6 +754,30 @@ function make_form(string $target, string $method="POST", bool $multipart=false,
     return '<form action="'.$target.'" method="'.$method.'" '.$extra.'>'.$extra_inputs;
 }
 
+// Temporary? This should eventually become make_form.
+function make_form_microhtml(string $target, string $method="POST", bool $multipart=false, string $form_id="", string $onsubmit=""): HTMLElement
+{
+    global $user;
+
+    if ($method == "GET") {
+        $extra_inputs = INPUT(["type"=>"hidden", "name"=>"q", "value"=>$target]);
+        $target = make_link($target);
+    } else {
+        $extra_inputs = $user->get_auth_microhtml();
+    }
+
+    $args = ["action"=>$target, "method"=>$method];
+
+    if ($multipart) {
+        $args["enctype"] = "multipart/form-data";
+    }
+    if ($onsubmit) {
+        $args["onsubmit"] = $onsubmit;
+    }
+
+    return FORM($args, $extra_inputs);
+}
+
 function SHM_FORM(string $target, string $method="POST", bool $multipart=false, string $form_id="", string $onsubmit=""): HTMLElement
 {
     global $user;

--- a/ext/pools/main.php
+++ b/ext/pools/main.php
@@ -473,7 +473,7 @@ class Pools extends Extension
                 $pools = $database->get_pairs("SELECT id,title FROM pools WHERE user_id=:id ORDER BY title", ["id" => $user->id]);
             }
             if (count($pools) > 0) {
-                $event->add_part($this->theme->get_adder_html($event->image, $pools));
+                $event->add_part((string)$this->theme->get_adder_html($event->image, $pools));
             }
         }
     }

--- a/ext/pools/main.php
+++ b/ext/pools/main.php
@@ -470,7 +470,7 @@ class Pools extends Extension
             if ($user->can(Permissions::POOLS_ADMIN)) {
                 $pools = $database->get_pairs("SELECT id,title FROM pools ORDER BY title");
             } else {
-                $pools = $database->get_pairs("SELECT id,title FROM pools ORDER BY title WHERE user_id=:id", ["id" => $user->id]);
+                $pools = $database->get_pairs("SELECT id,title FROM pools WHERE user_id=:id ORDER BY title", ["id" => $user->id]);
             }
             if (count($pools) > 0) {
                 $event->add_part($this->theme->get_adder_html($event->image, $pools));

--- a/ext/pools/main.php
+++ b/ext/pools/main.php
@@ -466,13 +466,13 @@ class Pools extends Extension
     {
         global $config, $database, $user;
         if ($config->get_bool(PoolsConfig::ADDER_ON_VIEW_IMAGE) && !$user->is_anonymous()) {
+            $pools = [];
             if ($user->can(Permissions::POOLS_ADMIN)) {
-                $rows = $database->get_all("SELECT * FROM pools");
+                $pools = $database->get_pairs("SELECT id,title FROM pools ORDER BY title");
             } else {
-                $rows = $database->get_all("SELECT * FROM pools WHERE user_id=:id", ["id" => $user->id]);
+                $pools = $database->get_pairs("SELECT id,title FROM pools ORDER BY title WHERE user_id=:id", ["id" => $user->id]);
             }
-            if (count($rows) > 0) {
-                $pools = array_map([Pool::class, "makePool"], $rows);
+            if (count($pools) > 0) {
                 $event->add_part($this->theme->get_adder_html($event->image, $pools));
             }
         }

--- a/ext/pools/main.php
+++ b/ext/pools/main.php
@@ -555,8 +555,9 @@ class Pools extends Extension
 
         $options = $database->get_pairs("SELECT id,title FROM pools ORDER BY title");
 
-        $event->add_action("bulk_pool_add_existing", "Add To (P)ool", "p", "", $this->theme->get_bulk_pool_selector($options));
-        $event->add_action("bulk_pool_add_new", "Create Pool", "", "", $this->theme->get_bulk_pool_input($event->search_terms));
+        // TODO: Don't cast into strings, make BABBE accept HTMLElement instead.
+        $event->add_action("bulk_pool_add_existing", "Add To (P)ool", "p", "", (string)$this->theme->get_bulk_pool_selector($options));
+        $event->add_action("bulk_pool_add_new", "Create Pool", "", "", (string)$this->theme->get_bulk_pool_input($event->search_terms));
     }
 
     public function onBulkAction(BulkActionEvent $event)

--- a/ext/pools/main.php
+++ b/ext/pools/main.php
@@ -553,12 +553,9 @@ class Pools extends Extension
     {
         global $database;
 
-        $pools = array_map(
-            [Pool::class, "makePool"],
-            $database->get_all("SELECT * FROM pools ORDER BY title ")
-        );
+        $options = $database->get_pairs("SELECT id,title FROM pools ORDER BY title");
 
-        $event->add_action("bulk_pool_add_existing", "Add To (P)ool", "p", "", $this->theme->get_bulk_pool_selector($pools));
+        $event->add_action("bulk_pool_add_existing", "Add To (P)ool", "p", "", $this->theme->get_bulk_pool_selector($options));
         $event->add_action("bulk_pool_add_new", "Create Pool", "", "", $this->theme->get_bulk_pool_input($event->search_terms));
     }
 

--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -41,8 +41,7 @@ class PoolsTheme extends Themelet
     public function get_adder_html(Image $image, array $pools): string
     {
         $selector = $this->build_selector("pool_id", $pools);
-        return "\n" . make_form(make_link("pool/add_post")) . "
-            $selector
+        return "\n" . make_form(make_link("pool/add_post")) . $selector . "
             <input type='hidden' name='image_id' value='{$image->id}'>
             <input type='submit' value='Add Post to Pool'>
             </form>
@@ -388,7 +387,7 @@ class PoolsTheme extends Themelet
 
     public function get_bulk_pool_selector(array $options): string
     {
-        return $this->build_selector("bulk_pool_select", $options, required: true, empty_option: true);
+        return (string)$this->build_selector("bulk_pool_select", $options, required: true, empty_option: true);
     }
 
     public function get_bulk_pool_input(array $search_terms): string

--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
+use function MicroHTML\INPUT;
+
 class PoolsTheme extends Themelet
 {
     /**
@@ -385,14 +389,22 @@ class PoolsTheme extends Themelet
         $this->display_paginator($page, "pool/updated", null, $pageNumber, $totalPages);
     }
 
-    public function get_bulk_pool_selector(array $options): string
+    public function get_bulk_pool_selector(array $options): HTMLElement
     {
-        return (string)$this->build_selector("bulk_pool_select", $options, required: true, empty_option: true);
+        return $this->build_selector("bulk_pool_select", $options, required: true, empty_option: true);
     }
 
-    public function get_bulk_pool_input(array $search_terms): string
+    public function get_bulk_pool_input(array $search_terms): HTMLElement
     {
-        return "<input type='text' name='bulk_pool_new' placeholder='New pool' required='required' value='".(implode(" ", $search_terms))."' />";
+        return INPUT(
+            [
+                "type"=>"text",
+                "name"=>"bulk_pool_new",
+                "placeholder"=>"New Pool",
+                "required"=>"",
+                "value"=>implode(" ", $search_terms)
+            ]
+        );
     }
 
     public function get_help_html(): string

--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -40,18 +40,13 @@ class PoolsTheme extends Themelet
 
     public function get_adder_html(Image $image, array $pools): string
     {
-        $h = "";
-        foreach ($pools as $pool) {
-            $h .= "<option value='" . $pool->id . "'>" . html_escape($pool->title) . "</option>";
-        }
+        $selector = $this->build_selector("pool_id", $pools);
         return "\n" . make_form(make_link("pool/add_post")) . "
-				<select name='pool_id'>
-					$h
-				</select>
-				<input type='hidden' name='image_id' value='{$image->id}'>
-				<input type='submit' value='Add Post to Pool'>
-			</form>
-		";
+            $selector
+            <input type='hidden' name='image_id' value='{$image->id}'>
+            <input type='submit' value='Add Post to Pool'>
+            </form>
+        ";
     }
 
     /**

--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -388,7 +388,7 @@ class PoolsTheme extends Themelet
 
     public function get_bulk_pool_selector(array $options): string
     {
-        return $this->build_selector("bulk_pool_select", $options, "required", true);
+        return $this->build_selector("bulk_pool_select", $options, required: true, empty_option: true);
     }
 
     public function get_bulk_pool_input(array $search_terms): string

--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -391,13 +391,9 @@ class PoolsTheme extends Themelet
         $this->display_paginator($page, "pool/updated", null, $pageNumber, $totalPages);
     }
 
-    public function get_bulk_pool_selector(array $pools): string
+    public function get_bulk_pool_selector(array $options): string
     {
-        $output = "<select name='bulk_pool_select' required='required'><option></option>";
-        foreach ($pools as $pool) {
-            $output .= "<option value='" . $pool->id . "' >" . $pool->title . "</option>";
-        }
-        return $output . "</select>";
+        return $this->build_selector("bulk_pool_select", $options, "required", true);
     }
 
     public function get_bulk_pool_input(array $search_terms): string

--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -42,14 +42,15 @@ class PoolsTheme extends Themelet
         }
     }
 
-    public function get_adder_html(Image $image, array $pools): string
+    public function get_adder_html(Image $image, array $pools): HTMLElement
     {
-        $selector = $this->build_selector("pool_id", $pools);
-        return "\n" . make_form(make_link("pool/add_post")) . $selector . "
-            <input type='hidden' name='image_id' value='{$image->id}'>
-            <input type='submit' value='Add Post to Pool'>
-            </form>
-        ";
+        $form = make_form_microhtml(make_link("pool/add_post"));
+
+        $form->appendChild($this->build_selector("pool_id", $pools));
+        $form->appendChild(INPUT(["type"=>"hidden", "name"=>"image_id", "value"=>$image->id]));
+        $form->appendChild(INPUT(["type"=>"submit", "value"=>"Add Post to Pool"]));
+
+        return $form;
     }
 
     /**

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -231,13 +231,8 @@ class Ratings extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event)
     {
         if ($event->key===HelpPages::SEARCH) {
-            $block = new Block();
-            $block->header = "Ratings";
-
             $ratings = self::get_sorted_ratings();
-
-            $block->body = $this->theme->get_help_html($ratings);
-            $event->add_block($block);
+            $event->add_block(new Block("Ratings", $this->theme->get_help_html($ratings)));
         }
     }
 

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -203,7 +203,7 @@ class Ratings extends Extension
     {
         global $user;
         $event->add_part(
-            $this->theme->get_rater_html(
+            (string)$this->theme->get_rater_html(
                 $event->image->id,
                 $event->image->rating,
                 $user->can(Permissions::EDIT_IMAGE_RATING)
@@ -345,7 +345,7 @@ class Ratings extends Extension
         global $user;
 
         if ($user->can(Permissions::BULK_EDIT_IMAGE_RATING)) {
-            $event->add_action("bulk_rate", "Set (R)ating", "r", "", $this->theme->get_selection_rater_html(["?"]));
+            $event->add_action("bulk_rate", "Set (R)ating", "r", "", (string)$this->theme->get_selection_rater_html(selected_options: ["?"]));
         }
     }
 

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -313,7 +313,7 @@ class Ratings extends Extension
             }
         }
 
-        $this->theme->display_form($original_values, self::get_sorted_ratings());
+        $this->theme->display_form($original_values);
     }
 
     public function onAdminAction(AdminActionEvent $event)
@@ -413,6 +413,21 @@ class Ratings extends Extension
             return $a->order <=> $b->order;
         });
         return $ratings;
+    }
+
+    public static function get_ratings_dict(array $ratings=null): array
+    {
+        if (!isset($ratings)) {
+            $ratings = self::get_sorted_ratings();
+        }
+        return array_combine(
+            array_map(function ($o) {
+                return $o->code;
+            }, $ratings),
+            array_map(function ($o) {
+                return $o->name;
+            }, $ratings)
+        );
     }
 
     public static function get_user_class_privs(User $user): array

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -33,8 +33,8 @@ class RatingsTheme extends Themelet
 
         $html = make_form(make_link("admin/update_ratings"))."<table class='form'>";
 
-        $html .= "<tr><th>Change</th><td>".$this->build_selector("rating_old", $current_ratings, required: true)."</td></tr>";
-        $html .= "<tr><th>To</th><td>".$this->build_selector("rating_new", Ratings::get_ratings_dict(), required: true)."</td></tr>";
+        $html .= "<tr><th>Change</th><td>" . $this->build_selector("rating_old", $current_ratings, required: true) . "</td></tr>";
+        $html .= "<tr><th>To</th><td>" . $this->build_selector("rating_new", Ratings::get_ratings_dict(), required: true) . "</td></tr>";
 
         $html .= "<tr><td colspan='2'><input type='submit' value='Update'></td></tr></table>
         </form>\n";
@@ -44,7 +44,7 @@ class RatingsTheme extends Themelet
 
     public function get_selection_rater_html(array $selected_options, bool $multiple = false): string
     {
-        return $this->build_selector("rating", Ratings::get_ratings_dict(), multiple: $multiple, empty_option: false, selected_options: $selected_options);
+        return (string)$this->build_selector("rating", Ratings::get_ratings_dict(), multiple: $multiple, empty_option: false, selected_options: $selected_options);
     }
 
     public function get_help_html(array $ratings): string

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -27,42 +27,24 @@ class RatingsTheme extends Themelet
         return $html;
     }
 
-    public function display_form(array $current_ratings, array $available_ratings)
+    public function display_form(array $current_ratings)
     {
         global $page;
 
-        $html = make_form(make_link("admin/update_ratings"))."<table class='form'><tr>
-        <th>Change</th><td><select name='rating_old' required='required'><option></option>";
-        foreach ($current_ratings as $key=>$value) {
-            $html .= "<option value='$key'>$value</option>";
-        }
-        $html .= "</select></td></tr>
-        <tr><th>To</th><td><select name='rating_new'  required='required'><option></option>";
-        foreach ($available_ratings as $value) {
-            $html .= "<option value='$value->code'>$value->name</option>";
-        }
-        $html .= "</select></td></tr>
-        <tr><td colspan='2'><input type='submit' value='Update'></td></tr></table>
+        $html = make_form(make_link("admin/update_ratings"))."<table class='form'>";
+
+        $html .= "<tr><th>Change</th><td>".$this->build_selector("rating_old", $current_ratings, "required", true)."</td></tr>";
+        $html .= "<tr><th>To</th><td>".$this->build_selector("rating_new", Ratings::get_ratings_dict(), "required", true)."</td></tr>";
+
+        $html .= "<tr><td colspan='2'><input type='submit' value='Update'></td></tr></table>
         </form>\n";
+
         $page->add_block(new Block("Update Ratings", $html));
     }
 
-    public function get_selection_rater_html(array $selected_options, bool $multiple = false, array $available_options = null): string
+    public function get_selection_rater_html(array $selected_options, bool $multiple = false): string
     {
-        $output = "<select name='rating".($multiple ? "[]' multiple='multiple'" : "' ")." >";
-
-        $options = Ratings::get_sorted_ratings();
-
-        foreach ($options as $option) {
-            if ($available_options!=null && !in_array($option->code, $available_options)) {
-                continue;
-            }
-
-            $output .= "<option value='".$option->code."' ".
-                (in_array($option->code, $selected_options) ? "selected='selected'" : "")
-                .">".$option->name."</option>";
-        }
-        return $output."</select>";
+        return $this->build_selector($multiple ? "rating[]" : "rating", Ratings::get_ratings_dict(), ($multiple ? "multiple" : ""), false, $selected_options);
     }
 
     public function get_help_html(array $ratings): string
@@ -93,7 +75,9 @@ class RatingsTheme extends Themelet
         return $output;
     }
 
-    public function get_user_options(User $user, array $selected_ratings, array $available_ratings): string
+    // This wasn't being used at all
+
+    /* public function get_user_options(User $user, array $selected_ratings, array $available_ratings): string
     {
         $html = "
                 <p>".make_form(make_link("user_admin/default_ratings"))."
@@ -115,5 +99,5 @@ class RatingsTheme extends Themelet
                 </form>
             ";
         return $html;
-    }
+    } */
 }

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -6,7 +6,8 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{TR,TH,TD,SPAN,INPUT};
+use function MicroHTML\emptyHTML;
+use function MicroHTML\{DIV,INPUT,P,PRE,SPAN,TABLE,TD,TH,TR};
 
 class RatingsTheme extends Themelet
 {
@@ -39,42 +40,50 @@ class RatingsTheme extends Themelet
     {
         global $page;
 
-        $html = make_form(make_link("admin/update_ratings"))."<table class='form'>";
+        $html = make_form_microhtml(make_link("admin/update_ratings"));
 
-        $html .= TR(TH("Change"), TD($this->get_selection_rater_html("rating_old", $current_ratings)));
-        $html .= TR(TH("To"), TD($this->get_selection_rater_html("rating_new")));
-
-        $html .= TR(TD(["colspan"=>"2"], INPUT(["type"=>"submit", "value"=>"Update"])));
-        $html .= "</table></form>\n";
+        $html->appendChild(TABLE(
+            ["class"=>"form"],
+            TR(TH("Change"), TD($this->get_selection_rater_html("rating_old", $current_ratings))),
+            TR(TH("To"), TD($this->get_selection_rater_html("rating_new"))),
+            TR(TD(["colspan"=>"2"], INPUT(["type"=>"submit", "value"=>"Update"])))
+        ));
 
         $page->add_block(new Block("Update Ratings", $html));
     }
 
-    public function get_help_html(array $ratings): string
+    public function get_help_html(array $ratings): HTMLElement
     {
-        $output =  '<p>Search for posts with one or more possible ratings.</p>
-        <div class="command_example">
-        <pre>rating:'.$ratings[0]->search_term.'</pre>
-        <p>Returns posts with the '.$ratings[0]->name.' rating.</p>
-        </div>
-        <p>Ratings can be abbreviated to a single letter as well</p>
-        <div class="command_example">
-        <pre>rating:'.$ratings[0]->code.'</pre>
-        <p>Returns posts with the '.$ratings[0]->name.' rating.</p>
-        </div>
-        <p>If abbreviations are used, multiple ratings can be searched for.</p>
-        <div class="command_example">
-        <pre>rating:'.$ratings[0]->code.$ratings[1]->code.'</pre>
-        <p>Returns posts with the '.$ratings[0]->name.' or '.$ratings[1]->name.' rating.</p>
-        </div>
-        <p>Available ratings:</p>
-        <table>
-        <tr><th>Name</th><th>Search Term</th><th>Abbreviation</th></tr>
-        ';
+        $output = emptyHTML(
+            P("Search for posts with one or more possible ratings."),
+            DIV(
+                ["class"=>"command_example"],
+                PRE("rating:" . $ratings[0]->search_term),
+                P("Returns posts with the " . $ratings[0]->name . " rating.")
+            ),
+            P("Ratings can be abbreviated to a single letter as well."),
+            DIV(
+                ["class"=>"command_example"],
+                PRE("rating:" . $ratings[0]->code),
+                P("Returns posts with the " . $ratings[0]->name . " rating.")
+            ),
+            P("If abbreviations are used, multiple ratings can be searched for."),
+            DIV(
+                ["class"=>"command_example"],
+                PRE("rating:" . $ratings[0]->code . $ratings[1]->code),
+                P("Returns posts with the " . $ratings[0]->name . " or " . $ratings[1]->name . " rating.")
+            ),
+            P("Available ratings:")
+        );
+
+        $table = TABLE(TR(TH("Name"),TH("Search Term"),TH("Abbreviation")));
+
         foreach ($ratings as $rating) {
-            $output .= "<tr><td>{$rating->name}</td><td>{$rating->search_term}</td><td>{$rating->code}</td></tr>";
+            $table->appendChild(TR(TD($rating->name),TD($rating->search_term),TD($rating->code)));
         }
-        $output .= "</table>";
+
+        $output->appendChild($table);
+
         return $output;
     }
 

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -33,8 +33,8 @@ class RatingsTheme extends Themelet
 
         $html = make_form(make_link("admin/update_ratings"))."<table class='form'>";
 
-        $html .= "<tr><th>Change</th><td>".$this->build_selector("rating_old", $current_ratings, "required", true)."</td></tr>";
-        $html .= "<tr><th>To</th><td>".$this->build_selector("rating_new", Ratings::get_ratings_dict(), "required", true)."</td></tr>";
+        $html .= "<tr><th>Change</th><td>".$this->build_selector("rating_old", $current_ratings, required: true)."</td></tr>";
+        $html .= "<tr><th>To</th><td>".$this->build_selector("rating_new", Ratings::get_ratings_dict(), required: true)."</td></tr>";
 
         $html .= "<tr><td colspan='2'><input type='submit' value='Update'></td></tr></table>
         </form>\n";
@@ -44,7 +44,7 @@ class RatingsTheme extends Themelet
 
     public function get_selection_rater_html(array $selected_options, bool $multiple = false): string
     {
-        return $this->build_selector($multiple ? "rating[]" : "rating", Ratings::get_ratings_dict(), ($multiple ? "multiple" : ""), false, $selected_options);
+        return $this->build_selector("rating", Ratings::get_ratings_dict(), multiple: $multiple, empty_option: false, selected_options: $selected_options);
     }
 
     public function get_help_html(array $ratings): string

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -76,10 +76,10 @@ class RatingsTheme extends Themelet
             P("Available ratings:")
         );
 
-        $table = TABLE(TR(TH("Name"),TH("Search Term"),TH("Abbreviation")));
+        $table = TABLE(TR(TH("Name"), TH("Search Term"), TH("Abbreviation")));
 
         foreach ($ratings as $rating) {
-            $table->appendChild(TR(TD($rating->name),TD($rating->search_term),TD($rating->code)));
+            $table->appendChild(TR(TD($rating->name), TD($rating->search_term), TD($rating->code)));
         }
 
         $output->appendChild($table);


### PR DESCRIPTION
Same proof of concept from #827 but without my custom wrapper. `build_selector` has been moved to `basethemelet.php`. I didn't even think of it before. Putting this function here means that in addition to overriding on the entire site, themes can override them on a per-extension basis, giving even more control to the designer.
Let's just hope we don't override the new functions on extensions themselves or we will end up in the same road :smile:

- The doc-string might be a bit too much, I just wanted to make it clear for this PR.
- There's an unrelated change that makes pools sort posts by ID when order is the same. It was a personal uncommitted change and it slipped on this one.

If this looks good, I will implement `build_selector` on more extensions.