### PR TITLE
[core] fix permissions in forum and notes

### DIFF
--- a/core/permissions.php
+++ b/core/permissions.php
@@ -125,6 +125,7 @@ abstract class Permissions
     public const NOTES_ADMIN = "notes_admin";
     public const NOTES_CREATE = "notes_create";
     public const NOTES_EDIT = "notes_edit";
+    public const NOTES_REQUEST = "notes_request";
 
     public const POOLS_ADMIN = "pools_admin";
     public const POOLS_CREATE = "pools_create";

--- a/core/permissions.php
+++ b/core/permissions.php
@@ -120,7 +120,7 @@ abstract class Permissions
     public const BYPASS_IMAGE_APPROVAL = "bypass_image_approval";
 
     public const FORUM_ADMIN = "forum_admin";
-    public const FORUM_CREATE_THREAD = "forum_create_thread";
+    public const FORUM_CREATE = "forum_create";
 
     public const NOTES_ADMIN = "notes_admin";
     public const NOTES_CREATE = "notes_create";

--- a/core/userclass.php
+++ b/core/userclass.php
@@ -119,6 +119,7 @@ new UserClass("user", "base", [
     Permissions::FORUM_CREATE => true,
     Permissions::NOTES_CREATE => true,
     Permissions::NOTES_EDIT => true,
+    Permissions::NOTES_REQUEST => true,
     Permissions::POOLS_CREATE => true,
     Permissions::POOLS_UPDATE => true,
 ]);

