### PR TITLE
Add option to return 404 code for nonexistent wiki pages

### DIFF
--- a/ext/wiki/main.php
+++ b/ext/wiki/main.php
@@ -93,7 +93,6 @@ abstract class WikiConfig
     const EMPTY_TAGINFO = "wiki_empty_taginfo";
     const TAG_SHORTWIKIS = "shortwikis_on_tags";
     const ENABLE_REVISIONS = "wiki_revisions";
-    const RETURN_NOT_FOUND = "wiki_return_not_found";
 }
 
 class Wiki extends Extension
@@ -114,7 +113,6 @@ class Wiki extends Extension
         $config->set_default_string(WikiConfig::EMPTY_TAGINFO, "none");
         $config->set_default_bool(WikiConfig::TAG_SHORTWIKIS, false);
         $config->set_default_bool(WikiConfig::ENABLE_REVISIONS, true);
-        $config->set_default_bool(WikiConfig::RETURN_NOT_FOUND, false);
     }
 
     // Add a block to the Board Config / Setup
@@ -125,7 +123,6 @@ class Wiki extends Extension
         $sb->add_longtext_option(WikiConfig::TAG_PAGE_TEMPLATE, "Tag page template: ");
         $sb->add_text_option(WikiConfig::EMPTY_TAGINFO, "Empty list text: ");
         $sb->add_bool_option(WikiConfig::TAG_SHORTWIKIS, "Show shortwiki entry when searching for a single tag: ");
-        $sb->add_bool_option(WikiConfig::RETURN_NOT_FOUND, "<br>Return '404 Not Found' code for wiki pages that don't exist: ");
     }
 
     public function onDatabaseUpgrade(DatabaseUpgradeEvent $event)

--- a/ext/wiki/theme.php
+++ b/ext/wiki/theme.php
@@ -10,7 +10,7 @@ class WikiTheme extends Themelet
      */
     public function display_page(Page $page, WikiPage $wiki_page, ?WikiPage $nav_page=null)
     {
-        global $config, $user;
+        global $user;
 
         if (is_null($nav_page)) {
             $nav_page = new WikiPage();
@@ -33,7 +33,7 @@ class WikiTheme extends Themelet
             $title_html = $this->tagcategories->getTagHtml($title_html, $tag_category_dict);
         }
 
-        if ($config->get_bool(WikiConfig::RETURN_NOT_FOUND) && !$wiki_page->exists) {
+        if (!$wiki_page->exists) {
             $page->set_code(404);
         }
 

--- a/ext/wiki/theme.php
+++ b/ext/wiki/theme.php
@@ -33,6 +33,10 @@ class WikiTheme extends Themelet
             $title_html = $this->tagcategories->getTagHtml($title_html, $tag_category_dict);
         }
 
+        if ($config->get_bool(WikiConfig::RETURN_NOT_FOUND) && !$wiki_page->exists) {
+            $page->set_code(404);
+        }
+
         $page->set_title(html_escape($wiki_page->title));
         $page->set_heading(html_escape($wiki_page->title));
         $page->add_block(new NavBlock());

--- a/ext/wiki/theme.php
+++ b/ext/wiki/theme.php
@@ -10,7 +10,7 @@ class WikiTheme extends Themelet
      */
     public function display_page(Page $page, WikiPage $wiki_page, ?WikiPage $nav_page=null)
     {
-        global $user;
+        global $config, $user;
 
         if (is_null($nav_page)) {
             $nav_page = new WikiPage();


### PR DESCRIPTION
I noticed search engines indexing wiki pages on my booru that didn't exist since they return a 200 code. this option sends a 404 instead if the wiki page doesn't exist when it's enabled.

if adding the function to the WikiPage class isn't the preferred way to do this let me know how you'd prefer me to implement it