### PR TITLE
[core] rename FORUM_CREATE permission

### DIFF
--- a/core/permissions.php
+++ b/core/permissions.php
@@ -120,7 +120,7 @@ abstract class Permissions
     public const BYPASS_IMAGE_APPROVAL = "bypass_image_approval";
 
     public const FORUM_ADMIN = "forum_admin";
-    public const FORUM_CREATE_THREAD = "forum_create_thread";
+    public const FORUM_CREATE = "forum_create";
 
     public const NOTES_ADMIN = "notes_admin";
     public const NOTES_CREATE = "notes_create";

--- a/core/userclass.php
+++ b/core/userclass.php
@@ -116,7 +116,7 @@ new UserClass("user", "base", [
     Permissions::PERFORM_BULK_ACTIONS => true,
     Permissions::BULK_DOWNLOAD => true,
     Permissions::CHANGE_USER_SETTING => true,
-    Permissions::FORUM_CREATE_THREAD => true,
+    Permissions::FORUM_CREATE => true,
     Permissions::NOTES_CREATE => true,
     Permissions::NOTES_EDIT => true,
     Permissions::POOLS_CREATE => true,

--- a/ext/forum/main.php
+++ b/ext/forum/main.php
@@ -102,7 +102,7 @@ class Forum extends Extension
         if ($event->page_matches("forum/index", paged: true)) {
             $pageNumber = $event->get_iarg('page_num', 1) - 1;
             $this->show_last_threads($page, $pageNumber, $user->can(Permissions::FORUM_ADMIN));
-            if (!$user->can(Permissions::FORUM_CREATE_THREAD)) {
+            if (!$user->can(Permissions::FORUM_CREATE)) {
                 $this->theme->display_new_thread_composer($page);
             }
         }
@@ -119,7 +119,7 @@ class Forum extends Extension
             if ($user->can(Permissions::FORUM_ADMIN)) {
                 $this->theme->add_actions_block($page, $threadID);
             }
-            if (!$user->can(Permissions::FORUM_CREATE_THREAD)) {
+            if (!$user->can(Permissions::FORUM_CREATE)) {
                 $this->theme->display_new_post_composer($page, $threadID);
             }
         }
@@ -128,7 +128,7 @@ class Forum extends Extension
         }
         if ($event->page_matches("forum/create")) {
             $redirectTo = "forum/index";
-            if (!$user->can(Permissions::FORUM_CREATE_THREAD)) {
+            if (!$user->can(Permissions::FORUM_CREATE)) {
                 $errors = $this->sanity_check_new_thread();
 
                 if (count($errors) > 0) {
@@ -167,7 +167,7 @@ class Forum extends Extension
         if ($event->page_matches("forum/answer")) {
             $threadID = int_escape($event->req_POST("threadID"));
             $total_pages = $this->get_total_pages_for_thread($threadID);
-            if (!$user->can(Permissions::FORUM_CREATE_THREAD)) {
+            if (!$user->can(Permissions::FORUM_CREATE)) {
                 $errors = $this->sanity_check_new_post();
 
                 if (count($errors) > 0) {


### PR DESCRIPTION
[core] rename FORUM_CREATE permission

This permission is for more than creating threads, making the previous name misleading

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/shish/shimmie2/pull/1056).
* #1057
* __->__ #1056