### PR TITLE
Attempt at externalizing layout from extensions

### DIFF
--- a/ext/artists/main.php
+++ b/ext/artists/main.php
@@ -33,7 +33,7 @@ class Artists extends Extension
         global $user;
         $artistName = $this->get_artistName_by_imageID($event->image->id);
         if (!$user->is_anonymous()) {
-            $event->add_part($this->theme->get_author_editor_html($artistName), 42, "Author");
+            $event->add_part([$this->theme->get_author_editor_html($artistName)], 42, "Author");
         }
     }
 

--- a/ext/artists/main.php
+++ b/ext/artists/main.php
@@ -33,7 +33,7 @@ class Artists extends Extension
         global $user;
         $artistName = $this->get_artistName_by_imageID($event->image->id);
         if (!$user->is_anonymous()) {
-            $event->add_part($this->theme->get_author_editor_html($artistName), 42);
+            $event->add_part($this->theme->get_author_editor_html($artistName), 42, "Author");
         }
     }
 

--- a/ext/artists/theme.php
+++ b/ext/artists/theme.php
@@ -5,13 +5,8 @@ class ArtistsTheme extends Themelet
     {
         $h_author = html_escape($author);
         return "
-			<tr>
-				<th>Author</th>
-				<td>
-					<span class='view'>$h_author</span>
-					<input class='edit' type='text' name='tag_edit__author' value='$h_author'>
-				</td>
-			</tr>
+			<span class='view'>$h_author</span>
+			<input class='edit' type='text' name='tag_edit__author' value='$h_author'>
 		";
     }
 

--- a/ext/ban_words/main.php
+++ b/ext/ban_words/main.php
@@ -56,7 +56,7 @@ xanax
     public function onSetupBuilding(SetupBuildingEvent $event)
     {
         $sb = $event->panel->create_new_block("Banned Phrases");
-        $sb->add_label("One per line, lines that start with slashes are treated as regex<br/>");
+        $sb->add_label("One per line, lines that start with slashes are treated as regex", true);
         $sb->add_longtext_option("banned_words");
         $failed = [];
         foreach ($this->get_words() as $word) {
@@ -67,7 +67,7 @@ xanax
             }
         }
         if ($failed) {
-            $sb->add_label("Failed regexes: ".join(", ", $failed));
+            $sb->add_label("Failed regexes: ".join(", ", $failed), true);
         }
     }
 

--- a/ext/blotter/main.php
+++ b/ext/blotter/main.php
@@ -41,9 +41,9 @@ class Blotter extends Extension
     public function onSetupBuilding(SetupBuildingEvent $event)
     {
         $sb = $event->panel->create_new_block("Blotter");
-        $sb->add_int_option("blotter_recent", "<br />Number of recent entries to display: ");
-        $sb->add_text_option("blotter_color", "<br />Color of important updates: (ABCDEF format) ");
-        $sb->add_choice_option("blotter_position", ["Top of page" => "subheading", "In navigation bar" => "left"], "<br>Position: ");
+        $sb->add_int_option("blotter_recent", "Number of recent entries to display: ");
+        $sb->add_text_option("blotter_color", "Color of important updates: (ABCDEF format)");
+        $sb->add_choice_option("blotter_position", ["Top of page" => "subheading", "In navigation bar" => "left"], "Position: ");
     }
 
     public function onPageSubNavBuilding(PageSubNavBuildingEvent $event)

--- a/ext/bulk_download/main.php
+++ b/ext/bulk_download/main.php
@@ -32,9 +32,7 @@ class BulkDownload extends Extension
     {
         $sb = $event->panel->create_new_block("Bulk Download");
 
-        $sb->start_table();
-        $sb->add_shorthand_int_option(BulkDownloadConfig::SIZE_LIMIT, "Size Limit", true);
-        $sb->end_table();
+        $sb->add_shorthand_int_option(BulkDownloadConfig::SIZE_LIMIT, "Size Limit");
     }
 
     public function onBulkAction(BulkActionEvent $event)

--- a/ext/comment/main.php
+++ b/ext/comment/main.php
@@ -358,19 +358,14 @@ class CommentList extends Extension
     {
         $sb = $event->panel->create_new_block("Comment Options");
         $sb->add_bool_option("comment_captcha", "Require CAPTCHA for anonymous comments: ");
-        $sb->add_label("<br>Limit to ");
-        $sb->add_int_option("comment_limit");
-        $sb->add_label(" comments per ");
-        $sb->add_int_option("comment_window");
-        $sb->add_label(" minutes");
-        $sb->add_label("<br>Show ");
-        $sb->add_int_option("comment_count");
-        $sb->add_label(" recent comments on the index");
-        $sb->add_label("<br>Show ");
-        $sb->add_int_option("comment_list_count");
-        $sb->add_label(" comments per image on the list");
-        $sb->add_label("<br>Make samefags public ");
-        $sb->add_bool_option("comment_samefags_public");
+
+        $sb->add_int_option("comment_limit", "Limit to ", " comments");
+        $sb->add_int_option("comment_window", "per", " minutes.");
+
+        $sb->add_int_option("comment_count", "Show ", "recent comments on the index.");
+        $sb->add_int_option("comment_list_count", "Show ", " comments per image on the list.");
+
+        $sb->add_bool_option("comment_samefags_public", "Make samefags public ");
     }
 
     public function onSearchTermParse(SearchTermParseEvent $event)

--- a/ext/cron_uploader/main.php
+++ b/ext/cron_uploader/main.php
@@ -34,19 +34,17 @@ class CronUploader extends Extension
             $documentation_link = make_http(make_link("cron_upload"));
 
             $sb = $event->panel->create_new_block("Cron Uploader");
-            $sb->start_table();
-            $sb->add_text_option(CronUploaderConfig::DIR, "Root dir", true);
-            $sb->add_bool_option(CronUploaderConfig::STOP_ON_ERROR, "Stop On Error", true);
+            $sb->add_text_option(CronUploaderConfig::DIR, "Root dir");
+            $sb->add_bool_option(CronUploaderConfig::STOP_ON_ERROR, "Stop On Error");
             $sb->add_choice_option(CronUploaderConfig::LOG_LEVEL, [
             LOGGING_LEVEL_NAMES[SCORE_LOG_DEBUG] => SCORE_LOG_DEBUG,
             LOGGING_LEVEL_NAMES[SCORE_LOG_INFO] => SCORE_LOG_INFO,
             LOGGING_LEVEL_NAMES[SCORE_LOG_WARNING] => SCORE_LOG_WARNING,
             LOGGING_LEVEL_NAMES[SCORE_LOG_ERROR] => SCORE_LOG_ERROR,
             LOGGING_LEVEL_NAMES[SCORE_LOG_CRITICAL] => SCORE_LOG_CRITICAL,
-        ], "Output Log Level: ", true);
-            $sb->add_bool_option(CronUploaderConfig::INCLUDE_ALL_LOGS, "Include All Logs", true);
-            $sb->end_table();
-            $sb->add_label("<a href='$documentation_link'>Read the documentation</a> for cron setup instructions.");
+        ], "Output Log Level: ");
+            $sb->add_bool_option(CronUploaderConfig::INCLUDE_ALL_LOGS, "Include All Logs");
+            $sb->add_label("<a href='$documentation_link'>Read the documentation</a> for cron setup instructions.", true);
         }
     }
 

--- a/ext/custom_html_headers/main.php
+++ b/ext/custom_html_headers/main.php
@@ -10,7 +10,7 @@ class CustomHtmlHeaders extends Extension
         // custom headers
         $sb->add_longtext_option(
             "custom_html_headers",
-            "HTML Code to place within &lt;head&gt;&lt;/head&gt; on all pages<br>"
+            "HTML Code to place within &lt;head&gt;&lt;/head&gt; on all pages"
         );
 
         // modified title
@@ -18,7 +18,7 @@ class CustomHtmlHeaders extends Extension
             "none" => "none",
             "as prefix" => "prefix",
             "as suffix" => "suffix"
-        ], "<br>Add website name in title");
+        ], "Add website name in title");
     }
 
     public function onInitExt(InitExtEvent $event)

--- a/ext/downtime/main.php
+++ b/ext/downtime/main.php
@@ -14,7 +14,7 @@ class Downtime extends Extension
     {
         $sb = $event->panel->create_new_block("Downtime");
         $sb->add_bool_option("downtime", "Disable non-admin access: ");
-        $sb->add_longtext_option("downtime_message", "<br>");
+        $sb->add_longtext_option("downtime_message", "Downtime Message:");
     }
 
     public function onPageRequest(PageRequestEvent $event)

--- a/ext/eokm/main.php
+++ b/ext/eokm/main.php
@@ -41,9 +41,7 @@ class Eokm extends Extension
     {
         $sb = $event->panel->create_new_block("EOKM Filter");
 
-        $sb->start_table();
-        $sb->add_text_option("eokm_username", "Username", true);
-        $sb->add_text_option("eokm_password", "Password", true);
-        $sb->end_table();
+        $sb->add_text_option("eokm_username", "Username");
+        $sb->add_text_option("eokm_password", "Password");
     }
 }

--- a/ext/forum/main.php
+++ b/ext/forum/main.php
@@ -64,10 +64,10 @@ class Forum extends Extension
     {
         $sb = $event->panel->create_new_block("Forum");
         $sb->add_int_option("forumTitleSubString", "Title max long: ");
-        $sb->add_int_option("forumThreadsPerPage", "<br>Threads per page: ");
-        $sb->add_int_option("forumPostsPerPage", "<br>Posts per page: ");
+        $sb->add_int_option("forumThreadsPerPage", "Threads per page: ");
+        $sb->add_int_option("forumPostsPerPage", "Posts per page: ");
 
-        $sb->add_int_option("forumMaxCharsPerPost", "<br>Max chars per post: ");
+        $sb->add_int_option("forumMaxCharsPerPost", "Max chars per post: ");
     }
 
     public function onUserPageBuilding(UserPageBuildingEvent $event)

