### PR TITLE
[tag_list] only match 'GET /tags/{sub}', to avoid conflicting with 'POST /tags/categories'

### DIFF
--- a/ext/tag_list/main.php
+++ b/ext/tag_list/main.php
@@ -31,7 +31,7 @@ class TagList extends Extension
     {
         global $config, $page;
 
-        if ($event->page_matches("tags/{sub}")) {
+        if ($event->page_matches("tags/{sub}", method: "GET")) {
             $this->theme->set_navigation($this->build_navigation());
             $sub = $event->get_arg('sub');
 


### PR DESCRIPTION
[tag_list] only match 'GET /tags/{sub}', to avoid conflicting with 'POST /tags/categories'
