### PR TITLE
Fix .htaccess rewrite

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,7 +21,7 @@
 
 	# any requests for files which don't physically exist should be handled by index.php
 	RewriteCond %{REQUEST_FILENAME} !-f
-	RewriteRule ^(.*)$ index.php?q=$1&%{QUERY_STRING} [L]
+	RewriteRule ^(.*)$ index.php?q=$1&%{QUERY_STRING} "[L,B= ?,BNP]"
 </IfModule>
 
 <IfModule mod_expires.c>


### PR DESCRIPTION
When using recent versions of Apache and the provided `.htaccess` file (with "Nice URLs" enabled in Shimmie), you get 403 Forbidden when attempting to navigate to a URL containing spaces, e.g. `http://<shimmie>/post/list/tag1%20tag2/1`.

Apache's error log shows:
```
AH10411: Rewritten query string contains control characters or spaces
```

We fix this by adding `B` and `BNP`, as per [here](https://webmasters.stackexchange.com/a/141978).