### PR TITLE
Autocomplete on upload page

### DIFF
--- a/ext/upload/theme.php
+++ b/ext/upload/theme.php
@@ -95,7 +95,9 @@ class UploadTheme extends Themelet
                 TR(
                     TD(["colspan"=>$tl_enabled ? 2 : 4], INPUT(["type"=>"file", "name"=>"data${i}[]", "accept"=>$accept, "multiple"=>true])),
                     $tl_enabled ? TD(["colspan"=>"2"], INPUT(["type"=>"text", "name"=>"url${i}"])) : emptyHTML(),
-                    TD(["colspan"=>"2"], INPUT(["type"=>"text", "name"=>"tags${i}", "class"=>"autocomplete_tags", "autocomplete"=>"off"])),
+                    DIV(["class"=>'edit'],
+                        TD(["colspan"=>"2"], INPUT(["type"=>"text", "name"=>"tags${i}", "id"=>"tag_editor", "class"=>"autocomplete_tags", "autocomplete"=>"off"])),
+                    )
                 )
             );
         }


### PR DESCRIPTION
This little change is thanks to https://github.com/ticky
It adds the autocomplete onto the upload page specific tag input form. I find it to be extremely useful.