--- a/core/userclass.php
+++ b/core/userclass.php
@@ -116,7 +116,7 @@ new UserClass("user", "base", [
     Permissions::PERFORM_BULK_ACTIONS => true,
     Permissions::BULK_DOWNLOAD => true,
     Permissions::CHANGE_USER_SETTING => true,
-    Permissions::FORUM_CREATE_THREAD => true,
+    Permissions::FORUM_CREATE => true,
     Permissions::NOTES_CREATE => true,
     Permissions::NOTES_EDIT => true,
     Permissions::POOLS_CREATE => true,

--- a/ext/forum/main.php
+++ b/ext/forum/main.php
@@ -102,7 +102,7 @@ class Forum extends Extension
         if ($event->page_matches("forum/index", paged: true)) {
             $pageNumber = $event->get_iarg('page_num', 1) - 1;
             $this->show_last_threads($page, $pageNumber, $user->can(Permissions::FORUM_ADMIN));
-            if (!$user->can(Permissions::FORUM_CREATE)) {
+            if ($user->can(Permissions::FORUM_CREATE)) {
                 $this->theme->display_new_thread_composer($page);
             }
         }
@@ -119,62 +119,51 @@ class Forum extends Extension
             if ($user->can(Permissions::FORUM_ADMIN)) {
                 $this->theme->add_actions_block($page, $threadID);
             }
-            if (!$user->can(Permissions::FORUM_CREATE)) {
+            if ($user->can(Permissions::FORUM_CREATE)) {
                 $this->theme->display_new_post_composer($page, $threadID);
             }
         }
-        if ($event->page_matches("forum/new")) {
+        if ($event->page_matches("forum/new", permission: Permissions::FORUM_CREATE)) {
             $this->theme->display_new_thread_composer($page);
         }
-        if ($event->page_matches("forum/create")) {
-            $redirectTo = "forum/index";
-            if (!$user->can(Permissions::FORUM_CREATE)) {
-                $errors = $this->sanity_check_new_thread();
+        if ($event->page_matches("forum/create", permission: Permissions::FORUM_CREATE)) {
+            $errors = $this->sanity_check_new_thread();
 
-                if (count($errors) > 0) {
-                    throw new InvalidInput(implode("<br>", $errors));
-                }
-
-                $newThreadID = $this->save_new_thread($user);
-                $this->save_new_post($newThreadID, $user);
-                $redirectTo = "forum/view/" . $newThreadID . "/1";
+            if (count($errors) > 0) {
+                throw new InvalidInput(implode("<br>", $errors));
             }
+
+            $newThreadID = $this->save_new_thread($user);
+            $this->save_new_post($newThreadID, $user);
+            $redirectTo = "forum/view/" . $newThreadID . "/1";
 
             $page->set_mode(PageMode::REDIRECT);
             $page->set_redirect(make_link($redirectTo));
         }
-        if ($event->page_matches("forum/delete/{threadID}/{postID}")) {
+        if ($event->page_matches("forum/delete/{threadID}/{postID}", permission: Permissions::FORUM_ADMIN)) {
             $threadID = $event->get_iarg('threadID');
             $postID = $event->get_iarg('postID');
-
-            if ($user->can(Permissions::FORUM_ADMIN)) {
-                $this->delete_post($postID);
-            }
-
+            $this->delete_post($postID);
             $page->set_mode(PageMode::REDIRECT);
             $page->set_redirect(make_link("forum/view/" . $threadID));
         }
-        if ($event->page_matches("forum/nuke/{threadID}")) {
+        if ($event->page_matches("forum/nuke/{threadID}", permission: Permissions::FORUM_ADMIN)) {
             $threadID = $event->get_iarg('threadID');
-
-            if ($user->can(Permissions::FORUM_ADMIN)) {
-                $this->delete_thread($threadID);
-            }
-
+            $this->delete_thread($threadID);
             $page->set_mode(PageMode::REDIRECT);
             $page->set_redirect(make_link("forum/index"));
         }
-        if ($event->page_matches("forum/answer")) {
+        if ($event->page_matches("forum/answer", permission: Permissions::FORUM_CREATE)) {
             $threadID = int_escape($event->req_POST("threadID"));
             $total_pages = $this->get_total_pages_for_thread($threadID);
-            if (!$user->can(Permissions::FORUM_CREATE)) {
-                $errors = $this->sanity_check_new_post();
 
-                if (count($errors) > 0) {
-                    throw new InvalidInput(implode("<br>", $errors));
-                }
-                $this->save_new_post($threadID, $user);
+            $errors = $this->sanity_check_new_post();
+
+            if (count($errors) > 0) {
+                throw new InvalidInput(implode("<br>", $errors));
             }
+            $this->save_new_post($threadID, $user);
+
             $page->set_mode(PageMode::REDIRECT);
             $page->set_redirect(make_link("forum/view/" . $threadID . "/" . $total_pages));
         }

--- a/ext/forum/main.php
+++ b/ext/forum/main.php
@@ -102,7 +102,7 @@ class Forum extends Extension
         if ($event->page_matches("forum/index", paged: true)) {
             $pageNumber = $event->get_iarg('page_num', 1) - 1;
             $this->show_last_threads($page, $pageNumber, $user->can(Permissions::FORUM_ADMIN));
-            if (!$user->can(Permissions::FORUM_CREATE_THREAD)) {
+            if (!$user->can(Permissions::FORUM_CREATE)) {
                 $this->theme->display_new_thread_composer($page);
             }
         }
@@ -119,7 +119,7 @@ class Forum extends Extension
             if ($user->can(Permissions::FORUM_ADMIN)) {
                 $this->theme->add_actions_block($page, $threadID);
             }
-            if (!$user->can(Permissions::FORUM_CREATE_THREAD)) {
+            if (!$user->can(Permissions::FORUM_CREATE)) {
                 $this->theme->display_new_post_composer($page, $threadID);
             }
         }
@@ -128,7 +128,7 @@ class Forum extends Extension
         }
         if ($event->page_matches("forum/create")) {
             $redirectTo = "forum/index";
-            if (!$user->can(Permissions::FORUM_CREATE_THREAD)) {
+            if (!$user->can(Permissions::FORUM_CREATE)) {
                 $errors = $this->sanity_check_new_thread();
 
                 if (count($errors) > 0) {
@@ -167,7 +167,7 @@ class Forum extends Extension
         if ($event->page_matches("forum/answer")) {
             $threadID = int_escape($event->req_POST("threadID"));
             $total_pages = $this->get_total_pages_for_thread($threadID);
-            if (!$user->can(Permissions::FORUM_CREATE_THREAD)) {
+            if (!$user->can(Permissions::FORUM_CREATE)) {
                 $errors = $this->sanity_check_new_post();
 
                 if (count($errors) > 0) {

--- a/ext/notes/script.js
+++ b/ext/notes/script.js
@@ -48,10 +48,13 @@ function renderNotes() {
 		noteDiv.style.height = note.height * scale + 'px';
 		let text = document.createElement('div');
 		text.innerText = note.note;
-		noteDiv.addEventListener('click', (e) => {
-			noteBeingEdited = note.note_id;
-			renderNotes();
-		});
+		// only add listener if user has edit permissions
+		if (window.notes_edit) {
+			noteDiv.addEventListener('click', (e) => {
+				noteBeingEdited = note.note_id;
+				renderNotes();
+			});
+		}
 		noteDiv.appendChild(text);
 		notesContainer.appendChild(noteDiv);
 

--- a/ext/notes/theme.php
+++ b/ext/notes/theme.php
@@ -47,7 +47,7 @@ class NotesTheme extends Themelet
     /**
      * @param Note[] $recovered_notes
      */
-    public function display_note_system(Page $page, int $image_id, array $recovered_notes, bool $adminOptions): void
+    public function display_note_system(Page $page, int $image_id, array $recovered_notes, bool $adminOptions, bool $editOptions): void
     {
         $to_json = [];
         foreach ($recovered_notes as $note) {
@@ -65,6 +65,7 @@ class NotesTheme extends Themelet
         window.notes = ".\Safe\json_encode($to_json).";
         window.notes_image_id = $image_id;
         window.notes_admin = ".($adminOptions ? "true" : "false").";
+        window.notes_edit = ".($editOptions ? "true" : "false").";
         </script>");
     }
 


### PR DESCRIPTION
[core] fix permissions in forum and notes

This includes preventing silent failures when permission is denied, preventing unauthorized users from being shown the note edit form, patching typos, and extracting NOTES_REQUEST to its own permission

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/shish/shimmie2/pull/1057).
* __->__ #1057
* #1056