### PR TITLE
[notes] allow clicking through notes container

### DIFF
--- a/ext/notes/style.css
+++ b/ext/notes/style.css
@@ -1,5 +1,6 @@
 .notes-container {
 	position: absolute;
+	pointer-events: none;
 }
 
 .notes-container .note {
@@ -13,6 +14,7 @@
 	position: absolute;
 	opacity: 0.5;
 	z-index: 1;
+	pointer-events: auto;
 }
 .notes-container .note.editing {
 	opacity: 1;
@@ -40,6 +42,7 @@
 		"save cancel"
 		"delete delete";
 	z-index: 4;
+	pointer-events: auto;
 }
 .notes-container .editor TEXTAREA {
 	grid-area: text;


### PR DESCRIPTION
If the notes extension is enabled, the container would block clicking the image, including right-clicking to save it