### PR TITLE
Add togglable thumbnails for post relationships

### DIFF
--- a/ext/relationships/info.php
+++ b/ext/relationships/info.php
@@ -10,7 +10,7 @@ class RelationshipsInfo extends ExtensionInfo
 
     public string $key = self::KEY;
     public string $name = "Post Relationships";
-    public array $authors = ["Angus Johnston" => "admin@codeanimu.net"];
+    public array $authors = ["Angus Johnston" => "admin@codeanimu.net", 'joe' => 'joe@thisisjoes.site'];
     public string $license = self::LICENSE_GPLV2;
     public ExtensionCategory $category = ExtensionCategory::METADATA;
     public string $description = "Allow posts to have relationships (parent/child).";

--- a/ext/relationships/script.js
+++ b/ext/relationships/script.js
@@ -1,0 +1,35 @@
+document.addEventListener('DOMContentLoaded', () => {
+        $(".shm-relationships-parent-toggle").click(function() {
+                $(".shm-relationships-parent-thumbs").slideToggle("fast", function() {
+                        if($(".shm-relationships-parent-thumbs").is(":hidden")) {
+                                $(".shm-relationships-parent-toggle").text("show »");
+                                Cookies.set("ui-relationships-parent-hidden", 'true');
+                        }
+                        else {
+                                $(".shm-relationships-parent-toggle").text("« hide");
+                                Cookies.set("ui-relationships-parent-hidden", 'false');
+                        }
+                });
+        });
+        if(Cookies.get("ui-relationships-parent-hidden") === 'true') {
+                $(".shm-relationships-parent-thumbs").hide();
+                $(".shm-relationships-parent-toggle").text("show »");
+        }
+
+        $(".shm-relationships-child-toggle").click(function() {
+                $(".shm-relationships-child-thumbs").slideToggle("fast", function() {
+                        if($(".shm-relationships-child-thumbs").is(":hidden")) {
+                                $(".shm-relationships-child-toggle").text("show »");
+                                Cookies.set("ui-relationships-child-hidden", 'true');
+                        }
+                        else {
+                                $(".shm-relationships-child-toggle").text("« hide");
+                                Cookies.set("ui-relationships-child-hidden", 'false');
+                        }
+                });
+        });
+        if(Cookies.get("ui-relationships-child-hidden") === 'true') {
+                $(".shm-relationships-child-thumbs").hide();
+                $(".shm-relationships-child-toggle").text("show »");
+        }
+});

--- a/ext/relationships/theme.php
+++ b/ext/relationships/theme.php
@@ -37,7 +37,7 @@ class RelationshipsTheme extends Themelet
             $parent_summary_html .= "<a href='#' id='relationships-parent-toggle' class='shm-relationships-parent-toggle'>« hide</a>";
             $parent_thumb_html .= "</div>";
             $html = $parent_summary_html . $parent_thumb_html;
-            $page->add_block(new Block(null, $html, "main", 5, "PostRelationships"));
+            $page->add_block(new Block(null, $html, "main", 5, "PostRelationshipsParent"));
         }
 
         if (bool_escape($image['has_children'])) {
@@ -54,7 +54,7 @@ class RelationshipsTheme extends Themelet
                 $child_summary_html .= "</span><a href='#' id='relationships-child-toggle' class='shm-relationships-child-toggle'>« hide</a>";
                 $child_thumb_html .= "</div></div>";
                 $html = $child_summary_html . $child_thumb_html;
-                $page->add_block(new Block(null, $html, "main", 5, "PostRelationships"));
+                $page->add_block(new Block(null, $html, "main", 5, "PostRelationshipsChildren"));
             }
         }
     }


### PR DESCRIPTION
Can show thumbnails for parents, children, and siblings! should not show any relationships if they are hidden by ratings/etc.

A lot of shimmie code has been refactored since this was originally written, so I've done my best to adapt it. if you have suggestions for optimizing the code or making it more readable lmk

**Child post thumbnails:**
![2024-02-14 22 34 12 localhost 5eb54811cad2](https://github.com/shish/shimmie2/assets/91732583/3e6cedea-8565-4204-b790-22286b1dbd11)

**Parent and sibling thumbnails:**
![2024-02-14 22 34 17 localhost fe84d3cf9397](https://github.com/shish/shimmie2/assets/91732583/c79279f6-a046-440e-86c4-68ba4cf3faea)
