### PR TITLE
[core] don't specify ORDER BY when counting total number of results, which allows the DB to be much faster

### DIFF
--- a/core/imageboard/search.php
+++ b/core/imageboard/search.php
@@ -174,7 +174,7 @@ class Search
             $total = $cache->get($cache_key);
             if (is_null($total)) {
                 [$tag_conditions, $img_conditions, $order] = self::terms_to_conditions($tags);
-                $querylet = self::build_search_querylet($tag_conditions, $img_conditions, $order);
+                $querylet = self::build_search_querylet($tag_conditions, $img_conditions, null);
                 $total = (int)$database->get_one("SELECT COUNT(*) AS cnt FROM ($querylet->sql) AS tbl", $querylet->variables);
                 if (SPEED_HAX && $total > 5000) {
                     // when we have a ton of images, the count
@@ -240,7 +240,7 @@ class Search
     private static function build_search_querylet(
         array $tag_conditions,
         array $img_conditions,
-        string $order,
+        ?string $order = null,
         ?int $limit = null,
         ?int $offset = null
     ): Querylet {
@@ -414,7 +414,9 @@ class Search
             $query->append(new Querylet($img_sql, $img_vars));
         }
 
-        $query->append(new Querylet(" ORDER BY ".$order));
+        if(!is_null($order)) {
+            $query->append(new Querylet(" ORDER BY ".$order));
+        }
 
         if (!is_null($limit)) {
             $query->append(new Querylet(" LIMIT :limit ", ["limit" => $limit]));


### PR DESCRIPTION
```
# explain analyze SELECT COUNT(*) AS cnt FROM (SELECT images.* FROM images WHERE 1=1 AND (numeric_score > 2) ORDER BY images.id DESC) AS tbl;
                                                                         QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=657728.66..657728.67 rows=1 width=8) (actual time=4842.412..4842.414 rows=1 loops=1)
   ->  Index Scan Backward using images_pkey on images  (cost=0.43..631953.33 rows=2062026 width=2377) (actual time=148.217..4729.022 rows=2039895 loops=1)
         Filter: (numeric_score > 2)
         Rows Removed by Filter: 3452140
 Planning Time: 0.208 ms
 JIT:
   Functions: 6
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 0.848 ms, Inlining 8.995 ms, Optimization 74.704 ms, Emission 64.108 ms, Total 148.655 ms
 Execution Time: 4843.408 ms
```

```
# explain analyze SELECT COUNT(*) AS cnt FROM (SELECT images.* FROM images WHERE 1=1 AND (numeric_score > 2)) AS tbl;
                                                                                   QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=39943.57..39943.58 rows=1 width=8) (actual time=291.672..342.260 rows=1 loops=1)
   ->  Gather  (cost=39943.36..39943.57 rows=2 width=8) (actual time=291.427..342.250 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=38943.36..38943.37 rows=1 width=8) (actual time=269.285..269.286 rows=1 loops=3)
               ->  Parallel Index Only Scan using images_numeric_score_idx on images  (cost=0.43..36795.41 rows=859178 width=0) (actual time=0.096..232.806 rows=679965 loops=3)
                     Index Cond: (numeric_score > 2)
                     Heap Fetches: 507029
 Planning Time: 0.236 ms
 Execution Time: 342.357 ms
```
