### PR TITLE
Do not cast hard drive size to integer - fixes #1037

### DIFF
--- a/core/polyfills.php
+++ b/core/polyfills.php
@@ -488,7 +488,7 @@ function parse_shorthand_int(string $limit): int
 /**
  * Turn an integer into a human readable filesize, eg 1024 -> 1KB
  */
-function to_shorthand_int(int $int): string
+function to_shorthand_int(int|float $int): string
 {
     assert($int >= 0);
 

--- a/ext/et/main.php
+++ b/ext/et/main.php
@@ -77,6 +77,8 @@ class ET extends Extension
             $ver .= "+";
         }
 
+        $disk_total = false_throws(disk_total_space("./"));
+        $disk_free = false_throws(disk_free_space("./"));
         $info = [
             "about" => [
                 'title' => $config->get_string(SetupConfig::TITLE),
@@ -103,8 +105,8 @@ class ET extends Extension
             ],
             "media" => [
                 "memory_limit" => to_shorthand_int($config->get_int(MediaConfig::MEM_LIMIT)),
-                "disk_use" => to_shorthand_int((int)disk_total_space("./") - (int)disk_free_space("./")),
-                "disk_total" => to_shorthand_int((int)disk_total_space("./")),
+                "disk_use" => to_shorthand_int($disk_total - $disk_free),
+                "disk_total" => to_shorthand_int($disk_total),
             ],
             "thumbnails" => [
                 "engine" => $config->get_string(ImageConfig::THUMB_ENGINE),


### PR DESCRIPTION
`disk_total_space` and `disk_free_space` return floats already, so we can avoid triggering an integer overflow by just working using those floats instead.