### PR TITLE
Edit sort by Categories

### DIFF
--- a/ext/tag_editcloud/main.php
+++ b/ext/tag_editcloud/main.php
@@ -102,7 +102,7 @@ class TagEditCloud extends Extension
                                         SELECT tag, FLOOR(LN(LN(count - :tag_min1 + 1)+1)*150)/200 AS scaled, count
                                         FROM tags
                                         WHERE count >= :tag_min2
-                                        ORDER BY CASE
+                                        ORDER BY SUM(count) OVER (PARTITION BY SUBSTRING_INDEX(tag, ':', 1)) DESC, CASE 
                                             WHEN tag LIKE '%:%' THEN 1
                                             ELSE 2
                                         END, tag


### PR DESCRIPTION
Sort by the number of tags (sum) for each category descending
This will allow the most used categories to appear first and not by alphabetical order