### PR TITLE
Add support for X-Forwarded-Proto Header

### DIFF
--- a/core/util.php
+++ b/core/util.php
@@ -63,6 +63,10 @@ function contact_link(): ?string
  */
 function is_https_enabled(): bool
 {
+    // check forwarded protocol
+    if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+        $_SERVER['HTTPS']='on';
+    }
     return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
 }
 


### PR DESCRIPTION
this allows passing the X-Forwarded-Proto header to Shimmie from a reverse proxy. useful when SSL/TLS is terminated at the reverse proxy