### PR TITLE
Allow ordering by favourites in searches

### DIFF
--- a/ext/autocomplete/script.js
+++ b/ext/autocomplete/script.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-	var metatags = ['order:id', 'order:width', 'order:height', 'order:filesize', 'order:filename'];
+	var metatags = ['order:id', 'order:width', 'order:height', 'order:filesize', 'order:filename', 'order:favorites'];
 
 	$('[name="search"]').tagit({
 		singleFieldDelimiter: ' ',

--- a/ext/favorites/main.php
+++ b/ext/favorites/main.php
@@ -133,6 +133,10 @@ class Favorites extends Extension
         } elseif (preg_match("/^favorited_by_userno[=|:](\d+)$/i", $event->term, $matches)) {
             $user_id = int_escape($matches[1]);
             $event->add_querylet(new Querylet("images.id IN (SELECT image_id FROM user_favorites WHERE user_id = $user_id)"));
+        } elseif (preg_match("/^order[=|:](favorites)(?:_(desc|asc))?$/i", $event->term, $matches)) {
+            $default_order_for_column = "DESC";
+            $sort = isset($matches[2]) ? strtoupper($matches[2]) : $default_order_for_column;
+            $event->order = "images.favorites $sort";
         }
     }
 


### PR DESCRIPTION
This allows sorting by the number of favorites a post has in the same way as other ordering metatags. If there's a better way to handle conditionally showing the metatag in autocomplete, let me know!

closes friends-of-the-core/shimmie2#1