--- a/ext/google_analytics/main.php
+++ b/ext/google_analytics/main.php
@@ -6,8 +6,7 @@ class GoogleAnalytics extends Extension
     public function onSetupBuilding(SetupBuildingEvent $event)
     {
         $sb = $event->panel->create_new_block("Google Analytics");
-        $sb->add_text_option("google_analytics_id", "Analytics ID: ");
-        $sb->add_label("<br>(eg. UA-xxxxxxxx-x)");
+        $sb->add_text_option("google_analytics_id", "Analytics ID: ", "(eg. UA-xxxxxxxx-x)");
     }
 
     # Load Analytics tracking code on page request

--- a/ext/handle_archive/main.php
+++ b/ext/handle_archive/main.php
@@ -14,8 +14,7 @@ class ArchiveFileHandler extends DataHandlerExtension
     {
         $sb = $event->panel->create_new_block("Archive Handler Options");
         $sb->add_text_option("archive_tmp_dir", "Temporary folder: ");
-        $sb->add_text_option("archive_extract_command", "<br>Extraction command: ");
-        $sb->add_label("<br>%f for archive, %d for temporary directory");
+        $sb->add_text_option("archive_extract_command", "Extraction command: ", "%f for archive, %d for temporary directory");
     }
 
     public function onDataUpload(DataUploadEvent $event)

--- a/ext/handle_video/main.php
+++ b/ext/handle_video/main.php
@@ -47,12 +47,10 @@ class VideoFileHandler extends DataHandlerExtension
     public function onSetupBuilding(SetupBuildingEvent $event)
     {
         $sb = $event->panel->create_new_block("Video Options");
-        $sb->start_table();
-        $sb->add_bool_option(VideoFileHandlerConfig::PLAYBACK_AUTOPLAY, "Autoplay", true);
-        $sb->add_bool_option(VideoFileHandlerConfig::PLAYBACK_LOOP, "Loop", true);
-        $sb->add_bool_option(VideoFileHandlerConfig::PLAYBACK_MUTE, "Mute", true);
-        $sb->add_multichoice_option(VideoFileHandlerConfig::ENABLED_FORMATS, $this->get_options(), "Enabled Formats", true);
-        $sb->end_table();
+        $sb->add_bool_option(VideoFileHandlerConfig::PLAYBACK_AUTOPLAY, "Autoplay");
+        $sb->add_bool_option(VideoFileHandlerConfig::PLAYBACK_LOOP, "Loop");
+        $sb->add_bool_option(VideoFileHandlerConfig::PLAYBACK_MUTE, "Mute");
+        $sb->add_multichoice_option(VideoFileHandlerConfig::ENABLED_FORMATS, $this->get_options(), "Enabled Formats");
     }
 
     protected function media_check_properties(MediaCheckPropertiesEvent $event): void

--- a/ext/home/main.php
+++ b/ext/home/main.php
@@ -29,8 +29,8 @@ class Home extends Extension
 
         $sb = $event->panel->create_new_block("Home Page");
         $sb->add_longtext_option("home_links", 'Page Links (Use BBCode, leave blank for defaults)');
-        $sb->add_longtext_option("home_text", "<br>Page Text:<br>");
-        $sb->add_choice_option("home_counter", $counters, "<br>Counter: ");
+        $sb->add_longtext_option("home_text", "Page Text:");
+        $sb->add_choice_option("home_counter", $counters, "Counter: ");
     }
 
 

--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -259,42 +259,38 @@ class ImageIO extends Extension
         global $config;
 
         $sb = $event->panel->create_new_block("Post Options");
-        $sb->start_table();
         $sb->position = 30;
         // advanced only
         //$sb->add_text_option(ImageConfig::ILINK, "Image link: ");
         //$sb->add_text_option(ImageConfig::TLINK, "<br>Thumbnail link: ");
-        $sb->add_text_option(ImageConfig::TIP, "Post tooltip", true);
-        $sb->add_text_option(ImageConfig::INFO, "Post info", true);
-        $sb->add_choice_option(ImageConfig::UPLOAD_COLLISION_HANDLER, self::COLLISION_OPTIONS, "Upload collision handler", true);
-        $sb->add_choice_option(ImageConfig::ON_DELETE, self::ON_DELETE_OPTIONS, "On Delete", true);
+        $sb->add_text_option(ImageConfig::TIP, "Post tooltip");
+        $sb->add_text_option(ImageConfig::INFO, "Post info");
+        $sb->add_choice_option(ImageConfig::UPLOAD_COLLISION_HANDLER, self::COLLISION_OPTIONS, "Upload collision handler");
+        $sb->add_choice_option(ImageConfig::ON_DELETE, self::ON_DELETE_OPTIONS, "On Delete");
         if (function_exists(self::EXIF_READ_FUNCTION)) {
-            $sb->add_bool_option(ImageConfig::SHOW_META, "Show metadata", true);
+            $sb->add_bool_option(ImageConfig::SHOW_META, "Show metadata");
         }
-        $sb->end_table();
 
         $sb = $event->panel->create_new_block("Thumbnailing");
-        $sb->start_table();
-        $sb->add_choice_option(ImageConfig::THUMB_ENGINE, self::THUMBNAIL_ENGINES, "Engine", true);
-        $sb->add_choice_option(ImageConfig::THUMB_MIME, self::THUMBNAIL_TYPES, "Filetype", true);
+        $sb->add_choice_option(ImageConfig::THUMB_ENGINE, self::THUMBNAIL_ENGINES, "Engine");
+        $sb->add_choice_option(ImageConfig::THUMB_MIME, self::THUMBNAIL_TYPES, "Filetype");
 
-        $sb->add_int_option(ImageConfig::THUMB_WIDTH, "Max Width", true);
-        $sb->add_int_option(ImageConfig::THUMB_HEIGHT, "Max Height", true);
+        $sb->add_int_option(ImageConfig::THUMB_WIDTH, "Max Width");
+        $sb->add_int_option(ImageConfig::THUMB_HEIGHT, "Max Height");
 
         $options = [];
         foreach (MediaEngine::RESIZE_TYPE_SUPPORT[$config->get_string(ImageConfig::THUMB_ENGINE)] as $type) {
             $options[$type] = $type;
         }
 
-        $sb->add_choice_option(ImageConfig::THUMB_FIT, $options, "Fit", true);
+        $sb->add_choice_option(ImageConfig::THUMB_FIT, $options, "Fit");
 
-        $sb->add_int_option(ImageConfig::THUMB_QUALITY, "Quality", true);
-        $sb->add_int_option(ImageConfig::THUMB_SCALING, "High-DPI Scale %", true);
+        $sb->add_int_option(ImageConfig::THUMB_QUALITY, "Quality");
+        $sb->add_int_option(ImageConfig::THUMB_SCALING, "High-DPI Scale %");
         if ($config->get_string(ImageConfig::THUMB_MIME)===MimeType::JPEG) {
-            $sb->add_color_option(ImageConfig::THUMB_ALPHA_COLOR, "Alpha Conversion Color", true);
+            $sb->add_color_option(ImageConfig::THUMB_ALPHA_COLOR, "Alpha Conversion Color");
         }
 
-        $sb->end_table();
     }
 
     public function onParseLinkTemplate(ParseLinkTemplateEvent $event)

--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -290,7 +290,6 @@ class ImageIO extends Extension
         if ($config->get_string(ImageConfig::THUMB_MIME)===MimeType::JPEG) {
             $sb->add_color_option(ImageConfig::THUMB_ALPHA_COLOR, "Alpha Conversion Color");
         }
-
     }
 
     public function onParseLinkTemplate(ParseLinkTemplateEvent $event)

--- a/ext/image_view_counter/main.php
+++ b/ext/image_view_counter/main.php
@@ -63,10 +63,7 @@ class ImageViewCounter extends Extension
                 ["image_id" => $event->image->id]
             );
 
-            $event->add_part(
-                "<tr><th>Views:</th><td>$view_count</td></tr>",
-                38
-            );
+            $event->add_part($view_count, 38, "Views:");
         }
     }
 

--- a/ext/image_view_counter/main.php
+++ b/ext/image_view_counter/main.php
@@ -63,7 +63,7 @@ class ImageViewCounter extends Extension
                 ["image_id" => $event->image->id]
             );
 
-            $event->add_part($view_count, 38, "Views:");
+            $event->add_part([$view_count], 38, "Views:");
         }
     }
 

--- a/ext/index/main.php
+++ b/ext/index/main.php
@@ -123,9 +123,7 @@ class Index extends Extension
         $sb = $event->panel->create_new_block("Index Options");
         $sb->position = 20;
 
-        $sb->add_label("Show ");
-        $sb->add_int_option(IndexConfig::IMAGES);
-        $sb->add_label(" images on the post list");
+        $sb->add_int_option(IndexConfig::IMAGES, "Show ", " images on the post list");
     }
 
     public function onPageNavBuilding(PageNavBuildingEvent $event)

--- a/ext/ipban/main.php
+++ b/ext/ipban/main.php
@@ -210,13 +210,14 @@ class IPBan extends Extension
         global $config;
 
         $sb = $event->panel->create_new_block("IP Ban");
-        $sb->add_longtext_option("ipban_message", 'Message to show to banned users:<br>(with $IP, $DATE, $ADMIN, $REASON, and $CONTACT)');
+        $sb->add_longtext_option("ipban_message", 'Message to show to banned users:');
         if ($config->get_string("ipban_message_ghost")) {
             $sb->add_longtext_option("ipban_message_ghost", 'Message to show to ghost users:');
         }
         if ($config->get_string("ipban_message_anon-ghost")) {
             $sb->add_longtext_option("ipban_message_anon-ghost", 'Message to show to ghost anons:');
         }
