### PR TITLE
Preserve posted date on rotate

### DIFF
--- a/ext/rotate/main.php
+++ b/ext/rotate/main.php
@@ -174,6 +174,7 @@ class RotateImage extends Extension
         $new_image->filename = 'rotated-'.$image_obj->filename;
         $new_image->width = $new_width;
         $new_image->height = $new_height;
+        $new_image->posted = $image_obj->posted;
 
         /* Move the new image into the main storage location */
         $target = warehouse_path(Image::IMAGE_DIR, $new_image->hash);


### PR DESCRIPTION
**Note**: This change relies on #875, and includes that commit until it is merged.

The image rotation extension currently relies on creating a new Image instance, and this doesn't change that, but it does make it keep the original upload date rather than replacing it.

closes friends-of-the-core#4