### PR TITLE
Optimisations for search queries

### DIFF
--- a/core/imageboard/search.php
+++ b/core/imageboard/search.php
@@ -244,10 +244,11 @@ class Search
         ?int $limit = null,
         ?int $offset = null
     ): Querylet {
+        $query = new Querylet("SELECT images.* FROM images INNER JOIN (");
         // no tags, do a simple search
         if (count($tag_conditions) === 0) {
             static::$_search_path[] = "no_tags";
-            $query = new Querylet("SELECT images.* FROM images WHERE 1=1");
+            $query->append(new Querylet("SELECT images.id FROM images WHERE 1=1"));
         }
 
         // one tag sorted by ID - we can fetch this from the image_tags table,
@@ -278,11 +279,11 @@ class Search
             if (count($tag_array) == 0) {
                 // if wildcard expanded to nothing, take a shortcut
                 static::$_search_path[] = "invalid_tag";
-                $query = new Querylet("SELECT images.* FROM images WHERE 1=0");
+                $query->append(new Querylet("SELECT images.id FROM images WHERE 1=0"));
             } else {
                 $set = implode(', ', $tag_array);
-                $query = new Querylet("
-                    SELECT images.*
+                $query->append(new Querylet("
+                    SELECT images.id
                     FROM images INNER JOIN (
                         SELECT DISTINCT it.image_id
                         FROM image_tags it
@@ -291,7 +292,7 @@ class Search
                         LIMIT :limit OFFSET :offset
                     ) a on a.image_id = images.id
                     WHERE 1=1
-                ", ["limit" => $limit, "offset" => $offset]);
+                ", ["limit" => $limit, "offset" => $offset]));
                 // don't offset at the image level because
                 // we already offset at the image_tags level
                 $limit = null;
@@ -317,7 +318,7 @@ class Search
                         # one of the positive tags had zero results, therefor there
                         # can be no results; "where 1=0" should shortcut things
                         static::$_search_path[] = "invalid_tag";
-                        return new Querylet("SELECT images.* FROM images WHERE 1=0");
+                        return new Querylet("SELECT images.id FROM images WHERE 1=0");
                     } elseif ($tag_count == 1) {
                         // All wildcard terms that qualify for a single tag can be treated the same as non-wildcards
                         $positive_tag_id_array[] = $tag_ids[0];
@@ -340,7 +341,7 @@ class Search
 
             if ($all_nonexistent_negatives) {
                 static::$_search_path[] = "all_nonexistent_negatives";
-                $query = new Querylet("SELECT images.* FROM images WHERE 1=1");
+                $query->append(new Querylet("SELECT images.id FROM images WHERE 1=1"));
             } elseif (!empty($positive_tag_id_array) || !empty($positive_wildcard_id_array)) {
                 static::$_search_path[] = "some_positives";
                 $inner_joins = [];
@@ -373,20 +374,20 @@ class Search
                 }
                 $sub_query .= " GROUP BY it.image_id ";
 
-                $query = new Querylet("
-                    SELECT images.*
+                $query->append(new Querylet("
+                    SELECT images.id
                     FROM images
                     INNER JOIN ($sub_query) a on a.image_id = images.id
-                ");
+                "));
             } elseif (!empty($negative_tag_id_array)) {
                 static::$_search_path[] = "only_negative_tags";
                 $negative_tag_id_list = join(', ', $negative_tag_id_array);
-                $query = new Querylet("
-                    SELECT images.*
+                $query->append(new Querylet("
+                    SELECT images.id
                     FROM images
                     LEFT JOIN image_tags negative ON negative.image_id = images.id AND negative.tag_id in ($negative_tag_id_list)
                     WHERE negative.image_id IS NULL
-                ");
+                "));
             } else {
                 throw new InvalidInput("No criteria specified");
             }
@@ -410,9 +411,11 @@ class Search
                 $img_sql .= " (" . $iq->qlet->sql . ")";
                 $img_vars = array_merge($img_vars, $iq->qlet->variables);
             }
-            $query->append(new Querylet(" AND "));
+            $query->append(new Querylet(" AND"));
             $query->append(new Querylet($img_sql, $img_vars));
         }
+
+        $query->append(new Querylet(") a on a.id = images.id"));
 
         if(!is_null($order)) {
             $query->append(new Querylet(" ORDER BY ".$order));

--- a/core/tests/SearchTest.php
+++ b/core/tests/SearchTest.php
@@ -180,6 +180,7 @@ class SearchTest extends ShimmiePHPUnitTestCase
      * @param string $order
      * @param int $limit
      * @param int $start
+     * @param bool $count
      * @param int[] $res
      * @param string[] $path
      */
@@ -189,6 +190,7 @@ class SearchTest extends ShimmiePHPUnitTestCase
         string $order = "id DESC",
         int $limit = 9999,
         int $start = 0,
+        bool $count = false,
         array $res = [],
         array $path = null,
     ): void {
@@ -214,7 +216,7 @@ class SearchTest extends ShimmiePHPUnitTestCase
         $build_search_querylet->setAccessible(true); // Use this if you are running PHP older than 8.1.0
 
         $obj = new Search();
-        $querylet = $build_search_querylet->invokeArgs($obj, [$tcs, $ics, $order, $limit, $start]);
+        $querylet = $build_search_querylet->invokeArgs($obj, [$tcs, $ics, $order, $limit, $start, $count]);
 
         $results = $database->get_all($querylet->sql, $querylet->variables);
 


### PR DESCRIPTION
Disclaimer: I'm not experienced with SQL, so feel welcome to correct any mistaken assumptions I've made.

The first commit prevents tag queries from selecting all columns when only the id is being used, improving the speed of the join operations.
The second commit prevents all columns being fetched when only the total number of rows is relevant.

These are both improvements by themselves, although the first is also a useful step towards other optimisations, especially those needed to make INTERSECT and UNION operations efficient, which are necessary for https://github.com/shish/shimmie2/issues/292