### PR TITLE
Allow image owner to view their unapproved images

### DIFF
--- a/ext/approval/main.php
+++ b/ext/approval/main.php
@@ -191,7 +191,7 @@ class Approval extends Extension
     {
         global $user, $config;
 
-        if ($config->get_bool(ApprovalConfig::IMAGES) && $image->approved===false && !$user->can(Permissions::APPROVE_IMAGE)) {
+        if ($config->get_bool(ApprovalConfig::IMAGES) && $image->approved===false && !$user->can(Permissions::APPROVE_IMAGE) && $user->id!==$image->owner_id) {
             return false;
         }
         return true;

--- a/ext/comment/main.php
+++ b/ext/comment/main.php
@@ -279,7 +279,7 @@ class CommentList extends Extension
                 Extension::is_enabled(ApprovalInfo::KEY) && !is_null($image) &&
                 $image->approved!==true
             ) {
-               $image = null;
+                $image = null;
             }
             if (!is_null($image)) {
                 $comments = $this->get_comments($image->id);

--- a/ext/comment/main.php
+++ b/ext/comment/main.php
@@ -275,6 +275,12 @@ class CommentList extends Extension
             ) {
                 $image = null; // this is "clever", I may live to regret it
             }
+            if (
+                Extension::is_enabled(ApprovalInfo::KEY) && !is_null($image) &&
+                $image->approved!==true
+            ) {
+               $image = null;
+            }
             if (!is_null($image)) {
                 $comments = $this->get_comments($image->id);
                 $images[] = [$image, $comments];


### PR DESCRIPTION
this allows a user to view the images they've uploaded, even if they haven't been approved. helpful to allow use of quality-of-life features like the tag edit cloud or correction of mistakes before approval

the owner may also comment on the unapproved image but these comments are hidden from the comment list until the image is approved