### PR TITLE
Autocomplete in more places

### DIFF
--- a/ext/autocomplete/script.js
+++ b/ext/autocomplete/script.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		})
 	});
 
-	$('#tag_editor').tagit({
+	$('#tag_editor,[name="bulk_tags"]').tagit({
 		singleFieldDelimiter: ' ',
 		autocomplete : ({
 			source: function (request, response) {

--- a/ext/autocomplete/script.js
+++ b/ext/autocomplete/script.js
@@ -59,6 +59,34 @@ document.addEventListener('DOMContentLoaded', () => {
 		})
 	});
 
+	$('#tag_editor').tagit({
+		singleFieldDelimiter: ' ',
+		autocomplete : ({
+			source: function (request, response) {
+				$.ajax({
+					url: base_href + '/api/internal/autocomplete',
+					data: {'s': request.term},
+					dataType : 'json',
+					type : 'GET',
+					success : function (data) {
+						response(
+							$.map(data, function (count, item) {
+								return {
+									label : item + ' ('+count+')',
+									value : item
+								};
+							})
+						);
+					},
+					error : function (request, status, error) {
+						console.log(error);
+					}
+				});
+			},
+			minLength: 1
+		})
+	});
+
 	$('.ui-autocomplete-input').keydown(function(e) {
 		var keyCode = e.keyCode || e.which;
 

--- a/ext/tag_edit/theme.php
+++ b/ext/tag_edit/theme.php
@@ -55,7 +55,9 @@ class TagEditTheme extends Themelet
 				<td>
 		".($user->can(Permissions::EDIT_IMAGE_TAG) ? "
 					<span class='view'>$h_tag_links</span>
-					<input class='edit autocomplete_tags' type='text' name='tag_edit__tags' value='$h_tags' id='tag_editor' autocomplete='off'>
+					<div class='edit'>
+						<input class='autocomplete_tags' type='text' name='tag_edit__tags' value='$h_tags' id='tag_editor' autocomplete='off'>
+					</div>
 		" : "
 					$h_tag_links
 		")."


### PR DESCRIPTION
This updates the autocomplete and tag_edit functionality to allow autocompletion in both the individual image tag editor, and in the sidebar bulk operations editor.

It pulls from the same source as the existing search autocomplete, albeit without metatags and negative matches.