### PR TITLE
add extension: hide_tags

### DIFF
--- a/core/imageboard/image.php
+++ b/core/imageboard/image.php
@@ -9,6 +9,19 @@ use GQLA\Field;
 use GQLA\Query;
 
 /**
+ * placed here until it finds a better home
+ *
+ * something seems to be special about core extensions? (at least
+ * in regards to loading the config from a non-core extension). Maybe
+ * it's just execution ordering. (and I would guess it's core before ext)
+ */
+class HideTagsConfig
+{
+    public const ENABLED = "hide_tags_enabled";
+    public const VERSION = "hide_tags_version";
+}
+
+/**
  * Class Image
  *
  * An object representing an entry in the images table.
@@ -274,6 +287,8 @@ class Image
 
     private static function terms_to_conditions(array $terms): array
     {
+        global $config;
+
         $tag_conditions = [];
         $img_conditions = [];
         $stpen = 0;  // search term parse event number
@@ -289,6 +304,15 @@ class Image
         } elseif (!empty($stpe->querylets)) {
             foreach ($stpe->querylets as $querylet) {
                 $img_conditions[] = new ImgCondition($querylet, true);
+            }
+        }
+
+        if ($config->get_bool(HideTagsConfig::ENABLED)) {
+            if (in_array('show_hidden', $terms)) {
+                $key = array_search('show_hidden', $terms);
+                unset($terms[$key]);
+            } else {
+                array_push($terms, '-hidden');
             }
         }
 

--- a/ext/hide_tags/info.php
+++ b/ext/hide_tags/info.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+class HideTagsInfo extends ExtensionInfo
+{
+    public const KEY = "hide_tags";
+
+    public string $key = self::KEY;
+    public string $name = "Hide Tags";
+    public string $url = "https://github.com/tegaki-tegaki/shimmie2-tegaki/";
+    public array $authors = ["tegaki"];
+    public string $license = self::LICENSE_GPLV2;
+    public string $description = "Allow hiding images through special tags";
+    public ?string $documentation =
+"This shimmie extension lets you hide images from discovery by ".
+"setting a tag 'hidden', you can reveal ".
+"hidden images in queries by adding the tag 'show_hidden'";
+}

--- a/ext/hide_tags/main.php
+++ b/ext/hide_tags/main.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+class HideTags extends Extension
+{
+    public function onInitExt(InitExtEvent $event)
+    {
+        global $config, $_shm_user_classes, $_shm_ratings;
+
+        $config->set_default_bool(HideTagsConfig::ENABLED, true);
+    }
+
+    public function onSetupBuilding(SetupBuildingEvent $event)
+    {
+        $sb = $event->panel->create_new_block("Hide Tags");
+        $sb->start_table();
+        $sb->add_bool_option(HideTagsConfig::ENABLED, "Enable hiding tags", true);
+        $sb->end_table();
+    }
+}


### PR DESCRIPTION
# why this extension

I made this feature for my booru so I could arbitrarily "soft hide" posts, while still making them visible if you have the post_id (eg if you link to an image hosted on the booru elsewhere). I wanted this because I wanted to essentially treat my booru _mostly_ like a _themed_ booru, but I also wanted the ability to treat it a bit like a generic image host, but if I post whatever on it, then people who come to the booru for the _theme_ will see all the _non-themed_ posts! This will not do! I know the "private" addon does the same thing but that opens the booru up to be more of a "private image host", and that's not quite what I want either, I just want to be able to casually hide images without too much fuss. It's not "well hidden", and it's not fully visible, just something in between :)

It can probably be used for other things too? 🤔 

I don't suggest merging it in _as is_, because It's not "clean enough" imo. I kinda "hacked it together" without too much thought. I'll try annotate the code with some PR comments of my own.

# features

1. if you tag a post with the now _special_ tag `hidden` the post will be hidden! (the way it does this is by injecting the string `-hidden` to all searches)
2. if you search for posts with the now _special_ tag `show_hidden`, it will let you search normally across all `hidden` tagged posts as well.