### PR TITLE
Improvements to notes, tag histories, source histories

### DIFF
--- a/ext/notes/main.php
+++ b/ext/notes/main.php
@@ -75,6 +75,21 @@ class Notes extends Extension
         }
     }
 
+    public function onPageNavBuilding(PageNavBuildingEvent $event): void
+    {
+        $event->add_nav_link("note", new Link('note/requests'), "Notes");
+    }
+
+    public function onPageSubNavBuilding(PageSubNavBuildingEvent $event): void
+    {
+        if ($event->parent == "note") {
+            $event->add_nav_link("note_requests", new Link('note/requests'), "Requests");
+            $event->add_nav_link("note_list", new Link('note/list'), "List");
+            $event->add_nav_link("note_updated", new Link('note/updated'), "Updates");
+            $event->add_nav_link("note_help", new Link('ext_doc/notes'), "Help");
+        }
+    }
+
     public function onPageRequest(PageRequestEvent $event): void
     {
         global $page, $user;

--- a/ext/notes/main.php
+++ b/ext/notes/main.php
@@ -234,7 +234,7 @@ class Notes extends Extension
             SELECT *
             FROM notes
             WHERE enable = :enable AND image_id = :image_id
-            ORDER BY date ASC
+            ORDER BY date ASC, id ASC
         ", ['enable' => '1', 'image_id' => $imageID]);
     }
 
@@ -364,7 +364,7 @@ class Notes extends Extension
 			SELECT DISTINCT image_id
 			FROM notes
 			WHERE enable = :enable
-			ORDER BY date DESC LIMIT :limit OFFSET :offset",
+			ORDER BY date DESC, id DESC LIMIT :limit OFFSET :offset",
             ['enable' => 1, 'offset' => $pageNumber * $notesPerPage, 'limit' => $notesPerPage]
         );
 
@@ -388,7 +388,7 @@ class Notes extends Extension
             "
 				SELECT DISTINCT image_id
 				FROM note_request
-				ORDER BY date DESC LIMIT :limit OFFSET :offset",
+				ORDER BY date DESC, id DESC LIMIT :limit OFFSET :offset",
             ["offset" => $pageNumber * $requestsPerPage, "limit" => $requestsPerPage]
         );
 
@@ -442,7 +442,7 @@ class Notes extends Extension
             "FROM note_histories AS h " .
             "INNER JOIN users AS u " .
             "ON u.id = h.user_id " .
-            "ORDER BY date DESC LIMIT :limit OFFSET :offset",
+            "ORDER BY date DESC, note_id DESC LIMIT :limit OFFSET :offset",
             ['offset' => $pageNumber * $historiesPerPage, 'limit' => $historiesPerPage]
         );
 
@@ -463,7 +463,7 @@ class Notes extends Extension
             "INNER JOIN users AS u " .
             "ON u.id = h.user_id " .
             "WHERE note_id = :note_id " .
-            "ORDER BY date DESC LIMIT :limit OFFSET :offset",
+            "ORDER BY date DESC, note_id DESC LIMIT :limit OFFSET :offset",
             ['note_id' => $noteID, 'offset' => $pageNumber * $historiesPerPage, 'limit' => $historiesPerPage]
         );
 

--- a/ext/notes/theme.php
+++ b/ext/notes/theme.php
@@ -188,6 +188,22 @@ class NotesTheme extends Themelet
         $this->display_paginator($page, "note/updated", null, $pageNumber, $totalPages);
     }
 
+    /**
+     * @param NoteHistory[] $histories
+     */
+    public function display_image_history(array $histories, int $imageID, int $pageNumber, int $totalPages): void
+    {
+        global $page;
+
+        $html = $this->get_history($histories);
+
+        $page->set_title("Note History #$imageID");
+        $page->set_heading("Note History #$imageID");
+        $page->add_block(new Block("Note History #$imageID", $html, "main", 10));
+
+        $this->display_paginator($page, "note_history/$imageID", null, $pageNumber, $totalPages);
+    }
+
     public function get_help_html(): string
     {
         return '<p>Search for posts with notes.</p>

--- a/ext/source_history/main.php
+++ b/ext/source_history/main.php
@@ -310,7 +310,7 @@ class SourceHistory extends Extension
 				FROM source_histories
 				WHERE image_id='.$image_id.'
 				AND NOT ('.implode(" AND ", $select_code).')
-				ORDER BY date_set DESC LIMIT 1
+				ORDER BY date_set DESC, id DESC LIMIT 1
 			', $select_args);
 
             if (!empty($row)) {

--- a/ext/tag_history/main.php
+++ b/ext/tag_history/main.php
@@ -356,7 +356,7 @@ class TagHistory extends Extension
 				FROM tag_histories
 				WHERE image_id='.$image_id.'
 				AND NOT ('.implode(" AND ", $select_code).')
-				ORDER BY date_set DESC LIMIT 1
+				ORDER BY date_set DESC, id DESC LIMIT 1
 			', $select_args);
 
             if (!empty($row)) {


### PR DESCRIPTION
First commit adds the notes pages to the navbars. These were inaccessible before.

Second commit orders SQL requests by id instead of date, since date is not necessarily unique (especially if imported data from another booru software).