### PR TITLE
implement MIME checks on upload

### DIFF
--- a/ext/transcode/main.php
+++ b/ext/transcode/main.php
@@ -167,6 +167,18 @@ class TranscodeImage extends Extension
     {
         global $config;
 
+        // this onDataUpload happens earlier (or could happen earlier) than handle_pixel.onDataUpload
+        // it mutates the image such that the incorrect mime type is not checked (checking against
+        // the post-transcode mime type instead). This is to  give user feedback on what the mime type
+        // was before potential transcoding (the original) at the time of upload, and that it failed if not allowed.
+        // does it break bulk image importing? ZIP? SVG? there are a few flows that are untested!
+        if ($config->get_bool(UploadConfig::MIME_CHECK_ENABLED) == true) {
+            $allowed_mimes = $config->get_array(UploadConfig::ALLOWED_MIME_STRINGS);
+            if (!MimeType::matches_array($event->mime, $allowed_mimes)) {
+                throw new UploadException("MIME type not supported: " . $event->mime);
+            }
+        }
+
         if ($config->get_bool(TranscodeConfig::UPLOAD) == true) {
             if ($event->mime === MimeType::GIF&&MimeType::is_animated_gif($event->tmpname)) {
                 return;

--- a/ext/upload/config.php
+++ b/ext/upload/config.php
@@ -11,4 +11,6 @@ class UploadConfig
     public const MIN_FREE_SPACE = "upload_min_free_space";
     public const TLSOURCE = "upload_tlsource";
     public const TRANSLOAD_ENGINE = "transload_engine";
+    public const MIME_CHECK_ENABLED = "mime_check_enabled";
+    public const ALLOWED_MIME_STRINGS = "allowed_mime_strings";
 }

--- a/ext/upload/main.php
+++ b/ext/upload/main.php
@@ -98,6 +98,12 @@ class Upload extends Extension
                 }
             }
         }
+
+        $config->set_default_bool(UploadConfig::MIME_CHECK_ENABLED, false);
+        $config->set_default_array(
+            UploadConfig::ALLOWED_MIME_STRINGS,
+            DataHandlerExtension::get_all_supported_mimes()
+        );
     }
 
     public function onSetupBuilding(SetupBuildingEvent $event)
@@ -119,8 +125,21 @@ class Upload extends Extension
         $sb->add_label("<i>PHP Limit = " . ini_get('upload_max_filesize') . "</i>");
         $sb->add_choice_option(UploadConfig::TRANSLOAD_ENGINE, $tes, "<br/>Transload: ");
         $sb->add_bool_option(UploadConfig::TLSOURCE, "<br/>Use transloaded URL as source if none is provided: ");
+
+        $sb->start_table();
+        $sb->add_bool_option(UploadConfig::MIME_CHECK_ENABLED, "Enable upload MIME checks", true);
+        $sb->add_multichoice_option(UploadConfig::ALLOWED_MIME_STRINGS, $this->get_mime_options(), "Allowed MIME uploads", true);
+        $sb->end_table();
     }
 
+    private function get_mime_options(): array
+    {
+        $output = [];
+        foreach (DataHandlerExtension::get_all_supported_mimes() as $mime) {
+            $output[MimeMap::get_name_for_mime($mime)] = $mime;
+        }
+        return $output;
+    }
 
     public function onPageNavBuilding(PageNavBuildingEvent $event)
     {


### PR DESCRIPTION
This is an idea to solve https://github.com/shish/shimmie2/issues/848

I think it's a step towards "full control of filetypes" on `upload`, as well as on `transcode`.

Idea is to allow for _all_ uploads / or a subset, but if  the maintainer wants, they can force them all to convert to a single format (or many). Currently there's already the ability to set an "transcoding mapping table" from input -> output, as well as enabling the transcoding on upload. This might help on guarding against weird file formats that might not work well with transcoding, or if you don't want to deal with them (on your instance).

Reason for having the "upload" check in the `ext/transcode/main.php` file is because it seems that `onUploadData` in the transcode happens _before_ the one in the `ext/upload/main.php` file? Is this correct? also, should it be like this? I feel like there's a better way around this, a _proper_ place for this check.

I've tried to keep it "sane by default" so all behaviour changes are behind a config toggle to enable it, and it's off by default.