### PR TITLE
Update memcache DSN condition matching

### DIFF
--- a/core/cacheengine.php
+++ b/core/cacheengine.php
@@ -144,7 +144,7 @@ class Cache
         $matches = [];
         $c = null;
         if ($dsn && preg_match("#(.*)://(.*)#", $dsn, $matches) && !isset($_GET['DISABLE_CACHE'])) {
-            if ($matches[1] == "memcached") {
+            if ($matches[1] == "memcached" || $matches[1] == "memcache") {
                 $c = new MemcachedCache($matches[2]);
             } elseif ($matches[1] == "apc") {
                 $c = new APCCache($matches[2]);


### PR DESCRIPTION
Add an additional OR conditional for memcache usage. If you use the DSN as listed at https://github.com/shish/shimmie2/wiki/Performance#software-cache the memcache section will never run because it is looking only for DSNs with 'memcached' causing an exception to be thrown on the first access as the cache is never setup.