### PR TITLE
Allow SearchTermParseEvent to have a bit more control over results

### DIFF
--- a/core/imageboard/image.php
+++ b/core/imageboard/image.php
@@ -283,38 +283,11 @@ class Image
          * Turn a bunch of strings into a bunch of TagCondition
          * and ImgCondition objects
          */
-        $stpe = send_event(new SearchTermParseEvent($stpen++, null, $terms));
-        if ($stpe->order) {
-            $order = $stpe->order;
-        } elseif (!empty($stpe->querylets)) {
-            foreach ($stpe->querylets as $querylet) {
-                $img_conditions[] = new ImgCondition($querylet, true);
-            }
-        }
-
-        foreach ($terms as $term) {
-            $positive = true;
-            if (is_string($term) && !empty($term) && ($term[0] == '-')) {
-                $positive = false;
-                $term = substr($term, 1);
-            }
-            if (strlen($term) === 0) {
-                continue;
-            }
-
+        foreach (array_merge([null], $terms) as $term) {
             $stpe = send_event(new SearchTermParseEvent($stpen++, $term, $terms));
-            if ($stpe->order) {
-                $order = $stpe->order;
-            } elseif (!empty($stpe->querylets)) {
-                foreach ($stpe->querylets as $querylet) {
-                    $img_conditions[] = new ImgCondition($querylet, $positive);
-                }
-            } else {
-                // if the whole match is wild, skip this
-                if (str_replace("*", "", $term) != "") {
-                    $tag_conditions[] = new TagCondition($term, $positive);
-                }
-            }
+            $order ??= $stpe->order;
+            $img_conditions = array_merge($img_conditions, $stpe->img_conditions);
+            $tag_conditions = array_merge($tag_conditions, $stpe->tag_conditions);
         }
         return [$tag_conditions, $img_conditions, $order];
     }

--- a/ext/index/events.php
+++ b/ext/index/events.php
@@ -12,23 +12,48 @@ class SearchTermParseEvent extends Event
 {
     public int $id = 0;
     public ?string $term = null;
+    public bool $positive = true;
     /** @var string[] */
     public array $context = [];
-    /** @var Querylet[] */
-    public array $querylets = [];
+    /** @var ImgCondition[] */
+    public array $img_conditions = [];
+    /** @var TagCondition[] */
+    public array $tag_conditions = [];
     public ?string $order = null;
 
     public function __construct(int $id, string $term=null, array $context=[])
     {
         parent::__construct();
+
+        if ($term == "-" || $term == "*") {
+            throw new SearchTermParseException("'$term' is not a valid search term");
+        }
+
+        $positive = true;
+        if (is_string($term) && !empty($term) && ($term[0] == '-')) {
+            $positive = false;
+            $term = substr($term, 1);
+        }
+
         $this->id = $id;
+        $this->positive = $positive;
         $this->term = $term;
         $this->context = $context;
     }
 
     public function add_querylet(Querylet $q)
     {
-        $this->querylets[] = $q;
+        $this->add_img_condition(new ImgCondition($q, $this->positive));
+    }
+
+    public function add_img_condition(ImgCondition $c)
+    {
+        $this->img_conditions[] = $c;
+    }
+
+    public function add_tag_condition(TagCondition $c)
+    {
+        $this->tag_conditions[] = $c;
     }
 }
 

--- a/ext/index/main.php
+++ b/ext/index/main.php
@@ -257,5 +257,16 @@ class Index extends Extension
             $seed = date("Ymd");
             $event->order = "RAND($seed)";
         }
+
+        // If we've reached this far, and nobody else has done anything with this term, then treat it as a tag
+        if ($event->order == null && $event->img_conditions == [] && $event->tag_conditions == []) {
+            $event->add_tag_condition(new TagCondition($event->term, $event->positive));
+        }
+    }
+
+    public function get_priority(): int
+    {
+        // we want to turn a search term into a TagCondition only if nobody did anything else with that term
+        return 95;
     }
 }


### PR DESCRIPTION
Rather than "add querylet or do nothing", moving more code into the event means that event handlers are able to add a positive or negative querylet, add a positive or negative tag, or do nothing

This means that events can respond to the `null` search term by adding a tag, which would be useful for #917