### PR TITLE
Fix unnecessary truncation when trimming comments

### DIFF
--- a/ext/comment/theme.php
+++ b/ext/comment/theme.php
@@ -209,7 +209,11 @@ class CommentListTheme extends Themelet
         $i_uid = $comment->owner_id;
         $h_name = html_escape($comment->owner_name);
         $h_timestamp = autodate($comment->posted);
-        $h_comment = ($trim ? truncate($tfe->stripped, 50) : $tfe->formatted);
+        if ($trim) {
+            $h_comment = strlen($tfe->stripped) > 52 ? substr($tfe->stripped, 0, 50)."..." : $tfe->stripped;
+        } else {
+            $h_comment = $tfe->formatted;
+        }
         $i_comment_id = $comment->comment_id;
         $i_image_id = $comment->image_id;
 

--- a/themes/danbooru/comment.theme.php
+++ b/themes/danbooru/comment.theme.php
@@ -103,7 +103,11 @@ class CustomCommentListTheme extends CommentListTheme
         //$i_uid = $comment->owner_id;
         $h_name = html_escape($comment->owner_name);
         //$h_poster_ip = html_escape($comment->poster_ip);
-        $h_comment = ($trim ? substr($tfe->stripped, 0, 50)."..." : $tfe->formatted);
+        if ($trim) {
+            $h_comment = strlen($tfe->stripped) > 52 ? substr($tfe->stripped, 0, 50)."..." : $tfe->stripped;
+        } else {
+            $h_comment = $tfe->formatted;
+        }
         $i_comment_id = $comment->comment_id;
         $i_image_id = $comment->image_id;
         $h_posted = autodate($comment->posted);

--- a/themes/danbooru2/comment.theme.php
+++ b/themes/danbooru2/comment.theme.php
@@ -103,7 +103,11 @@ class CustomCommentListTheme extends CommentListTheme
         //$i_uid = $comment->owner_id;
         $h_name = html_escape($comment->owner_name);
         //$h_poster_ip = html_escape($comment->poster_ip);
-        $h_comment = ($trim ? substr($tfe->stripped, 0, 50)."..." : $tfe->formatted);
+        if ($trim) {
+            $h_comment = strlen($tfe->stripped) > 52 ? substr($tfe->stripped, 0, 50)."..." : $tfe->stripped;
+        } else {
+            $h_comment = $tfe->formatted;
+        }
         $i_comment_id = $comment->comment_id;
         $i_image_id = $comment->image_id;
         $h_posted = autodate($comment->posted);

--- a/themes/futaba/comment.theme.php
+++ b/themes/futaba/comment.theme.php
@@ -77,7 +77,11 @@ class CustomCommentListTheme extends CommentListTheme
         //$i_uid = $comment->owner_id;
         $h_name = html_escape($comment->owner_name);
         //$h_poster_ip = html_escape($comment->poster_ip);
-        $h_comment = ($trim ? substr($tfe->stripped, 0, 50)."..." : $tfe->formatted);
+        if ($trim) {
+            $h_comment = strlen($tfe->stripped) > 52 ? substr($tfe->stripped, 0, 50)."..." : $tfe->stripped;
+        } else {
+            $h_comment = $tfe->formatted;
+        }
         $i_comment_id = $comment->comment_id;
         $i_image_id = $comment->image_id;
 


### PR DESCRIPTION
This prevents a very short comment from having the ellipsis (...) appended to it.

This commit also makes trimming consistent across themes (default theme truncated without any ellipsis to signal truncation, danboorus and futaba had ellipsis).