### PR TITLE
Installation Fixes and Default Config Changes

### DIFF
--- a/core/install.php
+++ b/core/install.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+require_once "core/urls.php";
+
 /**
  * Shimmie Installer
  *
@@ -126,13 +128,15 @@ function ask_questions(): void
     $warn_msg = $warnings ? "<h3>Warnings</h3>".implode("\n<p>", $warnings) : "";
     $err_msg = $errors ? "<h3>Errors</h3>".implode("\n<p>", $errors) : "";
 
+    $data_href = get_base_href();
+
     die_nicely(
         "Install Options",
         <<<EOD
     $warn_msg
     $err_msg
 
-    <form action="index.php" method="POST">
+    <form action="$data_href/index.php" method="POST">
 		<table class='form' style="margin: 1em auto;">
 			<tr>
 				<th>Type:</th>

--- a/core/sanitize_php.php
+++ b/core/sanitize_php.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+require_once "core/urls.php";
+
 /*
  * A small number of PHP-sanity things (eg don't silently ignore errors) to
  * be included right at the very start of index.php and tests/bootstrap.php
@@ -11,19 +13,20 @@ namespace Shimmie2;
 
 function die_nicely(string $title, string $body, int $code = 0): void
 {
+    $data_href = get_base_href();
     print("<!DOCTYPE html>
 <html lang='en'>
 	<head>
 		<title>Shimmie</title>
-		<link rel=\"shortcut icon\" href=\"ext/static_files/static/favicon.ico\">
-		<link rel=\"stylesheet\" href=\"ext/static_files/style.css\" type=\"text/css\">
-		<link rel=\"stylesheet\" href=\"ext/static_files/installer.css\" type=\"text/css\">
+		<link rel='shortcut icon' href='$data_href/ext/static_files/static/favicon.ico'>
+		<link rel='stylesheet' href='$data_href/ext/static_files/style.css' type='text/css'>
+		<link rel='stylesheet' href='$data_href/ext/static_files/installer.css' type='text/css'>
 	</head>
 	<body>
-		<div id=\"installer\">
+		<div id='installer'>
 		    <h1>Shimmie</h1>
 		    <h3>$title</h3>
-			<div class=\"container\">
+			<div class='container'>
 			    $body
 			</div>
 		</div>

--- a/ext/handle_pixel/script.js
+++ b/ext/handle_pixel/script.js
@@ -39,12 +39,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	$("img.shm-main-image").click(function(e) {
 		switch(shm_cookie_get("ui-image-zoom")) {
-			case "full": zoom("width"); break;
+			case "full": zoom("both"); break;
 			default: zoom("full"); break;
 		}
 	});
 
 	if(shm_cookie_get("ui-image-zoom")) {
 		zoom(shm_cookie_get("ui-image-zoom"));
+	}
+	else {
+		zoom("both");
 	}
 });

--- a/ext/handle_pixel/script.js
+++ b/ext/handle_pixel/script.js
@@ -38,9 +38,17 @@ document.addEventListener('DOMContentLoaded', () => {
 	});
 
 	$("img.shm-main-image").click(function(e) {
-		switch(shm_cookie_get("ui-image-zoom")) {
-			case "full": zoom("both"); break;
-			default: zoom("full"); break;
+		var val = $(".shm-zoomer")[0].value;
+		var cookie = shm_cookie_get("ui-image-zoom");
+
+		if (val == "full" && cookie == "full"){
+			zoom("both", false);
+		}
+		else if (val != "full"){
+			zoom("full", false);
+		}
+		else {
+			zoom(cookie, false);
 		}
 	});
 

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -144,7 +144,7 @@ class UserPage extends Extension
         $config->set_default_string("avatar_gravatar_default", "");
         $config->set_default_string("avatar_gravatar_rating", "g");
         $config->set_default_bool("login_tac_bbcode", true);
-        $config->set_default_bool("user_email_required", true);
+        $config->set_default_bool("user_email_required", false);
     }
 
     public function onUserLogin(UserLoginEvent $event): void


### PR DESCRIPTION
- core/install.php install form POST pointed to wrong location when the booru is in a subdirectory
- core/sanitize_php.php die_nicely is used by the installer and the static files point to the wrong location when the booru is in a subdirectory
- an email being required should not be the default since during installation the admin would need to enter one, there is an easy checkbox to enable it in the board config, and user emails aren't validated and generally unused except for gravatar
- changed the default zoom to be "both" since every other booru downsizes a post to fit it within view, nobody wants to just see just half of a large post by default