### PR TITLE
show blocks based on user class

### DIFF
--- a/ext/blocks/theme.php
+++ b/ext/blocks/theme.php
@@ -32,6 +32,8 @@ class BlocksTheme extends Themelet
                     TD(INPUT(["type"=>"text", "name"=>"area", "value"=>$block['area']])),
                     TH("Priority"),
                     TD(INPUT(["type"=>"text", "name"=>"priority", "value"=>$block['priority']])),
+                    TH("User Class"),
+                    TD(INPUT(["type"=>"text", "name"=>"userclass", "value"=>$block['userclass']])),
                     TH("Pages"),
                     TD(INPUT(["type"=>"text", "name"=>"pages", "value"=>$block['pages']])),
                     TH("Delete"),
@@ -39,10 +41,10 @@ class BlocksTheme extends Themelet
                     TD(INPUT(["type"=>"submit", "value"=>"Save"]))
                 ),
                 TR(
-                    TD(["colspan"=>"11"], TEXTAREA(["rows"=>"5", "name"=>"content"], $block['content']))
+                    TD(["colspan"=>"13"], TEXTAREA(["rows"=>"5", "name"=>"content"], $block['content']))
                 ),
                 TR(
-                    TD(["colspan"=>"11"], rawHTML("&nbsp;"))
+                    TD(["colspan"=>"13"], rawHTML("&nbsp;"))
                 ),
             ));
         }
@@ -56,12 +58,14 @@ class BlocksTheme extends Themelet
                 TD(SELECT(["name"=>"area"], OPTION("left"), OPTION("main"))),
                 TH("Priority"),
                 TD(INPUT(["type"=>"text", "name"=>"priority", "value"=>'50'])),
+                TH("User Class"),
+                TD(INPUT(["type"=>"text", "name"=>"userclass", "value"=>""])),
                 TH("Pages"),
                 TD(INPUT(["type"=>"text", "name"=>"pages", "value"=>'post/list*'])),
                 TD(["colspan"=>'3'], INPUT(["type"=>"submit", "value"=>"Add"]))
             ),
             TR(
-                TD(["colspan"=>"11"], TEXTAREA(["rows"=>"5", "name"=>"content"]))
+                TD(["colspan"=>"13"], TEXTAREA(["rows"=>"5", "name"=>"content"]))
             ),
         ));
 


### PR DESCRIPTION
Addressing #624, new documentation/help for the blocks extension might be needed.

Basically:

The userclass parameter can be left empty for blocks to show to everyone, or specified as a comma-separated, case-insensitive list of user classes that will see that block. Spaces around the comma get stripped.

Example, I have 3 blocks with the following content and userclass values:

- "You are not logged in": `anonymous`
- "You are logged in": `user, admin`
- "You are an admin": `admin`

A real use case:

- "<**ad here**>": `user, anonymous`
- "Thanks for supporting us!": `supporter`