+        $sb->add_label('Flags: $IP, $DATE, $ADMIN, $REASON, $CONTACT', true);
     }
 
     public function onPageSubNavBuilding(PageSubNavBuildingEvent $event)

--- a/ext/media/main.php
+++ b/ext/media/main.php
@@ -90,17 +90,15 @@ class Media extends Extension
 //                $sb->add_label("<b style='color:red'>ImageMagick not detected</b>");
 //            }
 //        } else {
-        $sb->start_table();
-        $sb->add_table_header("Commands");
+        $sb->add_header("Commands");
 
-        $sb->add_text_option(MediaConfig::CONVERT_PATH, "convert", true);
+        $sb->add_text_option(MediaConfig::CONVERT_PATH, "convert");
 //        }
 
-        $sb->add_text_option(MediaConfig::FFMPEG_PATH, "ffmpeg", true);
-        $sb->add_text_option(MediaConfig::FFPROBE_PATH, "ffprobe", true);
+        $sb->add_text_option(MediaConfig::FFMPEG_PATH, "ffmpeg");
+        $sb->add_text_option(MediaConfig::FFPROBE_PATH, "ffprobe");
 
-        $sb->add_shorthand_int_option(MediaConfig::MEM_LIMIT, "Mem limit", true);
-        $sb->end_table();
+        $sb->add_shorthand_int_option(MediaConfig::MEM_LIMIT, "Mem limit");
     }
 
     public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event)

--- a/ext/pools/main.php
+++ b/ext/pools/main.php
@@ -177,13 +177,13 @@ class Pools extends Extension
     {
         $sb = $event->panel->create_new_block("Pools");
         $sb->add_int_option(PoolsConfig::MAX_IMPORT_RESULTS, "Max results on import: ");
-        $sb->add_int_option(PoolsConfig::IMAGES_PER_PAGE, "<br>Posts per page: ");
-        $sb->add_int_option(PoolsConfig::LISTS_PER_PAGE, "<br>Index list items per page: ");
-        $sb->add_int_option(PoolsConfig::UPDATED_PER_PAGE, "<br>Updated list items per page: ");
-        $sb->add_bool_option(PoolsConfig::INFO_ON_VIEW_IMAGE, "<br>Show pool info on image: ");
-        $sb->add_bool_option(PoolsConfig::SHOW_NAV_LINKS, "<br>Show 'Prev' & 'Next' links when viewing pool images: ");
-        $sb->add_bool_option(PoolsConfig::AUTO_INCREMENT_ORDER, "<br>Autoincrement order when post is added to pool:");
-        //$sb->add_bool_option(PoolsConfig::ADDER_ON_VIEW_IMAGE, "<br>Show pool adder on image: ");
+        $sb->add_int_option(PoolsConfig::IMAGES_PER_PAGE, "Posts per page: ");
+        $sb->add_int_option(PoolsConfig::LISTS_PER_PAGE, "Index list items per page: ");
+        $sb->add_int_option(PoolsConfig::UPDATED_PER_PAGE, "Updated list items per page: ");
+        $sb->add_bool_option(PoolsConfig::INFO_ON_VIEW_IMAGE, "Show pool info on image: ");
+        $sb->add_bool_option(PoolsConfig::SHOW_NAV_LINKS, "Show 'Prev' & 'Next' links when viewing pool images: ");
+        $sb->add_bool_option(PoolsConfig::AUTO_INCREMENT_ORDER, "Autoincrement order when post is added to pool:");
+        //$sb->add_bool_option(PoolsConfig::ADDER_ON_VIEW_IMAGE, "Show pool adder on image: ");
     }
 
     public function onPageNavBuilding(PageNavBuildingEvent $event)

--- a/ext/post_titles/main.php
+++ b/ext/post_titles/main.php
@@ -44,7 +44,7 @@ class PostTitles extends Extension
     {
         global $user;
 
-        $event->add_part($this->theme->get_title_set_html(self::get_title($event->image), $user->can(Permissions::EDIT_IMAGE_TITLE)), 10);
+        $event->add_part($this->theme->get_title_set_html(self::get_title($event->image), $user->can(Permissions::EDIT_IMAGE_TITLE)), 10, "Title");
     }
 
     public function onImageInfoSet(ImageInfoSetEvent $event)

--- a/ext/post_titles/main.php
+++ b/ext/post_titles/main.php
@@ -65,10 +65,8 @@ class PostTitles extends Extension
     public function onSetupBuilding(SetupBuildingEvent $event)
     {
         $sb = $event->panel->create_new_block("Post Titles");
-        $sb->start_table();
-        $sb->add_bool_option(PostTitlesConfig::DEFAULT_TO_FILENAME, "Default to filename", true);
-        $sb->add_bool_option(PostTitlesConfig::SHOW_IN_WINDOW_TITLE, "Show in window title", true);
-        $sb->end_table();
+        $sb->add_bool_option(PostTitlesConfig::DEFAULT_TO_FILENAME, "Default to filename");
+        $sb->add_bool_option(PostTitlesConfig::SHOW_IN_WINDOW_TITLE, "Show in window title");
     }
 
     public function onBulkExport(BulkExportEvent $event)

--- a/ext/post_titles/main.php
+++ b/ext/post_titles/main.php
@@ -44,7 +44,7 @@ class PostTitles extends Extension
     {
         global $user;
 
-        $event->add_part($this->theme->get_title_set_html(self::get_title($event->image), $user->can(Permissions::EDIT_IMAGE_TITLE)), 10, "Title");
+        $event->add_part([$this->theme->get_title_set_html(self::get_title($event->image), $user->can(Permissions::EDIT_IMAGE_TITLE))], 10, "Title");
     }
 
     public function onImageInfoSet(ImageInfoSetEvent $event)

--- a/ext/post_titles/theme.php
+++ b/ext/post_titles/theme.php
@@ -3,19 +3,12 @@ class PostTitlesTheme extends Themelet
 {
     public function get_title_set_html(string $title, bool $can_set): string
     {
-        $html = "
-			<tr>
-				<th>Title</th>
-				<td>
-		".($can_set ? "
+        $html = ($can_set ? "
 					<span class='view'>".html_escape($title)."</span>
 						<input class='edit'  type='text' name='post_title' value='".html_escape($title)."' />
 		" : html_escape("
 					 $title
-		"))."
-				</td>
-			</tr>
-		";
+		"));
         return $html;
     }
 }

--- a/ext/private_image/main.php
+++ b/ext/private_image/main.php
@@ -26,10 +26,8 @@ class PrivateImage extends Extension
     public function onUserOptionsBuilding(UserOptionsBuildingEvent $event)
     {
         $sb = $event->panel->create_new_block("Private Posts");
-        $sb->start_table();
-        $sb->add_bool_option(PrivateImageConfig::USER_SET_DEFAULT, "Mark posts private by default", true);
-        $sb->add_bool_option(PrivateImageConfig::USER_VIEW_DEFAULT, "View private posts by default", true);
-        $sb->end_table();
+        $sb->add_bool_option(PrivateImageConfig::USER_SET_DEFAULT, "Mark posts private by default");
+        $sb->add_bool_option(PrivateImageConfig::USER_VIEW_DEFAULT, "View private posts by default");
     }
 
     public function onPageRequest(PageRequestEvent $event)

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -143,10 +143,8 @@ class Ratings extends Extension
         }
 
         $sb = $event->panel->create_new_block("Default Rating Filter");
-        $sb->start_table();
-        $sb->add_multichoice_option(RatingsConfig::USER_DEFAULTS, $options, "Output Log Level: ", true);
-        $sb->end_table();
-        $sb->add_label("This controls the default rating search results will be filtered by, and nothing else. To override in your search results, add rating:* to your search.");
+        $sb->add_multichoice_option(RatingsConfig::USER_DEFAULTS, $options, "Output Log Level: ");
+        $sb->add_label("This controls the default rating search results will be filtered by, and nothing else. To override in your search results, add rating:* to your search.", true);
     }
 
     public function onSetupBuilding(SetupBuildingEvent $event)
@@ -161,14 +159,12 @@ class Ratings extends Extension
         }
 
         $sb = $event->panel->create_new_block("Post Ratings");
-        $sb->start_table();
         foreach (array_keys($_shm_user_classes) as $key) {
             if ($key == "base" || $key == "hellbanned") {
                 continue;
             }
-            $sb->add_multichoice_option("ext_rating_" . $key . "_privs", $options, $key, true);
+            $sb->add_multichoice_option("ext_rating_" . $key . "_privs", $options, $key);
         }
-        $sb->end_table();
     }
 
     public function onDisplayingImage(DisplayingImageEvent $event)

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -215,7 +215,8 @@ class Ratings extends Extension
                 $event->image->rating,
                 $user->can(Permissions::EDIT_IMAGE_RATING)
             ),
-            80
+            80,
+            "Rating"
         );
     }
 

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -206,11 +206,11 @@ class Ratings extends Extension
     {
         global $user;
         $event->add_part(
-            $this->theme->get_rater_html(
+            [$this->theme->get_rater_html(
                 $event->image->id,
                 $event->image->rating,
                 $user->can(Permissions::EDIT_IMAGE_RATING)
-            ),
+            )],
             80,
             "Rating"
         );

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -5,21 +5,14 @@ class RatingsTheme extends Themelet
     public function get_rater_html(int $image_id, string $rating, bool $can_rate): string
     {
         $human_rating = Ratings::rating_to_human($rating);
-        $html = "
-			<tr>
-				<th>Rating</th>
-				<td>
-		".($can_rate ? "
+        $html = ($can_rate ? "
 					<span class='view'>$human_rating</span>
 					<span class='edit'>
 						".$this->get_selection_rater_html([$rating])."
 					</span>
 		" : "
 					$human_rating
-		")."
-				</td>
-			</tr>
-		";
+		");
         return $html;
     }
 

--- a/ext/relationships/main.php
+++ b/ext/relationships/main.php
@@ -125,7 +125,7 @@ class Relationships extends Extension
 
     public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event)
     {
-        $event->add_part($this->theme->get_parent_editor_html($event->image), 45);
+        $event->add_part($this->theme->get_parent_editor_html($event->image), 45, "Parent");
     }
 
     public function onImageDeletion(ImageDeletionEvent $event)

--- a/ext/relationships/main.php
+++ b/ext/relationships/main.php
@@ -125,7 +125,7 @@ class Relationships extends Extension
 
     public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event)
     {
-        $event->add_part($this->theme->get_parent_editor_html($event->image), 45, "Parent");
+        $event->add_part([$this->theme->get_parent_editor_html($event->image)], 45, "Parent");
     }
 
     public function onImageDeletion(ImageDeletionEvent $event)

