### PR TITLE
fix no handler for 'bulk_download'

### DIFF
--- a/core/userclass.php
+++ b/core/userclass.php
@@ -89,6 +89,7 @@ new UserClass("user", "base", [
     Permissions::SEND_PM => true,
     Permissions::READ_PM => true,
     Permissions::SET_PRIVATE_IMAGE => true,
+	Permissions::PERFORM_BULK_ACTIONS => true,
     Permissions::BULK_DOWNLOAD => true,
     Permissions::CHANGE_USER_SETTING => true
 ]);


### PR DESCRIPTION
Shimmie out of the box has bulk downloads enabled for the 'user' and 'base', but perform bulk actions isn't enabled, so it goes to a handler not found page. This fixes that.