### PR TITLE
Fixing bulk add bug, tag is set to "\" if no other tags are present

### DIFF
--- a/core/imageboard/misc.php
+++ b/core/imageboard/misc.php
@@ -20,6 +20,8 @@ function add_dir(string $base): array
         $filename = basename($full_path);
 
         $tags = path_to_tags($short_path);
+		if ($tags[0] == "\\")
+			$tags = "";
         $result = "$short_path (".str_replace(" ", ", ", $tags).")... ";
         try {
             add_image($full_path, $filename, $tags);


### PR DESCRIPTION
Images will now be uploaded with no tags, which will cause them to be generated with "tagme" instead.
This function is also used by archiver, hopefully not a problem.