### PR TITLE
Build upload post fields using events, add ratings field to upload page

### DIFF
--- a/ext/post_source/main.php
+++ b/ext/post_source/main.php
@@ -98,6 +98,21 @@ class PostSource extends Extension
         }
     }
 
+    public function onUploadHeaderBuilding(UploadHeaderBuildingEvent $event): void
+    {
+        $event->add_part("Source", 11);
+    }
+
+    public function onUploadCommonBuilding(UploadCommonBuildingEvent $event): void
+    {
+        $event->add_part($this->theme->get_upload_common_html(), 11);
+    }
+
+    public function onUploadSpecificBuilding(UploadSpecificBuildingEvent $event): void
+    {
+        $event->add_part($this->theme->get_upload_specific_html($event->suffix), 11);
+    }
+
     private function mass_source_edit(string $tags, string $source): void
     {
         $tags = Tag::explode($tags);

--- a/ext/post_source/theme.php
+++ b/ext/post_source/theme.php
@@ -51,4 +51,23 @@ class PostSourceTheme extends Themelet
         }
         return rawHTML("Unknown");
     }
+
+    public function get_upload_common_html(): HTMLElement
+    {
+        return TR(
+            TH(["width" => "20"], "Common Source"),
+            TD(["colspan" => "6"], INPUT(["name" => "source", "type" => "text", "placeholder" => "https://..."]))
+        );
+    }
+
+    public function get_upload_specific_html(string $suffix): HTMLElement
+    {
+        return TD(
+            INPUT([
+                "type" => "text",
+                "name" => "source{$suffix}",
+                "value" => ($suffix == 0) ? @$_GET['source'] : null,
+            ])
+        );
+    }
 }

--- a/ext/post_tags/main.php
+++ b/ext/post_tags/main.php
@@ -218,6 +218,22 @@ class PostTags extends Extension
         }
     }
 
+
+    public function onUploadHeaderBuilding(UploadHeaderBuildingEvent $event): void
+    {
+        $event->add_part("Tags", 10);
+    }
+
+    public function onUploadCommonBuilding(UploadCommonBuildingEvent $event): void
+    {
+        $event->add_part($this->theme->get_upload_common_html(), 10);
+    }
+
+    public function onUploadSpecificBuilding(UploadSpecificBuildingEvent $event): void
+    {
+        $event->add_part($this->theme->get_upload_specific_html($event->suffix), 10);
+    }
+
     private function mass_tag_edit(string $search, string $replace, bool $commit): void
     {
         global $database, $tracer_enabled, $_tracer;

--- a/ext/post_tags/theme.php
+++ b/ext/post_tags/theme.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{joinHTML, A, TEXTAREA};
+use function MicroHTML\{joinHTML, A, TEXTAREA, TR, TH, TD, INPUT};
 
 class PostTagsTheme extends Themelet
 {
@@ -51,6 +51,26 @@ class PostTagsTheme extends Themelet
             link: Extension::is_enabled(TagHistoryInfo::KEY) ?
                 make_link("tag_history/{$image->id}") :
                 null,
+        );
+    }
+
+    public function get_upload_common_html(): HTMLElement
+    {
+        return TR(
+            TH(["width" => "20"], "Common Tags"),
+            TD(["colspan" => "6"], INPUT(["name" => "tags", "type" => "text", "placeholder" => "tagme", "class" => "autocomplete_tags"]))
+        );
+    }
+
+    public function get_upload_specific_html(string $suffix): HTMLElement
+    {
+        return TD(
+            INPUT([
+                "type" => "text",
+                "name" => "tags{$suffix}",
+                "class" => "autocomplete_tags",
+                "value" => ($suffix == 0) ? @$_GET['tags'] : null,
+            ])
         );
     }
 }

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -20,13 +20,18 @@ class RatingsTheme extends Themelet
         return SHM_SELECT($name, !empty($ratings) ? $ratings : Ratings::get_ratings_dict(), required: true, selected_options: $selected_options);
     }
 
-    public function get_rater_html(int $image_id, string $rating, bool $can_rate): HTMLElement
+    public function get_image_rater_html(int $image_id, string $rating, bool $can_rate): HTMLElement
     {
         return SHM_POST_INFO(
             "Rating",
             A(["href" => search_link(["rating=$rating"])], Ratings::rating_to_human($rating)),
             $can_rate ? $this->get_selection_rater_html("rating", selected_options: [$rating]) : null
         );
+    }
+
+    public function get_upload_specific_rater_html(string $suffix): HTMLElement
+    {
+        return TD($this->get_selection_rater_html(name:"rating${suffix}", selected_options: ["?"]));
     }
 
     /**

--- a/ext/upload/events/upload_common_building_event.php
+++ b/ext/upload/events/upload_common_building_event.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+use MicroHTML\HTMLElement;
+
+/**
+ * @extends PartListBuildingEvent<HTMLElement>
+ */
+class UploadCommonBuildingEvent extends PartListBuildingEvent
+{
+}

--- a/ext/upload/events/upload_header_building_event.php
+++ b/ext/upload/events/upload_header_building_event.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+/**
+ * @extends PartListBuildingEvent<string>
+ */
+class UploadHeaderBuildingEvent extends PartListBuildingEvent
+{
+}

--- a/ext/upload/events/upload_specific_building_event.php
+++ b/ext/upload/events/upload_specific_building_event.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+use MicroHTML\HTMLElement;
+
+/**
+ * @extends PartListBuildingEvent<HTMLElement>
+ */
+class UploadSpecificBuildingEvent extends PartListBuildingEvent
+{
+    public string $suffix;
+
+    public function __construct(string $suffix)
+    {
+        parent::__construct();
+
+        $this->suffix = $suffix;
+    }
+}


### PR DESCRIPTION
Builds upon #1052

First commit creates events for adding fields to the upload form, and replaces the hardcoded 'tags' and 'source' fields.

Second commit adds the ratings field to the upload form.