### PR TITLE
Added Tag Categories link from Tags page

### DIFF
--- a/ext/tag_categories/main.php
+++ b/ext/tag_categories/main.php
@@ -54,6 +54,13 @@ class TagCategories extends Extension
             );
         }
     }
+    
+    public function onPageSubNavBuilding(PageSubNavBuildingEvent $event)
+    {
+        if ($event->parent=="tags") {
+            $event->add_nav_link("tag_categories", new Link('tags/categories'), "Tag Gategories", NavLink::is_active(["tag_categories"]));
+        }
+    }
 
     public function onPageRequest(PageRequestEvent $event)
     {

--- a/ext/tag_categories/main.php
+++ b/ext/tag_categories/main.php
@@ -58,7 +58,7 @@ class TagCategories extends Extension
     public function onPageSubNavBuilding(PageSubNavBuildingEvent $event)
     {
         if ($event->parent=="tags") {
-            $event->add_nav_link("tag_categories", new Link('tags/categories'), "Tag Gategories", NavLink::is_active(["tag_categories"]));
+            $event->add_nav_link("tag_categories", new Link('tags/categories'), "Tag Categories", NavLink::is_active(["tag_categories"]));
         }
     }
 


### PR DESCRIPTION
For some reason it wasn't there, so you had to manually type (address)/tags/categories
For a while I had no idea it existed until I dug through the code, maybe that will expose users to that feature