### PR TITLE
Fix apt errors when running in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # "Build" shimmie (composer install - done in its own stage so that we don't
 # need to include all the composer fluff in the final image)
-FROM debian:testing-slim AS app
+FROM debian:stable AS app
 RUN apt update && apt install -y composer php7.4-gd php7.4-dom php7.4-sqlite3 php-xdebug imagemagick
 COPY composer.json composer.lock /app/
 WORKDIR /app
@@ -10,7 +10,7 @@ COPY . /app/
 # Tests in their own image. Really we should inherit from app and then
 # `composer install` phpunit on top of that; but for some reason
 # `composer install --no-dev && composer install` doesn't install dev
-FROM debian:testing-slim AS tests
+FROM debian:stable AS tests
 RUN apt update && apt install -y composer php7.4-gd php7.4-dom php7.4-sqlite3 php-xdebug imagemagick
 COPY composer.json composer.lock /app/
 WORKDIR /app
@@ -25,7 +25,7 @@ RUN [ $RUN_TESTS = false ] || (\
     echo '=== Cleaning ===' && rm -rf data)
 
 # Build su-exec so that our final image can be nicer
-FROM debian:testing-slim AS suexec
+FROM debian:stable AS suexec
 RUN  apt-get update && apt-get install -y --no-install-recommends gcc libc-dev curl
 RUN  curl -k -o /usr/local/bin/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/master/su-exec.c; \
      gcc -Wall /usr/local/bin/su-exec.c -o/usr/local/bin/su-exec; \
@@ -33,7 +33,7 @@ RUN  curl -k -o /usr/local/bin/su-exec.c https://raw.githubusercontent.com/ncopa
      chmod 0755 /usr/local/bin/su-exec;
 
 # Actually run shimmie
-FROM debian:testing-slim
+FROM debian:stable
 EXPOSE 8000
 HEALTHCHECK --interval=1m --timeout=3s CMD curl --fail http://127.0.0.1:8000/ || exit 1
 ENV UID=1000 \


### PR DESCRIPTION
I was facing some errors when running Shimmie2 in a Docker container:

![image](https://user-images.githubusercontent.com/75134774/153343327-4134a41e-3bf1-49fa-82f4-ab0a071e66bc.png)

Which was fixed by replacing the `debian:testing-slim` source image with `debian:stable` in the Dockerfile, as suggested by @shish [here](https://github.com/shish/shimmie2/issues/849#issuecomment-964527949) (for a different issue lol).