### PR TITLE
[upload] add rating fields to upload form

### DIFF
--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -165,6 +165,11 @@ class Ratings extends Extension
         }
     }
 
+    public function onUploadRatingBuilding(UploadRatingBuildingEvent $event): void
+    {
+        $event->part = (string)$this->theme->get_upload_rater_html($event->suffix);
+    }
+
     public function onDisplayingImage(DisplayingImageEvent $event): void
     {
         global $page;
@@ -204,7 +209,7 @@ class Ratings extends Extension
     {
         global $user;
         $event->add_part(
-            $this->theme->get_rater_html(
+            $this->theme->get_image_rater_html(
                 $event->image->id,
                 $event->image['rating'],
                 $user->can(Permissions::EDIT_IMAGE_RATING)

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -7,6 +7,7 @@ namespace Shimmie2;
 use MicroHTML\HTMLElement;
 
 use function MicroHTML\emptyHTML;
+use function MicroHTML\rawHTML;
 use function MicroHTML\{A,P,TABLE,TD,TH,TR};
 
 class RatingsTheme extends Themelet
@@ -20,13 +21,18 @@ class RatingsTheme extends Themelet
         return SHM_SELECT($name, !empty($ratings) ? $ratings : Ratings::get_ratings_dict(), required: true, selected_options: $selected_options);
     }
 
-    public function get_rater_html(int $image_id, string $rating, bool $can_rate): HTMLElement
+    public function get_image_rater_html(int $image_id, string $rating, bool $can_rate): HTMLElement
     {
         return SHM_POST_INFO(
             "Rating",
             A(["href" => search_link(["rating=$rating"])], Ratings::rating_to_human($rating)),
             $can_rate ? $this->get_selection_rater_html("rating", selected_options: [$rating]) : null
         );
+    }
+
+    public function get_upload_rater_html(string $suffix): HTMLElement
+    {
+        return $this->get_selection_rater_html(name:"rating${suffix}", selected_options: ["?"]);
     }
 
     /**

--- a/ext/upload/events/upload_rating_building_event.php
+++ b/ext/upload/events/upload_rating_building_event.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+class UploadRatingBuildingEvent extends Event
+{
+    public string $part;
+    public string $suffix;
+
+    public function __construct(string $suffix)
+    {
+        parent::__construct();
+
+        $this->suffix = $suffix;
+    }
+}

--- a/ext/upload/main.php
+++ b/ext/upload/main.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shimmie2;
 
 require_once "config.php";
+require_once "events/upload_rating_building_event.php";
 
 /**
  * Occurs when some data is being uploaded.
@@ -36,6 +37,9 @@ class DataUploadEvent extends Event
         assert(is_string($metadata["filename"]));
         assert(is_array($metadata["tags"]));
         assert(is_string($metadata["source"]) || is_null($metadata["source"]));
+        if (Extension::is_enabled(RatingsInfo::KEY)) {
+            assert(is_string($metadata['rating']));
+        }
 
         // DB limits to 255 char filenames
         $metadata['filename'] = substr($metadata['filename'], 0, 255);
@@ -237,7 +241,8 @@ class Upload extends Extension
                 $slot = int_escape(substr($name, 4));
                 $tags = $this->tags_for_upload_slot($event->POST, $slot);
                 $source = $this->source_for_upload_slot($event->POST, $slot);
-                $results = array_merge($results, $this->try_upload($file, $tags, $source));
+                $rating = $this->rating_for_upload_slot($event->POST, $slot);
+                $results = array_merge($results, $this->try_upload($file, $tags, $source, $rating));
             }
 
             $urls = array_filter($event->POST, function ($value, $key) {
@@ -247,7 +252,8 @@ class Upload extends Extension
                 $slot = int_escape(substr($name, 3));
                 $tags = $this->tags_for_upload_slot($event->POST, $slot);
                 $source = $this->source_for_upload_slot($event->POST, $slot);
-                $results = array_merge($results, $this->try_transload($value, $tags, $source));
+                $rating = $this->rating_for_upload_slot($event->POST, $slot);
+                $results = array_merge($results, $this->try_transload($value, $tags, $source, $rating));
             }
 
             $this->theme->display_upload_status($page, $results);
@@ -288,6 +294,22 @@ class Upload extends Extension
     }
 
     /**
+     * @param array<string, mixed> $params
+     */
+    private function rating_for_upload_slot(array $params, int $id): ?string
+    {
+        if (Extension::is_enabled(RatingsInfo::KEY) && (!empty($params["rating"]) || !empty($params["rating$id"]))) {
+            if($params["rating$id"] != "?") {
+                return $params["rating$id"];
+            }
+            if($params["rating"] != "?") {
+                return $params["rating"];
+            }
+        }
+        return null;
+    }
+
+    /**
      * Returns a descriptive error message for the specified PHP error code.
      *
      * This is a helper function based on the one from the online PHP Documentation
@@ -323,7 +345,7 @@ class Upload extends Extension
      * @param string[] $tags
      * @return UploadResult[]
      */
-    private function try_upload(array $file, array $tags, ?string $source = null): array
+    private function try_upload(array $file, array $tags, ?string $source = null, ?string $rating = null): array
     {
         global $page, $config, $database;
 
@@ -352,11 +374,12 @@ class Upload extends Extension
                     throw new UploadException($this->upload_error_message($error));
                 }
 
-                $new_images = $database->with_savepoint(function () use ($tmp_name, $name, $tags, $source) {
+                $new_images = $database->with_savepoint(function () use ($tmp_name, $name, $tags, $source, $rating) {
                     $event = send_event(new DataUploadEvent($tmp_name, [
                         'filename' => pathinfo($name, PATHINFO_BASENAME),
                         'tags' => $tags,
                         'source' => $source,
+                        'rating' => $rating,
                     ]));
                     if (count($event->images) == 0) {
                         throw new UploadException("MIME type not supported: " . $event->mime);
@@ -378,7 +401,7 @@ class Upload extends Extension
      * @param string[] $tags
      * @return UploadResult[]
      */
-    private function try_transload(string $url, array $tags, string $source = null): array
+    private function try_transload(string $url, array $tags, string $source = null, ?string $rating = null): array
     {
         global $page, $config, $user, $database;
 
@@ -402,6 +425,9 @@ class Upload extends Extension
             $metadata['filename'] = $filename;
             $metadata['tags'] = $tags;
             $metadata['source'] = $source;
+            if (Extension::is_enabled(RatingsInfo::KEY)) {
+                $metadata['rating'] = $rating;
+            }
 
             $new_images = $database->with_savepoint(function () use ($tmp_filename, $metadata) {
                 $event = send_event(new DataUploadEvent($tmp_filename, $metadata));

--- a/ext/upload/theme.php
+++ b/ext/upload/theme.php
@@ -94,6 +94,7 @@ class UploadTheme extends Themelet
         $upload_list = emptyHTML();
         $upload_count = $config->get_int(UploadConfig::COUNT);
         $tl_enabled = ($config->get_string(UploadConfig::TRANSLOAD_ENGINE, "none") != "none");
+        $ratings_enabled = Extension::is_enabled(RatingsInfo::KEY);
         $accept = $this->get_accept();
 
         $upload_list->appendChild(
@@ -103,8 +104,11 @@ class UploadTheme extends Themelet
                 TH($tl_enabled ? "or URL" : null),
                 TH("Post-Specific Tags"),
                 TH("Post-Specific Source"),
+                TH($ratings_enabled ? "Rating" : null),
             )
         );
+
+
 
         for ($i = 0; $i < $upload_count; $i++) {
             $upload_list->appendChild(
@@ -145,6 +149,9 @@ class UploadTheme extends Themelet
                             "name" => "source{$i}",
                             "value" => ($i == 0) ? @$_GET['source'] : null,
                         ])
+                    ),
+                    TD(
+                        $ratings_enabled ? rawHTML(send_event(new UploadRatingBuildingEvent((string)$i))->part) : null
                     ),
                 )
             );


### PR DESCRIPTION
If the Post Ratings extension is enabled, encourage a rating to be selected when uploading.

This can be extended to also have a Common Ratings field, if wanted.