### PR TITLE
Approval bypass

### DIFF
--- a/core/permissions.php
+++ b/core/permissions.php
@@ -110,6 +110,7 @@ abstract class Permissions
     public const CRON_ADMIN = "cron_admin";
     public const APPROVE_IMAGE = "approve_image";
     public const APPROVE_COMMENT = "approve_comment";
+    public const BYPASS_IMAGE_APPROVAL = "bypass_image_approval";
 
     public const SET_PRIVATE_IMAGE = "set_private_image";
     public const SET_OTHERS_PRIVATE_IMAGES = "set_others_private_images";

--- a/core/userclass.php
+++ b/core/userclass.php
@@ -217,6 +217,7 @@ new UserClass("admin", "base", [
 
     Permissions::APPROVE_IMAGE => true,
     Permissions::APPROVE_COMMENT => true,
+    Permissions::BYPASS_IMAGE_APPROVAL => true,
 
     Permissions::CRON_RUN =>true,
 

--- a/ext/approval/main.php
+++ b/ext/approval/main.php
@@ -28,7 +28,8 @@ class Approval extends Extension
         Image::$bool_props[] = "approved";
     }
 
-    public function onImageAddition(ImageAdditionEvent $event) {
+    public function onImageAddition(ImageAdditionEvent $event)
+    {
         global $user, $config;
 
         if ($config->get_bool(ApprovalConfig::IMAGES) && $config->get_bool(ApprovalConfig::BYPASS) && $user->can(Permissions::BYPASS_IMAGE_APPROVAL)) {

--- a/ext/approval/main.php
+++ b/ext/approval/main.php
@@ -9,7 +9,6 @@ abstract class ApprovalConfig
     public const VERSION = "ext_approval_version";
     public const IMAGES = "approve_images";
     public const COMMENTS = "approve_comments";
-    public const BYPASS = "approval_bypass";
 }
 
 class Approval extends Extension
@@ -23,7 +22,6 @@ class Approval extends Extension
 
         $config->set_default_bool(ApprovalConfig::IMAGES, false);
         $config->set_default_bool(ApprovalConfig::COMMENTS, false);
-        $config->set_default_bool(ApprovalConfig::BYPASS, false);
 
         Image::$bool_props[] = "approved";
     }
@@ -32,7 +30,7 @@ class Approval extends Extension
     {
         global $user, $config;
 
-        if ($config->get_bool(ApprovalConfig::IMAGES) && $config->get_bool(ApprovalConfig::BYPASS) && $user->can(Permissions::BYPASS_IMAGE_APPROVAL)) {
+        if ($config->get_bool(ApprovalConfig::IMAGES) && $user->can(Permissions::BYPASS_IMAGE_APPROVAL)) {
             self::approve_image($event->image->id);
         }
     }

--- a/ext/approval/main.php
+++ b/ext/approval/main.php
@@ -9,6 +9,7 @@ abstract class ApprovalConfig
     public const VERSION = "ext_approval_version";
     public const IMAGES = "approve_images";
     public const COMMENTS = "approve_comments";
+    public const BYPASS = "approval_bypass";
 }
 
 class Approval extends Extension
@@ -22,8 +23,17 @@ class Approval extends Extension
 
         $config->set_default_bool(ApprovalConfig::IMAGES, false);
         $config->set_default_bool(ApprovalConfig::COMMENTS, false);
+        $config->set_default_bool(ApprovalConfig::BYPASS, false);
 
         Image::$bool_props[] = "approved";
+    }
+
+    public function onImageAddition(ImageAdditionEvent $event) {
+        global $user, $config;
+
+        if ($config->get_bool(ApprovalConfig::IMAGES) && $config->get_bool(ApprovalConfig::BYPASS) && $user->can(Permissions::BYPASS_IMAGE_APPROVAL)) {
+            self::approve_image($event->image->id);
+        }
     }
 
     public function onPageRequest(PageRequestEvent $event)

--- a/ext/approval/theme.php
+++ b/ext/approval/theme.php
@@ -47,7 +47,6 @@ class ApprovalTheme extends Themelet
     {
         $sb = $event->panel->create_new_block("Approval");
         $sb->add_bool_option(ApprovalConfig::IMAGES, "Posts: ");
-        $sb->add_bool_option(ApprovalConfig::BYPASS, "<br>Enable Bypass (if user has permission): ");
     }
 
     public function display_admin_form()

--- a/ext/approval/theme.php
+++ b/ext/approval/theme.php
@@ -47,6 +47,7 @@ class ApprovalTheme extends Themelet
     {
         $sb = $event->panel->create_new_block("Approval");
         $sb->add_bool_option(ApprovalConfig::IMAGES, "Posts: ");
+        $sb->add_bool_option(ApprovalConfig::BYPASS, "<br>Enable Bypass (if user has permission): ");
     }
 
     public function display_admin_form()


### PR DESCRIPTION
Hi! I implemented this quick change for images to be auto-approved on upload if the user has a special new permission to bypass the aproval process. A few things to note:

1. Possible improvement: I found it weird that I had to use the `approve_image` method instead of `$event->image->approved = true`, as this wasn't working. Is it because the `approved` boolean is not part of the default Image class?
2. I could've reused the existing permission for the bypass. After all, if you can approve posts you can approve your own. But doing it this way lets you assign only the bypass permission to a userclass, trusting all their posts by default but not letting them approve others'.
3. To keep the existing behaviour, I made a configuration option so that bypass is disabled by default. It can of course be removed if deemed unnecesary. This can also be achieved by simply removing the bypass permission from the admin userclass, but that would obscure the bypass functionality behind the need of a custom permissions file.

Let me know if this needs any changes :)