### PR TITLE
Added missing colon to version title on extension page

### DIFF
--- a/ext/ext_manager/theme.php
+++ b/ext/ext_manager/theme.php
@@ -107,7 +107,7 @@ class ExtManagerTheme extends Themelet
         $html = DIV(
             ["style"=>'margin: auto; text-align: left; width: 512px;'],
             $author,
-            ($info->version ? emptyHTML(BR(), B("Version"), $info->version) : null),
+            ($info->version ? emptyHTML(BR(), B("Version: "), $info->version) : null),
             ($info->link ? emptyHTML(BR(), B("Home Page"), A(["href"=>$info->link], "Link")) : null),
             P(rawHTML($info->documentation ?? "(This extension has no documentation)")),
             // <hr>,


### PR DESCRIPTION
Before:
![version-before](https://user-images.githubusercontent.com/75134774/141364000-c677dd05-d4e2-4b93-8c10-c6a1b85a8880.png)

After:
![version-after](https://user-images.githubusercontent.com/75134774/141364028-c037d983-deb1-4437-90f0-6ef8cb5f410f.png)

