### PR TITLE
Minor improvements to tag category editor

### DIFF
--- a/ext/tag_categories/style.css
+++ b/ext/tag_categories/style.css
@@ -33,6 +33,10 @@
 	padding:0.2rem 0.6rem;
 }
 
+.tagcategoryblock input[type="color"] {
+	height: 22px;
+}
+
 .tagcategoryblock .tc_colorswatch {
 	display:inline-block;
 	vertical-align:middle;

--- a/ext/tag_categories/style.css
+++ b/ext/tag_categories/style.css
@@ -23,11 +23,20 @@
 	width:60%;
 }
 .tagcategoryblock td:last-child span {
+	width:7ch;
 	padding:0.24rem 0.7rem 0.5rem 0;
-	display:block;
+	display:inline-block;
 }
 .tagcategoryblock button {
 	width:100%;
 	margin-top:0.4rem;
 	padding:0.2rem 0.6rem;
+}
+
+.tagcategoryblock .tc_colorswatch {
+	display:inline-block;
+	vertical-align:middle;
+	height:1.25rem;
+	width:1.25rem;
+	border-radius:4px;
 }

--- a/ext/tag_categories/theme.php
+++ b/ext/tag_categories/theme.php
@@ -49,12 +49,12 @@ class TagCategoriesTheme extends Themelet
                 <tr>
                     <td>Color</td>
                     <td>
-                        <span>'.$tag_color.'</span>
+                        <span>'.$tag_color.'</span><div class="tc_colorswatch" style="background-color:'.$tag_color.'"></div>
                         <input type="text" name="tc_color" style="display:none" value="'.$tag_color.'">
                     </td>
                 </tr>
                 </table>
-                <button class="tc_edit" type="button" onclick="$(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') tr + tr td span\').hide(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') td input\').show(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_edit\').hide(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_submit\').show();">Edit</button>
+                <button class="tc_edit" type="button" onclick="$(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') tr + tr td span\').hide(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') td input\').show(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_edit\').hide(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_colorswatch\').hide(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_submit\').show();">Edit</button>
                 <button class="tc_submit" type="submit" style="display:none;" name="tc_status" value="edit">Submit</button>
                 <button class="tc_submit" type="button" style="display:none;" onclick="$(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_delete\').show(); $(this).hide();">Delete</button>
                 <button class="tc_delete" type="submit" style="display:none;" name="tc_status" value="delete">Really, really delete</button>

--- a/ext/tag_categories/theme.php
+++ b/ext/tag_categories/theme.php
@@ -50,7 +50,7 @@ class TagCategoriesTheme extends Themelet
                     <td>Color</td>
                     <td>
                         <span>'.$tag_color.'</span><div class="tc_colorswatch" style="background-color:'.$tag_color.'"></div>
-                        <input type="text" name="tc_color" style="display:none" value="'.$tag_color.'">
+                        <input type="color" name="tc_color" style="display:none" value="'.$tag_color.'">
                     </td>
                 </tr>
                 </table>


### PR DESCRIPTION
Pulling this from a custom theme I have used for a while. adds a color swatch next to the hex code to show the current color of each category. also changes the category editor to use a color input instead of a text input to match the new category creation form

![Screenshot_20240317_123749](https://github.com/shish/shimmie2/assets/91732583/84bfde67-e866-4376-833a-34a3eb75f48c)

I noticed the preview for the color input was too short to be visible so added an explicit height

color input before:
![Screenshot_20240317_123843](https://github.com/shish/shimmie2/assets/91732583/fa1244c7-f6d8-43ad-a3b1-798ed4914aa2)

color input after:
![Screenshot_20240317_123850](https://github.com/shish/shimmie2/assets/91732583/0d61d433-b713-4f34-b54c-e770bcc8754b)
