### PR TITLE
Scale thumbnails in ffmpeg to avoid excessive memory use on high-resolution videos

### DIFF
--- a/ext/media/main.php
+++ b/ext/media/main.php
@@ -335,7 +335,7 @@ class Media extends Extension
             $args = [
                 escapeshellarg($ffmpeg),
                 "-y", "-i", escapeshellarg($inname),
-                "-vf", "thumbnail",
+                "-vf", "scale=$scaled_size[0]:$scaled_size[1],thumbnail",
                 "-f", "image2",
                 "-vframes", "1",
                 "-c:v", "png",
@@ -343,6 +343,8 @@ class Media extends Extension
             ];
 
             $cmd = escapeshellcmd(implode(" ", $args));
+
+            log_debug('media', "Generating thumbnail with command `$cmd`...");
 
             exec($cmd, $output, $ret);
 


### PR DESCRIPTION
ffmpeg's `thumbnail` filter by default [loads one hundred frames into memory](https://ffmpeg.org/ffmpeg-filters.html#thumbnail) to determine the most representative.

For 4K videos this can mean ffmpeg memory usage in excess of a gigabyte, as the analysis is performed on frames of the input video's frame size. I'm running Shimmie on a bit of a potato machine where this is too much! 😅 As a result, the entire PHP process is out of memory killed, and the thumbnail goes ungenerated.

It turns out, however, that you can ask ffmpeg to scale the video before it thumbnails it, significantly reducing the memory requirements. This makes Shimmie work in my specific case, but is also a decent efficiency improvement for others! ☺️

closes friends-of-the-core#5