### PR TITLE
[core] don't limit searchable tag length, only writable length, fixes #1087

### DIFF
--- a/core/imageboard/tag.php
+++ b/core/imageboard/tag.php
@@ -210,9 +210,6 @@ class Tag
             $tag = "";
         }  // hard-code one bad case...
 
-        if (mb_strlen($tag, 'UTF-8') > 255) {
-            throw new InvalidInput("The tag below is longer than 255 characters, please use a shorter tag.\n$tag\n");
-        }
         return $tag;
     }
 

--- a/ext/post_tags/main.php
+++ b/ext/post_tags/main.php
@@ -141,6 +141,7 @@ class PostTags extends Extension
                 } else {
                     $page->flash($e->getMessage());
                 }
+                throw $e;
             }
         }
     }

--- a/ext/post_tags/test.php
+++ b/ext/post_tags/test.php
@@ -42,8 +42,8 @@ class PostTagsTest extends ShimmiePHPUnitTestCase
     public function testTagEdit_tooLong(): void
     {
         $this->log_in_as_user();
-        $image_id = $this->post_image("tests/pbx_screenshot.jpg", str_repeat("a", 500));
-        $this->get_page("post/view/$image_id");
-        $this->assert_title("Post $image_id: tagme");
+        $this->assertException(TagSetException::class, function () {
+            $this->post_image("tests/pbx_screenshot.jpg", str_repeat("a", 500));
+        });
     }
 }


### PR DESCRIPTION
[core] don't limit searchable tag length, only writable length, fixes #1087
