### PR TITLE
[core] give admin all permissions

### DIFF
--- a/core/userclass.php
+++ b/core/userclass.php
@@ -79,11 +79,17 @@ class UserClass
 }
 
 $_all_false = [];
+$_all_true = [];
 foreach ((new \ReflectionClass(Permissions::class))->getConstants() as $k => $v) {
     assert(is_string($v));
     $_all_false[$v] = false;
+    $_all_true[$v] = true;
 }
+// hellbanned is a snowflake, it isn't really a "permission" so much as
+// "a special behaviour which applies to one particular user class"
+$_all_true[Permissions::HELLBANNED] = false;
 new UserClass("base", null, $_all_false);
+new UserClass("admin", null, $_all_true);
 unset($_all_false);
 
 // Ghost users can't do anything
@@ -125,115 +131,6 @@ new UserClass("user", "base", [
 
 new UserClass("hellbanned", "user", [
     Permissions::HELLBANNED => true,
-]);
-
-new UserClass("admin", "base", [
-    Permissions::CHANGE_SETTING => true,
-    Permissions::CHANGE_USER_SETTING => true,
-    Permissions::CHANGE_OTHER_USER_SETTING => true,
-    Permissions::OVERRIDE_CONFIG => true,
-    Permissions::BIG_SEARCH => true,
-
-    Permissions::MANAGE_EXTENSION_LIST => true,
-    Permissions::MANAGE_ALIAS_LIST => true,
-    Permissions::MANAGE_AUTO_TAG => true,
-    Permissions::MASS_TAG_EDIT => true,
-
-    Permissions::VIEW_IP => true,
-    Permissions::BAN_IP => true,
-
-    Permissions::CREATE_USER => true,
-    Permissions::CREATE_OTHER_USER => true,
-    Permissions::EDIT_USER_NAME => true,
-    Permissions::EDIT_USER_PASSWORD => true,
-    Permissions::EDIT_USER_INFO => true,
-    Permissions::EDIT_USER_CLASS => true,
-    Permissions::DELETE_USER => true,
-
-    Permissions::CREATE_COMMENT => true,
-    Permissions::DELETE_COMMENT => true,
-    Permissions::BYPASS_COMMENT_CHECKS => true,
-
-    Permissions::REPLACE_IMAGE => true,
-    Permissions::CREATE_IMAGE => true,
-    Permissions::EDIT_IMAGE_TAG => true,
-    Permissions::EDIT_IMAGE_SOURCE => true,
-    Permissions::EDIT_IMAGE_OWNER => true,
-    Permissions::EDIT_IMAGE_LOCK => true,
-    Permissions::EDIT_IMAGE_TITLE => true,
-    Permissions::EDIT_IMAGE_RELATIONSHIPS => true,
-    Permissions::EDIT_IMAGE_ARTIST => true,
-    Permissions::BULK_EDIT_IMAGE_TAG => true,
-    Permissions::BULK_EDIT_IMAGE_SOURCE => true,
-    Permissions::DELETE_IMAGE => true,
-
-    Permissions::BAN_IMAGE => true,
-
-    Permissions::VIEW_EVENTLOG => true,
-    Permissions::IGNORE_DOWNTIME => true,
-    Permissions::VIEW_REGISTRATIONS => true,
-
-    Permissions::CREATE_IMAGE_REPORT => true,
-    Permissions::VIEW_IMAGE_REPORT => true,
-
-    Permissions::WIKI_ADMIN => true,
-    Permissions::EDIT_WIKI_PAGE => true,
-    Permissions::DELETE_WIKI_PAGE => true,
-
-    Permissions::MANAGE_BLOCKS => true,
-
-    Permissions::MANAGE_ADMINTOOLS => true,
-
-    Permissions::SEND_PM => true,
-    Permissions::READ_PM => true,
-    Permissions::VIEW_OTHER_PMS => true, # hm
-    Permissions::EDIT_FEATURE => true,
-    Permissions::BULK_EDIT_VOTE => true,
-    Permissions::EDIT_OTHER_VOTE => true,
-    Permissions::CREATE_VOTE => true,
-    Permissions::VIEW_SYSINFO => true,
-
-    Permissions::HELLBANNED => false,
-    Permissions::VIEW_HELLBANNED => true,
-
-    Permissions::PROTECTED => true,
-
-    Permissions::EDIT_IMAGE_RATING => true,
-    Permissions::BULK_EDIT_IMAGE_RATING => true,
-
-    Permissions::VIEW_TRASH => true,
-
-    Permissions::PERFORM_BULK_ACTIONS => true,
-
-    Permissions::BULK_ADD => true,
-    Permissions::EDIT_FILES => true,
-    Permissions::EDIT_TAG_CATEGORIES => true,
-    Permissions::RESCAN_MEDIA => true,
-    Permissions::SEE_IMAGE_VIEW_COUNTS => true,
-
-    Permissions::EDIT_FAVOURITES => true,
-
-    Permissions::ARTISTS_ADMIN => true,
-    Permissions::BLOTTER_ADMIN => true,
-    Permissions::FORUM_ADMIN => true,
-    Permissions::NOTES_ADMIN => true,
-    Permissions::POOLS_ADMIN => true,
-    Permissions::TIPS_ADMIN => true,
-    Permissions::CRON_ADMIN => true,
-
-    Permissions::APPROVE_IMAGE => true,
-    Permissions::APPROVE_COMMENT => true,
-    Permissions::BYPASS_IMAGE_APPROVAL => true,
-
-    Permissions::CRON_RUN => true,
-
-    Permissions::BULK_IMPORT => true,
-    Permissions::BULK_EXPORT => true,
-    Permissions::BULK_DOWNLOAD => true,
-    Permissions::BULK_PARENT_CHILD => true,
-
-    Permissions::SET_PRIVATE_IMAGE => true,
-    Permissions::SET_OTHERS_PRIVATE_IMAGES => true,
 ]);
 
 @include_once "data/config/user-classes.conf.php";


### PR DESCRIPTION
Up until now I've been mentally defining an "admin" as "Somebody who has access to *all* current *and future* features" (as opposed to "Somebody who has access to a large but finite number of features") - having the code line up with this mental model seems less misleading (and leaves less room for future bugs)

`Permissions::HELLBANNED` is a special snowflake - that's more like "an attribute of a user"  than "a permission", and IMO using the permission system for that was a mistake; it just happened to be the quickest way to get results at the time...