--- a/ext/relationships/theme.php
+++ b/ext/relationships/theme.php
@@ -32,18 +32,13 @@ class RelationshipsTheme extends Themelet
         $h_parent_id = $image->parent_id;
         $s_parent_id = $h_parent_id ?: "None";
 
-        $html = "<tr>\n".
-                "	<th>Parent</th>\n".
-                "	<td>\n".
-                (
+        $html = (
                     !$user->is_anonymous() ?
                     "		<span class='view' style='overflow: hidden; white-space: nowrap;'>{$s_parent_id}</span>\n".
                     "		<input class='edit' type='number' name='tag_edit__parent' type='number' value='{$h_parent_id}'>\n"
                 :
                     $s_parent_id
-                ).
-                "	<td>\n".
-                "</tr>\n";
+                );
         return $html;
     }
 

--- a/ext/relationships/theme.php
+++ b/ext/relationships/theme.php
@@ -33,12 +33,12 @@ class RelationshipsTheme extends Themelet
         $s_parent_id = $h_parent_id ?: "None";
 
         $html = (
-                    !$user->is_anonymous() ?
+            !$user->is_anonymous() ?
                     "		<span class='view' style='overflow: hidden; white-space: nowrap;'>{$s_parent_id}</span>\n".
                     "		<input class='edit' type='number' name='tag_edit__parent' type='number' value='{$h_parent_id}'>\n"
                 :
                     $s_parent_id
-                );
+        );
         return $html;
     }
 

--- a/ext/res_limit/main.php
+++ b/ext/res_limit/main.php
@@ -60,22 +60,18 @@ class ResolutionLimit extends Extension
     {
         $sb = $event->panel->create_new_block("Resolution Limits");
 
-        $sb->add_label("Min ");
-        $sb->add_int_option("upload_min_width");
-        $sb->add_label(" x ");
-        $sb->add_int_option("upload_min_height");
-        $sb->add_label(" px");
+        //TODO: Allow two fields in one row.
+        $sb->add_header("Minimum Resolution");
+        $sb->add_int_option("upload_min_width", "Min Width", " px");
+        $sb->add_int_option("upload_min_height", "Min Height", " px");
+        $sb->add_label("(-1 for no limit)", true);
 
-        $sb->add_label("<br>Max ");
-        $sb->add_int_option("upload_max_width");
-        $sb->add_label(" x ");
-        $sb->add_int_option("upload_max_height");
-        $sb->add_label(" px");
+        $sb->add_header("Maximum Resolution");
+        $sb->add_int_option("upload_max_width", "Max Width", " px");
+        $sb->add_int_option("upload_max_height", "Max Height", " px");
 
-        $sb->add_label("<br>(-1 for no limit)");
+        $sb->add_label("(-1 for no limit)", true);
 
-        $sb->add_label("<br>Ratios ");
-        $sb->add_text_option("upload_ratios");
-        $sb->add_label("<br>(eg. '4:3 16:9', blank for no limit)");
+        $sb->add_text_option("upload_ratios", "Ratios", "(eg. '4:3 16:9', blank for no limit)");
     }
 }

--- a/ext/resize/main.php
+++ b/ext/resize/main.php
@@ -51,22 +51,15 @@ class ResizeImage extends Extension
     public function onSetupBuilding(SetupBuildingEvent $event)
     {
         $sb = $event->panel->create_new_block("Image Resize");
-        $sb->start_table();
-        $sb->add_choice_option(ResizeConfig::ENGINE, MediaEngine::IMAGE_ENGINES, "Engine", true);
-        $sb->add_bool_option(ResizeConfig::ENABLED, "Allow resizing images", true);
-        $sb->add_bool_option(ResizeConfig::GET_ENABLED, "Allow GET args", true);
-        $sb->add_bool_option(ResizeConfig::UPLOAD, "Resize on upload", true);
-        $sb->end_table();
-        $sb->start_table();
-        $sb->add_table_header("Preset/Default Dimensions");
-        $sb->add_label("<tr><th>Width</th><td>");
-        $sb->add_int_option(ResizeConfig::DEFAULT_WIDTH);
-        $sb->add_label("</td><td>px</td></tr>");
-        $sb->add_label("<tr><th>Height</th><td>");
-        $sb->add_int_option(ResizeConfig::DEFAULT_HEIGHT);
-        $sb->add_label("</td><td>px</td></tr>");
-        $sb->add_label("<tr><td></td><td>(enter 0 for no default)</td></tr>");
-        $sb->end_table();
+        $sb->add_choice_option(ResizeConfig::ENGINE, MediaEngine::IMAGE_ENGINES, "Engine");
+        $sb->add_bool_option(ResizeConfig::ENABLED, "Allow resizing images");
+        $sb->add_bool_option(ResizeConfig::GET_ENABLED, "Allow GET args");
+        $sb->add_bool_option(ResizeConfig::UPLOAD, "Resize on upload");
+
+        $sb->add_header("Preset/Default Dimensions");
+        $sb->add_int_option(ResizeConfig::DEFAULT_WIDTH, "Width: ", " px");
+        $sb->add_int_option(ResizeConfig::DEFAULT_HEIGHT, "Height: ", " px");
+        $sb->add_label("(enter 0 for no default)", true);
     }
 
     public function onDataUpload(DataUploadEvent $event)

--- a/ext/rotate/main.php
+++ b/ext/rotate/main.php
@@ -40,9 +40,7 @@ class RotateImage extends Extension
     {
         $sb = $event->panel->create_new_block("Image Rotate");
         $sb->add_bool_option("rotate_enabled", "Allow rotating images: ");
-        $sb->add_label("<br>Default Orientation: ");
-        $sb->add_int_option("rotate_default_deg");
-        $sb->add_label(" deg");
+        $sb->add_int_option("rotate_default_deg", "Default Orientation: ", " deg");
     }
 
     public function onPageRequest(PageRequestEvent $event)

--- a/ext/rule34/main.php
+++ b/ext/rule34/main.php
@@ -38,7 +38,7 @@ class Rule34 extends Extension
         $url1 = $event->image->parse_link_template($image_link, 1);
         $html = (string)A(["href"=>$url0], "File Only")." (".
                 A(["href"=>$url1], "Backup Server").")";
-        $event->add_part($html, 90, "Links");
+        $event->add_part([$html], 90, "Links");
     }
 
     public function onAdminBuilding(AdminBuildingEvent $event)

--- a/ext/rule34/main.php
+++ b/ext/rule34/main.php
@@ -36,16 +36,9 @@ class Rule34 extends Extension
         $image_link = $config->get_string(ImageConfig::ILINK);
         $url0 = $event->image->parse_link_template($image_link, 0);
         $url1 = $event->image->parse_link_template($image_link, 1);
-        $html = (string)TR(
-            TH("Links"),
-            TD(
-                A(["href"=>$url0], "File Only"),
-                " (",
-                A(["href"=>$url1], "Backup Server"),
-                ")"
-            )
-        );
-        $event->add_part($html, 90);
+        $html = (string)A(["href"=>$url0], "File Only")." (".
+                A(["href"=>$url1], "Backup Server").")";
+        $event->add_part($html, 90, "Links");
     }
 
     public function onAdminBuilding(AdminBuildingEvent $event)

--- a/ext/setup/main.php
+++ b/ext/setup/main.php
@@ -72,11 +72,13 @@ class SetupBlock extends Block
         $this->body .= $this->theme->format_item($text, null, null, false, $full_width);
     }
 
