### PR TITLE
Make SHM_POST_INFO more logical

### DIFF
--- a/core/microhtml.php
+++ b/core/microhtml.php
@@ -15,6 +15,7 @@ use function MicroHTML\OPTION;
 use function MicroHTML\PRE;
 use function MicroHTML\P;
 use function MicroHTML\SELECT;
+use function MicroHTML\SPAN;
 use function MicroHTML\TABLE;
 use function MicroHTML\THEAD;
 use function MicroHTML\TFOOT;
@@ -154,17 +155,20 @@ function SHM_OPTION(string $value, string $text, bool $selected = false): HTMLEl
 
 function SHM_POST_INFO(
     HTMLElement|string $title,
-    bool $can_edit,
-    HTMLElement|string $view,
-    HTMLElement|string $edit = "",
+    HTMLElement|string|null $view = null,
+    HTMLElement|string|null $edit = null,
 ): HTMLElement {
-    return TR(
-        TH(["width" => "50px"], $title),
-        $can_edit ?
-            emptyHTML(
-                TD(["class" => "view"], $view),
-                TD(["class" => "edit"], $edit),
-            ) :
-            TD($view)
-    );
+    if(!is_null($view) && !is_null($edit)) {
+        $show = emptyHTML(
+            SPAN(["class" => "view"], $view),
+            SPAN(["class" => "edit"], $edit),
+        );
+    } elseif(!is_null($edit)) {
+        $show = $edit;
+    } elseif(!is_null($view)) {
+        $show = $view;
+    } else {
+        $show = "???";
+    }
+    return TR(TH(["width" => "50px"], $title), TD($show));
 }

--- a/ext/artists/theme.php
+++ b/ext/artists/theme.php
@@ -15,7 +15,6 @@ class ArtistsTheme extends Themelet
     {
         return SHM_POST_INFO(
             "Author",
-            true,
             $author,
             INPUT(["type" => "text", "name" => "tag_edit__author", "value" => $author])
         );

--- a/ext/image_view_counter/main.php
+++ b/ext/image_view_counter/main.php
@@ -70,7 +70,7 @@ class ImageViewCounter extends Extension
                 ["image_id" => $event->image->id]
             );
 
-            $event->add_part(SHM_POST_INFO("Views", false, $view_count, ""), 38);
+            $event->add_part(SHM_POST_INFO("Views", $view_count), 38);
         }
     }
 

--- a/ext/post_titles/theme.php
+++ b/ext/post_titles/theme.php
@@ -14,9 +14,8 @@ class PostTitlesTheme extends Themelet
     {
         return SHM_POST_INFO(
             "Title",
-            $can_set,
             $title,
-            INPUT(["type" => "text", "name" => "post_title", "value" => $title])
+            $can_set ? INPUT(["type" => "text", "name" => "post_title", "value" => $title]) : null
         );
     }
 }

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -20,9 +20,8 @@ class RatingsTheme extends Themelet
     {
         return SHM_POST_INFO(
             "Rating",
-            $can_rate,
             A(["href" => search_link(["rating=$rating"])], Ratings::rating_to_human($rating)),
-            $this->get_selection_rater_html("rating", selected_options: [$rating])
+            $can_rate ? $this->get_selection_rater_html("rating", selected_options: [$rating]) : null
         );
     }
 

--- a/ext/relationships/theme.php
+++ b/ext/relationships/theme.php
@@ -39,9 +39,8 @@ class RelationshipsTheme extends Themelet
 
         return SHM_POST_INFO(
             "Parent",
-            !$user->is_anonymous(),
             strval($image->parent_id) ?: "None",
-            INPUT(["type" => "number", "name" => "tag_edit__parent", "value" => $image->parent_id])
+            !$user->is_anonymous() ? INPUT(["type" => "number", "name" => "tag_edit__parent", "value" => $image->parent_id]) : null
         );
     }
 

--- a/ext/rule34/main.php
+++ b/ext/rule34/main.php
@@ -41,7 +41,6 @@ class Rule34 extends Extension
         $event->add_part(
             SHM_POST_INFO(
                 "Links",
-                false,
                 emptyHTML(
                     A(["href" => $url0], "File Only"),
                     " (",

--- a/ext/tag_edit/theme.php
+++ b/ext/tag_edit/theme.php
@@ -56,16 +56,15 @@ class TagEditTheme extends Themelet
 
         return SHM_POST_INFO(
             "Tags",
-            $user->can(Permissions::EDIT_IMAGE_TAG),
             joinHTML(", ", $tag_links),
-            INPUT([
+            $user->can(Permissions::EDIT_IMAGE_TAG) ? INPUT([
                 "class" => "autocomplete_tags",
                 "type" => "text",
                 "name" => "tag_edit__tags",
                 "value" => $image->get_tag_list(),
                 "id" => "tag_editor",
                 "autocomplete" => "off"
-            ])
+            ]) : null
         );
     }
 
@@ -77,9 +76,8 @@ class TagEditTheme extends Themelet
         $ip = $user->can(Permissions::VIEW_IP) ? rawHTML(" (" . show_ip($image->owner_ip, "Post posted {$image->posted}") . ")") : "";
         $info = SHM_POST_INFO(
             "Uploader",
-            $user->can(Permissions::EDIT_IMAGE_OWNER),
             emptyHTML(A(["class" => "username", "href" => make_link("user/$owner")], $owner), $ip, ", ", $date),
-            INPUT(["type" => "text", "name" => "tag_edit__owner", "value" => $owner])
+            $user->can(Permissions::EDIT_IMAGE_OWNER) ? INPUT(["type" => "text", "name" => "tag_edit__owner", "value" => $owner]) : null
         );
         // SHM_POST_INFO returns a TR, let's sneakily append
         // a TD with the avatar in it
@@ -97,12 +95,11 @@ class TagEditTheme extends Themelet
         global $user;
         return SHM_POST_INFO(
             "Source",
-            $user->can(Permissions::EDIT_IMAGE_SOURCE),
             DIV(
                 ["style" => "overflow: hidden; white-space: nowrap; max-width: 350px; text-overflow: ellipsis;"],
                 $this->format_source($image->get_source())
             ),
-            INPUT(["type" => "text", "name" => "tag_edit__source", "value" => $image->get_source()])
+            $user->can(Permissions::EDIT_IMAGE_SOURCE) ? INPUT(["type" => "text", "name" => "tag_edit__source", "value" => $image->get_source()]) : null
         );
     }
 
@@ -127,9 +124,8 @@ class TagEditTheme extends Themelet
         global $user;
         return SHM_POST_INFO(
             "Locked",
-            $user->can(Permissions::EDIT_IMAGE_LOCK),
             $image->is_locked() ? "Yes (Only admins may edit these details)" : "No",
-            INPUT(["type" => "checkbox", "name" => "tag_edit__locked", "checked" => $image->is_locked()])
+            $user->can(Permissions::EDIT_IMAGE_LOCK) ? INPUT(["type" => "checkbox", "name" => "tag_edit__locked", "checked" => $image->is_locked()]) : null
         );
     }
 }

--- a/ext/view/main.php
+++ b/ext/view/main.php
@@ -123,7 +123,7 @@ class ViewImage extends Extension
         global $config;
         $image_info = $config->get_string(ImageConfig::INFO);
         if ($image_info) {
-            $event->add_part(SHM_POST_INFO("Info", false, $event->image->get_info()), 85);
+            $event->add_part(SHM_POST_INFO("Info", $event->image->get_info()), 85);
         }
     }
 }


### PR DESCRIPTION
Rather than having a boolean for view or edit + optional editor, use the existence of the editor to know if a field is editable