-    public function add_header(string $text) {
+    public function add_header(string $text)
+    {
         $this->body .= $this->theme->format_item($text, null, null, true);
     }
 
-    protected function add_option(?string $label, ?string $html, ?string $name, bool $label_is_header=false, bool $full_width=false) {
+    protected function add_option(?string $label, ?string $html, ?string $name, bool $label_is_header=false, bool $full_width=false)
+    {
         $this->body .= $this->theme->format_item($label, $html, $name, $label_is_header, $full_width);
     }
 
@@ -290,8 +292,11 @@ class Setup extends Extension
         $sb->add_text_option("contact_link", "Contact URL: ");
         $sb->add_choice_option(SetupConfig::THEME, $themes, "Theme: ");
         //$sb->add_multichoice_option("testarray", array("a" => "b", "c" => "d"), "Test Array: ");
-        $sb->add_bool_option("nice_urls", "Nice URLs: ",
-            "<span title='$test_url' id='nicetest'>(Javascript inactive, can't test!)</span>$nicescript");
+        $sb->add_bool_option(
+            "nice_urls",
+            "Nice URLs: ",
+            "<span title='$test_url' id='nicetest'>(Javascript inactive, can't test!)</span>$nicescript"
+        );
 
         $sb = $event->panel->create_new_block("Remote API Integration");
         $sb->add_label("<a href='https://akismet.com/'>Akismet</a>", true);

--- a/ext/setup/main.php
+++ b/ext/setup/main.php
@@ -67,7 +67,7 @@ class SetupBlock extends Block
         $this->theme = $theme;
     }
 
-    public function add_label(string $text)
+    public function add_label(string $text, bool $is_header=false)
     {
         $this->body .= $text;
     }
@@ -76,62 +76,28 @@ class SetupBlock extends Block
     {
         $this->body .= "<table class='form'>";
     }
+
     public function end_table()
     {
         $this->body .= "</table>";
     }
-    public function start_table_row()
-    {
-        $this->body .= "<tr>";
-    }
-    public function end_table_row()
-    {
-        $this->body .= "</tr>";
-    }
-    public function start_table_head()
-    {
-        $this->body .= "<thead>";
-    }
-    public function end_table_head()
-    {
-        $this->body .= "</thead>";
-    }
+
     public function add_table_header($content, int $colspan = 2)
     {
-        $this->start_table_head();
-        $this->start_table_row();
-        $this->add_table_header_cell($content, $colspan);
-        $this->end_table_row();
-        $this->end_table_head();
+        $this->body .= "<thead>";
+        $this->body .= "<tr>";
+        $this->body .= "<th colspan='$colspan' style='text-align: right'>";
+        $this->body .= $content;
+        $this->body .= "</th>";
+        $this->body .= "</tr>";
+        $this->body .= "</thead>";
     }
 
-    public function start_table_cell(int $colspan = 1)
-    {
-        $this->body .= "<td colspan='$colspan'>";
-    }
-    public function end_table_cell()
-    {
-        $this->body .= "</td>";
-    }
-    public function add_table_cell($content, int $colspan = 1)
-    {
-        $this->start_table_cell($colspan);
-        $this->body .= $content;
-        $this->end_table_cell();
-    }
-    public function start_table_header_cell(int $colspan = 1, string $align = 'right')
-    {
-        $this->body .= "<th colspan='$colspan' style='text-align: $align'>";
-    }
-    public function end_table_header_cell()
-    {
-        $this->body .= "</th>";
-    }
     public function add_table_header_cell($content, int $colspan = 1)
     {
-        $this->start_table_header_cell($colspan);
+        $this->body .= "<th colspan='$colspan' style='text-align: right'>";
         $this->body .= $content;
-        $this->end_table_header_cell();
+        $this->body .= "</th>";
     }
 
     public function add_text_option(string $name, string $label=null, bool $table_row = false)

--- a/ext/setup/theme.php
+++ b/ext/setup/theme.php
@@ -89,7 +89,7 @@ class SetupTheme extends Themelet
     protected function sb_to_html(SetupBlock $block): string
     {
         $h = $block->header;
-        $b = $block->body;
+        $b = $this->build_setup_chunk($block->body);
         $i = preg_replace('/[^a-zA-Z0-9]/', '_', $h) . "-setup";
         $html = "
 			<section class='setupblock'>
@@ -100,35 +100,55 @@ class SetupTheme extends Themelet
         return $html;
     }
 
-    public function format_option(string $name, $html, ?string $label, bool $table_row, bool $label_row = false): string
+    protected function build_setup_chunk(string $html): string
     {
-        $output = "";
-        if ($table_row) {
-            $output .= "<tr><th colspan='".($label_row ? 2 : 1)."' style='text-align: ".($label_row ? 'center' : 'right')."'>";
+        return "<table class='form'>$html</table>";
+    }
+
+    protected function build_setup_row(string $html): string
+    {
+        return "<tr>$html</tr>";
+    }
+
+    protected function build_setup_cell(string $html, bool $is_header=false, bool $full_width=false): string
+    {
+        $colspan = ($is_header || $full_width ? 2 : 1);
+        if ($is_header) {
+            return $this->build_setup_row("<th colspan='$colspan'>$html</th>");
+        } else {
+            if ($full_width) {
+                return $this->build_setup_row("<td colspan='$colspan'>$html</td>");
+            } else {
+                return "<td colspan='$colspan'>$html</td>";
+            }
         }
-        if (!is_null($label)) {
-            $output .= "<label for='{$name}'>{$label}</label>";
+    }
+
+    public function format_item(?string $label, ?string $html, ?string $config_name, bool $label_is_header=false, bool $full_width=false): string
+    {
+        if (empty($label) && empty($html)) {
+            return "";
         }
 
-        if ($table_row) {
-            $output .= "</th>";
+        if (!empty($label)) {
+            if (!empty($config_name)) {
+                $label = "<label for='{$config_name}'>{$label}</label>";
+            }
+            $label = $this->build_setup_cell($label, $label_is_header, $full_width);
+        } else {
+            $label = "";
         }
 
-        if ($table_row && $label_row) {
-            $output .= "</tr><tr>";
+        if (!empty($html)) {
+            $html = $this->build_setup_cell($html, $label_is_header, $full_width);
+        } else {
+            $html = "";
         }
 
-        if ($table_row) {
-            $output .= "<td colspan='".($label_row ? 2 : 1)."'>";
+        if ($label_is_header) {
+            return $label . $this->build_setup_row($html);
         }
-        $output .= $html;
-        if ($table_row) {
-            $output .= "</td>";
-        }
-        if ($table_row) {
-            $output .= "</tr>";
-        }
-
-        return $output;
+        
+        return $this->build_setup_row($label . $html);
     }
 }

--- a/ext/setup/theme.php
+++ b/ext/setup/theme.php
@@ -140,15 +140,15 @@ class SetupTheme extends Themelet
         }
 
         if (!empty($html)) {
-            $html = $this->build_setup_cell($html, $label_is_header, $full_width);
+            $html = $this->build_setup_cell($html, false, $full_width);
         } else {
             $html = "";
         }
 
-        if ($label_is_header) {
-            return $label . $this->build_setup_row($html);
+        if ($label_is_header || $full_width) {
+            return $label . $html;
         }
-        
+
         return $this->build_setup_row($label . $html);
     }
 }

--- a/ext/setup/theme.php
+++ b/ext/setup/theme.php
@@ -1,5 +1,10 @@
 <?php declare(strict_types=1);
 
+use function MicroHTML\rawHTML;
+use function MicroHTML\TR;
+use function MicroHTML\TH;
+use function MicroHTML\TD;
+
 class SetupTheme extends Themelet
 {
     /*
@@ -107,20 +112,23 @@ class SetupTheme extends Themelet
 
     protected function build_setup_row(string $html): string
     {
-        return "<tr>$html</tr>";
+        return (string)TR(rawHTML($html));
     }
 
     protected function build_setup_cell(string $html, bool $is_header=false, bool $full_width=false): string
     {
-        $colspan = ($is_header || $full_width ? 2 : 1);
+        $attr = ["colspan"=>($is_header || $full_width ? '2' : '1')];
+        $cell = null;
         if ($is_header) {
-            return $this->build_setup_row("<th colspan='$colspan'>$html</th>");
+            $cell = TH($attr, rawHTML($html));
         } else {
-            if ($full_width) {
-                return $this->build_setup_row("<td colspan='$colspan'>$html</td>");
-            } else {
-                return "<td colspan='$colspan'>$html</td>";
-            }
+            $cell = TD($attr, rawHTML($html));
+        }
+
+        if ($is_header || $full_width) {
+            return $this->build_setup_row((string)$cell);
+        } else {
+            return (string)$cell;
         }
     }
 

--- a/ext/setup/theme.php
+++ b/ext/setup/theme.php
@@ -99,4 +99,36 @@ class SetupTheme extends Themelet
 		";
         return $html;
     }
+
+    public function format_option(string $name, $html, ?string $label, bool $table_row, bool $label_row = false): string
+    {
+        $output = "";
+        if ($table_row) {
+            $output .= "<tr><th colspan='".($label_row ? 2 : 1)."' style='text-align: ".($label_row ? 'center' : 'right')."'>";
+        }
+        if (!is_null($label)) {
+            $output .= "<label for='{$name}'>{$label}</label>";
+        }
+
+        if ($table_row) {
+            $output .= "</th>";
+        }
+
+        if ($table_row && $label_row) {
+            $output .= "</tr><tr>";
+        }
+
+        if ($table_row) {
+            $output .= "<td colspan='".($label_row ? 2 : 1)."'>";
+        }
+        $output .= $html;
+        if ($table_row) {
+            $output .= "</td>";
+        }
+        if ($table_row) {
+            $output .= "</tr>";
+        }
+
+        return $output;
+    }
 }

--- a/ext/site_description/main.php
+++ b/ext/site_description/main.php
@@ -19,6 +19,6 @@ class SiteDescription extends Extension
     {
         $sb = $event->panel->create_new_block("Site Description");
         $sb->add_text_option("site_description", "Description: ");
-        $sb->add_text_option("site_keywords", "<br>Keywords: ");
+        $sb->add_text_option("site_keywords", "Keywords: ");
     }
 }

--- a/ext/sitemap/main.php
+++ b/ext/sitemap/main.php
@@ -31,8 +31,8 @@ class XMLSitemap extends Extension
         $sb = $event->panel->create_new_block("Sitemap");
 
         $sb->add_bool_option("sitemap_generatefull", "Generate full sitemap");
-        $sb->add_label("<br>(Enabled: every image and tag in sitemap, generation takes longer)");
-        $sb->add_label("<br>(Disabled: only display the last 50 uploads in the sitemap)");
+        $sb->add_label("(Enabled: every image and tag in sitemap, generation takes longer)", true);
+        $sb->add_label("(Disabled: only display the last 50 uploads in the sitemap)", true);
     }
 
     // sitemap with only the latest 50 images

--- a/ext/tag_edit/main.php
+++ b/ext/tag_edit/main.php
@@ -258,10 +258,10 @@ class TagEdit extends Extension
 
     public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event)
     {
-        $event->add_part($this->theme->get_user_editor_html($event->image), 39);
-        $event->add_part($this->theme->get_tag_editor_html($event->image), 40);
-        $event->add_part($this->theme->get_source_editor_html($event->image), 41);
-        $event->add_part($this->theme->get_lock_editor_html($event->image), 42);
+        $event->add_part($this->theme->get_user_editor_html($event->image), 39, "Uploader");
+        $event->add_part($this->theme->get_tag_editor_html($event->image), 40, "Tags");
+        $event->add_part($this->theme->get_source_editor_html($event->image), 41, "Source");
+        $event->add_part($this->theme->get_lock_editor_html($event->image), 42, "Locked");
     }
 
     public function onTagTermCheck(TagTermCheckEvent $event)

--- a/ext/tag_edit/main.php
+++ b/ext/tag_edit/main.php
@@ -258,10 +258,14 @@ class TagEdit extends Extension
 
     public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event)
     {
-        $event->add_part($this->theme->get_user_editor_html($event->image), 39, "Uploader");
-        $event->add_part($this->theme->get_tag_editor_html($event->image), 40, "Tags");
-        $event->add_part($this->theme->get_source_editor_html($event->image), 41, "Source");
-        $event->add_part($this->theme->get_lock_editor_html($event->image), 42, "Locked");
+        $user_editor = $this->theme->get_user_editor_html($event->image);
+        $avatar = $event->image->get_owner()->get_avatar_html();
+        $attributes = [[], ["rowspan"=>'4', "width"=>'80px']];
+        $event->add_part([$user_editor, $avatar], 39, "Uploader", false, $attributes);
+
+        $event->add_part([$this->theme->get_tag_editor_html($event->image)], 40, "Tags");
+        $event->add_part([$this->theme->get_source_editor_html($event->image)], 41, "Source");
+        $event->add_part([$this->theme->get_lock_editor_html($event->image)], 42, "Locked");
     }
 
     public function onTagTermCheck(TagTermCheckEvent $event)

--- a/ext/tag_edit/theme.php
+++ b/ext/tag_edit/theme.php
@@ -47,19 +47,12 @@ class TagEditTheme extends Themelet
         $h_tag_links = Tag::implode($tag_links);
         $h_tags = html_escape($image->get_tag_list());
 
-        return "
-			<tr>
-				<th width='50px'>Tags</th>
-				<td>
-		".($user->can(Permissions::EDIT_IMAGE_TAG) ? "
+        return ($user->can(Permissions::EDIT_IMAGE_TAG) ? "
 					<span class='view'>$h_tag_links</span>
 					<input class='edit autocomplete_tags' type='text' name='tag_edit__tags' value='$h_tags' id='tag_editor' autocomplete='off'>
 		" : "
 					$h_tag_links
-		")."
-				</td>
-			</tr>
-		";
+		");
     }
 
     public function get_user_editor_html(Image $image): string
@@ -69,20 +62,12 @@ class TagEditTheme extends Themelet
         $h_av = $image->get_owner()->get_avatar_html();
         $h_date = autodate($image->posted);
         $h_ip = $user->can(Permissions::VIEW_IP) ? " (".show_ip($image->owner_ip, "Post posted {$image->posted}").")" : "";
-        return "
-			<tr>
-				<th>Uploader</th>
-				<td>
-		".($user->can(Permissions::EDIT_IMAGE_OWNER) ? "
+        return ($user->can(Permissions::EDIT_IMAGE_OWNER) ? "
 					<span class='view'><a class='username' href='".make_link("user/$h_owner")."'>$h_owner</a>$h_ip, $h_date</span>
 					<input class='edit' type='text' name='tag_edit__owner' value='$h_owner'>
 		" : "
 					<a class='username' href='".make_link("user/$h_owner")."'>$h_owner</a>$h_ip, $h_date
-		")."
-				</td>
-				<td width='80px' rowspan='4'>$h_av</td>
-			</tr>
-		";
+		"); //TODO: Implement removed <td width='80px' rowspan='4'>$h_av</td>
     }
 
     public function get_source_editor_html(Image $image): string
@@ -91,19 +76,12 @@ class TagEditTheme extends Themelet
         $h_source = html_escape($image->get_source());
         $f_source = $this->format_source($image->get_source());
         $style = "overflow: hidden; white-space: nowrap; max-width: 350px; text-overflow: ellipsis;";
-        return "
-			<tr>
-				<th>Source</th>
-				<td>
-		".($user->can(Permissions::EDIT_IMAGE_SOURCE) ? "
+        return ($user->can(Permissions::EDIT_IMAGE_SOURCE) ? "
 					<div class='view' style='$style'>$f_source</div>
 					<input class='edit' type='text' name='tag_edit__source' value='$h_source'>
 		" : "
 					<div style='$style'>$f_source</div>
-		")."
-				</td>
-			</tr>
-		";
+		");
     }
 
     protected function format_source(string $source=null): string
@@ -128,18 +106,11 @@ class TagEditTheme extends Themelet
         global $user;
         $b_locked = $image->is_locked() ? "Yes (Only admins may edit these details)" : "No";
         $h_locked = $image->is_locked() ? " checked" : "";
-        return "
-			<tr>
-				<th>Locked</th>
-				<td>
-		".($user->can(Permissions::EDIT_IMAGE_LOCK) ? "
+        return ($user->can(Permissions::EDIT_IMAGE_LOCK) ? "
 					<span class='view'>$b_locked</span>
 					<input class='edit' type='checkbox' name='tag_edit__locked'$h_locked>
 		" : "
 					$b_locked
-		")."
-				</td>
-			</tr>
-		";
+		");
     }
 }

--- a/ext/tag_edit/theme.php
+++ b/ext/tag_edit/theme.php
@@ -67,7 +67,7 @@ class TagEditTheme extends Themelet
 					<input class='edit' type='text' name='tag_edit__owner' value='$h_owner'>
 		" : "
 					<a class='username' href='".make_link("user/$h_owner")."'>$h_owner</a>$h_ip, $h_date
-		"); //TODO: Implement removed <td width='80px' rowspan='4'>$h_av</td>
+		");
     }
 
     public function get_source_editor_html(Image $image): string

--- a/ext/tag_editcloud/main.php
+++ b/ext/tag_editcloud/main.php
@@ -36,17 +36,15 @@ class TagEditCloud extends Extension
 
         $sb = $event->panel->create_new_block("Tag Edit Cloud");
         $sb->add_bool_option("tageditcloud_disable", "Disable Tag Selection Cloud: ");
-        $sb->add_choice_option("tageditcloud_sort", $sort_by, "<br>Sort the tags by:");
-        $sb->add_bool_option("tageditcloud_usedfirst", "<br>Always show used tags first: ");
-        $sb->add_label("<br><b>Alpha sort</b>:<br>Only show tags used at least ");
-        $sb->add_int_option("tageditcloud_minusage");
-        $sb->add_label(" times.<br><b>Popularity/Relevance sort</b>:<br>Show ");
-        $sb->add_int_option("tageditcloud_defcount");
-        $sb->add_label(" tags by default.<br>Show a maximum of ");
-        $sb->add_int_option("tageditcloud_maxcount");
-        $sb->add_label(" tags.");
-        $sb->add_label("<br><b>Relevance sort</b>:<br>Ignore tags (space separated): ");
-        $sb->add_text_option("tageditcloud_ignoretags");
+        $sb->add_choice_option("tageditcloud_sort", $sort_by, "Sort the tags by:");
+        $sb->add_bool_option("tageditcloud_usedfirst", "Always show used tags first: ");
+        $sb->add_header("Alpha sort");
+        $sb->add_int_option("tageditcloud_minusage", "Only show tags used at least ", " times.");
+        $sb->add_header("Popularity/Relevance sort");
+        $sb->add_int_option("tageditcloud_defcount", "Show ", " tags by default.");
+        $sb->add_int_option("tageditcloud_maxcount", "Show a maximum of ", " tags.");
+        $sb->add_header("Relevance sort");
+        $sb->add_text_option("tageditcloud_ignoretags", "Ignore tags (space separated): ");
     }
 
     private function build_tag_map(Image $image): ?string

--- a/ext/tag_editcloud/main.php
+++ b/ext/tag_editcloud/main.php
@@ -13,7 +13,7 @@ class TagEditCloud extends Extension
         if (!$config->get_bool("tageditcloud_disable") && $this->can_tag($event->image)) {
             $html = $this->build_tag_map($event->image);
             if (!is_null($html)) {
-                $event->add_part($html, 40, "", true);
+                $event->add_part([$html], 40, "", true);
             }
         }
     }

--- a/ext/tag_editcloud/main.php
+++ b/ext/tag_editcloud/main.php
@@ -13,7 +13,7 @@ class TagEditCloud extends Extension
         if (!$config->get_bool("tageditcloud_disable") && $this->can_tag($event->image)) {
             $html = $this->build_tag_map($event->image);
             if (!is_null($html)) {
-                $event->add_part($html, 40);
+                $event->add_part($html, 40); //TODO: Tell the event this should not be wrapped in tables for build_info to act accordingly.
             }
         }
     }

--- a/ext/tag_editcloud/main.php
+++ b/ext/tag_editcloud/main.php
@@ -13,7 +13,7 @@ class TagEditCloud extends Extension
         if (!$config->get_bool("tageditcloud_disable") && $this->can_tag($event->image)) {
             $html = $this->build_tag_map($event->image);
             if (!is_null($html)) {
-                $event->add_part($html, 40); //TODO: Tell the event this should not be wrapped in tables for build_info to act accordingly.
+                $event->add_part($html, 40, "", true);
             }
         }
     }

--- a/ext/tag_list/main.php
+++ b/ext/tag_list/main.php
@@ -98,38 +98,30 @@ class TagList extends Extension
     public function onSetupBuilding(SetupBuildingEvent $event)
     {
         $sb = $event->panel->create_new_block("Tag Map Options");
-        $sb->add_int_option(TagListConfig::TAGS_MIN, "Only show tags used at least ");
-        $sb->add_label(" times");
-        $sb->add_bool_option(TagListConfig::PAGES, "<br>Paged tag lists: ");
+        $sb->add_int_option(TagListConfig::TAGS_MIN, "Only show tags used at least ", " times");
+        $sb->add_bool_option(TagListConfig::PAGES, "Paged tag lists: ");
 
         $sb = $event->panel->create_new_block("Popular / Related Tag List");
-        $sb->add_int_option(TagListConfig::LENGTH, "Show top ");
-        $sb->add_label(" related tags");
-        $sb->add_int_option(TagListConfig::POPULAR_TAG_LIST_LENGTH, "<br>Show top ");
-        $sb->add_label(" popular tags");
-        $sb->start_table();
-        $sb->add_text_option(TagListConfig::INFO_LINK, "Tag info link", true);
-        $sb->add_text_option(TagListConfig::OMIT_TAGS, "Omit tags", true);
+        $sb->add_int_option(TagListConfig::LENGTH, "Show top ", " related tags");
+        $sb->add_int_option(TagListConfig::POPULAR_TAG_LIST_LENGTH, "<br>Show top ", " popular tags");
+        $sb->add_text_option(TagListConfig::INFO_LINK, "Tag info link");
+        $sb->add_text_option(TagListConfig::OMIT_TAGS, "Omit tags");
         $sb->add_choice_option(
             TagListConfig::IMAGE_TYPE,
             TagListConfig::TYPE_CHOICES,
-            "Post tag list",
-            true
+            "Post tag list"
         );
         $sb->add_choice_option(
             TagListConfig::RELATED_SORT,
             TagListConfig::SORT_CHOICES,
-            "Sort related list by",
-            true
+            "Sort related list by"
         );
         $sb->add_choice_option(
             TagListConfig::POPULAR_SORT,
             TagListConfig::SORT_CHOICES,
-            "Sort popular list by",
-            true
+            "Sort popular list by"
         );
-        $sb->add_bool_option("tag_list_numbers", "Show tag counts", true);
-        $sb->end_table();
+        $sb->add_bool_option("tag_list_numbers", "Show tag counts");
     }
 
     /**

--- a/ext/transcode/main.php
+++ b/ext/transcode/main.php
@@ -143,20 +143,18 @@ class TranscodeImage extends Extension
 
 
         $sb = $event->panel->create_new_block("Image Transcode");
-        $sb->start_table();
-        $sb->add_bool_option(TranscodeConfig::ENABLED, "Allow transcoding images", true);
-        $sb->add_bool_option(TranscodeConfig::GET_ENABLED, "Enable GET args", true);
-        $sb->add_bool_option(TranscodeConfig::UPLOAD, "Transcode on upload", true);
-        $sb->add_choice_option(TranscodeConfig::ENGINE, MediaEngine::IMAGE_ENGINES, "Engine", true);
+        $sb->add_bool_option(TranscodeConfig::ENABLED, "Allow transcoding images");
+        $sb->add_bool_option(TranscodeConfig::GET_ENABLED, "Enable GET args");
+        $sb->add_bool_option(TranscodeConfig::UPLOAD, "Transcode on upload");
+        $sb->add_choice_option(TranscodeConfig::ENGINE, MediaEngine::IMAGE_ENGINES, "Engine");
         foreach (self::INPUT_MIMES as $display=> $mime) {
             if (MediaEngine::is_input_supported($engine, $mime)) {
                 $outputs = $this->get_supported_output_mimes($engine, $mime);
-                $sb->add_choice_option(self::get_mapping_name($mime), $outputs, "$display", true);
+                $sb->add_choice_option(self::get_mapping_name($mime), $outputs, "$display");
             }
         }
-        $sb->add_int_option(TranscodeConfig::QUALITY, "Lossy Format Quality", true);
-        $sb->add_color_option(TranscodeConfig::ALPHA_COLOR, "Alpha Conversion Color", true);
-        $sb->end_table();
+        $sb->add_int_option(TranscodeConfig::QUALITY, "Lossy Format Quality");
+        $sb->add_color_option(TranscodeConfig::ALPHA_COLOR, "Alpha Conversion Color");
     }
 
     public function onDataUpload(DataUploadEvent $event)

--- a/ext/transcode_video/main.php
+++ b/ext/transcode_video/main.php
@@ -55,10 +55,8 @@ class TranscodeVideo extends Extension
     public function onSetupBuilding(SetupBuildingEvent $event)
     {
         $sb = $event->panel->create_new_block("Video Transcode");
-        $sb->start_table();
-        $sb->add_bool_option(TranscodeVideoConfig::ENABLED, "Allow transcoding images: ", true);
-        $sb->add_bool_option(TranscodeVideoConfig::UPLOAD_TO_NATIVE_CONTAINER, "Convert videos using MPEG-4 or WEBM to their native containers:", true);
-        $sb->end_table();
+        $sb->add_bool_option(TranscodeVideoConfig::ENABLED, "Allow transcoding images: ");
+        $sb->add_bool_option(TranscodeVideoConfig::UPLOAD_TO_NATIVE_CONTAINER, "Convert videos using MPEG-4 or WEBM to their native containers:");
     }
 
     public function onDataUpload(DataUploadEvent $event)

--- a/ext/upload/main.php
+++ b/ext/upload/main.php
@@ -125,12 +125,10 @@ class Upload extends Extension
         $sb = $event->panel->create_new_block("Upload");
         $sb->position = 10;
         // Output the limits from PHP so the user has an idea of what they can set.
-        $sb->add_int_option(UploadConfig::COUNT, "Max uploads: ");
-        $sb->add_label("<i>PHP Limit = " . ini_get('max_file_uploads') . "</i>");
-        $sb->add_shorthand_int_option(UploadConfig::SIZE, "<br/>Max size per file: ");
-        $sb->add_label("<i>PHP Limit = " . ini_get('upload_max_filesize') . "</i>");
-        $sb->add_choice_option(UploadConfig::TRANSLOAD_ENGINE, $tes, "<br/>Transload: ");
-        $sb->add_bool_option(UploadConfig::TLSOURCE, "<br/>Use transloaded URL as source if none is provided: ");
+        $sb->add_int_option(UploadConfig::COUNT, "Max uploads: ", "<i>PHP Limit = " . ini_get('max_file_uploads') . "</i>");
+        $sb->add_shorthand_int_option(UploadConfig::SIZE, "Max size per file: ", "<i>PHP Limit = " . ini_get('upload_max_filesize') . "</i>");
+        $sb->add_choice_option(UploadConfig::TRANSLOAD_ENGINE, $tes, "Transload: ");
+        $sb->add_bool_option(UploadConfig::TLSOURCE, "Use transloaded URL as source if none is provided: ");
     }
 
 

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -278,22 +278,20 @@ class UserPage extends Extension
         ];
 
         $sb = $event->panel->create_new_block("User Options");
-        $sb->start_table();
-        $sb->add_bool_option(UserConfig::ENABLE_API_KEYS, "Enable user API keys", true);
-        $sb->add_bool_option("login_signup_enabled", "Allow new signups", true);
-        $sb->add_longtext_option("login_tac", "Terms &amp; Conditions", true);
+        $sb->add_bool_option(UserConfig::ENABLE_API_KEYS, "Enable user API keys");
+        $sb->add_bool_option("login_signup_enabled", "Allow new signups");
+        $sb->add_longtext_option("login_tac", "Terms &amp; Conditions");
         $sb->add_choice_option(
             "user_loginshowprofile",
             [
                 "return to previous page" => 0, // 0 is default
                 "send to user profile" => 1],
-            "On log in/out",
-            true
+            "On log in/out"
         );
-        $sb->add_choice_option("avatar_host", $hosts, "Avatars", true);
+        $sb->add_choice_option("avatar_host", $hosts, "Avatars");
 
         if ($config->get_string("avatar_host") == "gravatar") {
-            $sb->add_table_header_cell("<div style='text-align: center'><b>Gravatar Options</b></div>", 2);
+            $sb->add_header("<div style='text-align: center'><b>Gravatar Options</b></div>");
 
             $sb->add_choice_option(
                 "avatar_gravatar_type",
@@ -303,17 +301,14 @@ class UserPage extends Extension
                     'Monster ID'=>'monsterid',
                     'Identicon'=>'identicon'
                 ],
-                "Type",
-                true
+                "Type"
             );
             $sb->add_choice_option(
                 "avatar_gravatar_rating",
                 ['G'=>'g', 'PG'=>'pg', 'R'=>'r', 'X'=>'x'],
-                "Rating",
-                true
+                "Rating"
             );
         }
-        $sb->end_table();
     }
 
     public function onPageSubNavBuilding(PageSubNavBuildingEvent $event)

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -293,11 +293,7 @@ class UserPage extends Extension
         $sb->add_choice_option("avatar_host", $hosts, "Avatars", true);
 
         if ($config->get_string("avatar_host") == "gravatar") {
-            $sb->start_table_row();
-            $sb->start_table_cell(2);
-            $sb->add_label("<div style='text-align: center'><b>Gravatar Options</b></div>");
-            $sb->end_table_cell();
-            $sb->end_table_row();
+            $sb->add_table_header_cell("<div style='text-align: center'><b>Gravatar Options</b></div>", 2);
 
             $sb->add_choice_option(
                 "avatar_gravatar_type",

--- a/ext/user_config/main.php
+++ b/ext/user_config/main.php
@@ -141,7 +141,7 @@ class UserConfig extends Extension
                         return;
                     }
 
-                    $uobe = new UserOptionsBuildingEvent($display_user, new SetupPanel($user_config));
+                    $uobe = new UserOptionsBuildingEvent($display_user, new SetupPanel($user_config, new SetupTheme));
                     send_event($uobe);
 
                     $this->theme->display_user_config_page($page, $uobe->user, $uobe->panel);

--- a/ext/view/events/image_info_box_building_event.php
+++ b/ext/view/events/image_info_box_building_event.php
@@ -2,15 +2,17 @@
 
 class ImageInfoBoxPart
 {
+    public array $items = [];
+    public array $attributes = [];
     public string $header = "";
-    public string $body = "";
     public int $order = 50;
     public bool $raw = false;
 
-    public function __construct(string $header, string $body, int $order, bool $raw)
+    public function __construct(string $header, array $items, int $order, bool $raw, array $attributes)
     {
         $this->header = $header;
-        $this->body = $body;
+        $this->items = $items;
+        $this->attributes = $attributes;
         $this->order = $order;
         $this->raw = $raw;
     }
@@ -29,9 +31,14 @@ class ImageInfoBoxBuildingEvent extends Event
         $this->user = $user;
     }
 
-    public function add_part(string $html, int $position=50, string $header="", bool $raw=false)
+    /* public function add_part(string $html, int $order=50, string $header="", bool $raw=false, array $attributes=[])
     {
-        array_push($this->parts, new ImageInfoBoxPart($header, $html, $position, $raw));
+        $this->parts[] = new ImageInfoBoxPart($header, [$html], $order, $raw, $attributes);
+    } */
+
+    public function add_part(array $html, int $order=50, string $header="", bool $raw=false, array $attributes=[])
+    {
+        $this->parts[] = new ImageInfoBoxPart($header, $html, $order, $raw, $attributes);
     }
 
     public function get_sorted_parts()

--- a/ext/view/events/image_info_box_building_event.php
+++ b/ext/view/events/image_info_box_building_event.php
@@ -44,7 +44,7 @@ class ImageInfoBoxBuildingEvent extends Event
     public function get_sorted_parts()
     {
         $parts = $this->parts;
-        usort($parts, function($a, $b) {
+        usort($parts, function ($a, $b) {
             return $a->order <=> $b->order;
         });
         return $parts;

--- a/ext/view/events/image_info_box_building_event.php
+++ b/ext/view/events/image_info_box_building_event.php
@@ -5,12 +5,14 @@ class ImageInfoBoxPart
     public string $header = "";
     public string $body = "";
     public int $order = 50;
+    public bool $raw = false;
 
-    public function __construct(string $header, string $body, int $order)
+    public function __construct(string $header, string $body, int $order, bool $raw)
     {
         $this->header = $header;
         $this->body = $body;
         $this->order = $order;
+        $this->raw = $raw;
     }
 }
 
@@ -27,9 +29,9 @@ class ImageInfoBoxBuildingEvent extends Event
         $this->user = $user;
     }
 
-    public function add_part(string $html, int $position=50, string $header="")
+    public function add_part(string $html, int $position=50, string $header="", bool $raw=false)
     {
-        array_push($this->parts, new ImageInfoBoxPart($header, $html, $position));
+        array_push($this->parts, new ImageInfoBoxPart($header, $html, $position, $raw));
     }
 
     public function get_sorted_parts()

--- a/ext/view/events/image_info_box_building_event.php
+++ b/ext/view/events/image_info_box_building_event.php
@@ -40,5 +40,6 @@ class ImageInfoBoxBuildingEvent extends Event
         usort($parts, function($a, $b) {
             return $a->order <=> $b->order;
         });
+        return $parts;
     }
 }

--- a/ext/view/events/image_info_box_building_event.php
+++ b/ext/view/events/image_info_box_building_event.php
@@ -1,5 +1,19 @@
 <?php declare(strict_types=1);
 
+class ImageInfoBoxPart
+{
+    public string $header = "";
+    public string $body = "";
+    public int $order = 50;
+
+    public function __construct(string $header, string $body, int $order)
+    {
+        $this->header = $header;
+        $this->body = $body;
+        $this->order = $order;
+    }
+}
+
 class ImageInfoBoxBuildingEvent extends Event
 {
     public array $parts = [];
@@ -13,11 +27,16 @@ class ImageInfoBoxBuildingEvent extends Event
         $this->user = $user;
     }
 
-    public function add_part(string $html, int $position=50)
+    public function add_part(string $html, int $position=50, string $header="")
     {
-        while (isset($this->parts[$position])) {
-            $position++;
-        }
-        $this->parts[$position] = $html;
+        array_push($this->parts, new ImageInfoBoxPart($header, $html, $position));
+    }
+
+    public function get_sorted_parts()
+    {
+        $parts = $this->parts;
+        usort($parts, function($a, $b) {
+            return $a->order <=> $b->order;
+        });
     }
 }

--- a/ext/view/main.php
+++ b/ext/view/main.php
@@ -112,7 +112,7 @@ class ViewImage extends Extension
         global $config;
         $image_info = $config->get_string(ImageConfig::INFO);
         if ($image_info) {
-            $event->add_part(html_escape($event->image->get_info()), 85, "Info");
+            $event->add_part([html_escape($event->image->get_info())], 85, "Info");
         }
     }
 }

--- a/ext/view/main.php
+++ b/ext/view/main.php
@@ -99,8 +99,7 @@ class ViewImage extends Extension
 
         $iibbe = new ImageInfoBoxBuildingEvent($image, $user);
         send_event($iibbe);
-        ksort($iibbe->parts);
-        $this->theme->display_page($image, $iibbe->parts);
+        $this->theme->display_page($image, $iibbe->get_sorted_parts());
 
         $iabbe = new ImageAdminBlockBuildingEvent($image, $user, "view");
         send_event($iabbe);

--- a/ext/view/main.php
+++ b/ext/view/main.php
@@ -113,11 +113,7 @@ class ViewImage extends Extension
         global $config;
         $image_info = $config->get_string(ImageConfig::INFO);
         if ($image_info) {
-            $html = (string)TR(
-                TH("Info"),
-                TD($event->image->get_info())
-            );
-            $event->add_part($html, 85);
+            $event->add_part(html_escape($event->image->get_info()), 85, "Info");
         }
     }
 }

--- a/ext/view/theme.php
+++ b/ext/view/theme.php
@@ -95,11 +95,11 @@ class ViewImageTheme extends Themelet
         $html = "";
         foreach ($editor_parts as $part) {
             if ($part->raw) {
-                $html .= $part->header . implode("", $part->items); //TODO: Use all items.
+                $html .= $part->header . implode("", $part->items);
             } else {
                 $items = $part->items;
                 array_walk($items, function (&$item, $index, $part) {
-                    $item = $this->build_item($part->attributes[$index] ?? [], $item);
+                    $item = $this->build_item($part->attributes[$index] ?? [], (string)$item);
                 }, $part);
                 $html .= $this->build_part($items, $part->header);
             }

--- a/ext/view/theme.php
+++ b/ext/view/theme.php
@@ -85,7 +85,14 @@ class ViewImageTheme extends Themelet
 					<table style='width: 500px; max-width: 100%;' class='image_info form'>
 		";
         foreach ($editor_parts as $part) {
-            $html .= $part;
+            // This could be using something like MicroHTML? but the contents need to allow HTML anyway.
+            // TODO: Let parts decide if they should be wrapped.
+            $html .= "
+                <tr>
+                    <th>{$part->header}</th>
+                    <td>{$part->body}</td>
+                </tr>
+            ";
         }
         if (
             (!$image->is_locked() || $user->can(Permissions::EDIT_IMAGE_LOCK)) &&

--- a/ext/view/theme.php
+++ b/ext/view/theme.php
@@ -86,13 +86,16 @@ class ViewImageTheme extends Themelet
 		";
         foreach ($editor_parts as $part) {
             // This could be using something like MicroHTML? but the contents need to allow HTML anyway.
-            // TODO: Let parts decide if they should be wrapped.
-            $html .= "
-                <tr>
-                    <th>{$part->header}</th>
-                    <td>{$part->body}</td>
-                </tr>
-            ";
+            if ($part->raw) {
+                $html .= $part->header . $part->body;
+            } else {
+                $html .= "
+                    <tr>
+                        <th>{$part->header}</th>
+                        <td>{$part->body}</td>
+                    </tr>
+                ";
+            }
         }
         if (
             (!$image->is_locked() || $user->can(Permissions::EDIT_IMAGE_LOCK)) &&

--- a/ext/view/theme.php
+++ b/ext/view/theme.php
@@ -98,7 +98,7 @@ class ViewImageTheme extends Themelet
                 $html .= $part->header . implode("", $part->items); //TODO: Use all items.
             } else {
                 $items = $part->items;
-                array_walk($items, function(&$item, $index, $part) {
+                array_walk($items, function (&$item, $index, $part) {
                     $item = $this->build_item($part->attributes[$index] ?? [], $item);
                 }, $part);
                 $html .= $this->build_part($items, $part->header);

--- a/ext/word_filter/main.php
+++ b/ext/word_filter/main.php
@@ -18,7 +18,7 @@ class WordFilter extends Extension
     {
         $sb = $event->panel->create_new_block("Word Filter");
         $sb->add_longtext_option("word_filter");
-        $sb->add_label("<br>(each line should be search term and replace term, separated by a comma)");
+        $sb->add_label("(each line should be search term and replace term, separated by a comma)", true);
     }
 
     private function filter(string $text): string


### PR DESCRIPTION
Decided to go for a different branch for this, so we can easily discard it or merge onto the other one, since I'm still trying to find the workflow we should go for with this rework.

If we want to let themes completely replace layouts, like replacing this table with a flexbox or grid, we should externalize the TR, TH, TD wrappers found in extensions. This is just one example of them.

I decided to go for a custom class for parts of this `ImageInfo` block but this is not the only place where an object with `header`, `body` and `order` is needed, so I can see Parts becoming its own thing like Blocks but with just the bare minimum information. They would be useful for events that build blocks like this one. Maybe we end up using an array and not a dedicated class for this, idk.

The part building process is not definitive, it's just a quick prototype.

I wanted to use MicroHTML on `ext/view/theme.php`'s `build_info` but the contents of the table still needed to allow for HTML to be injected. This may be improved as well.

There's a few TODOs here, mainly notes for myself. Also, sorry @shish, I know this is a lot of work and a lot to think about and review. I'm trying to maximize my contributions since this is my last free week before starting uni.