### PR TITLE
[user] fix typo in password check

### DIFF
--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -210,7 +210,7 @@ class UserPage extends Extension
                 new UserCreationEvent(
                     $event->req_POST("name"),
                     $event->req_POST("pass1"),
-                    $event->req_POST("pass1"),
+                    $event->req_POST("pass2"),
                     $event->req_POST("email"),
                     false
                 )

--- a/ext/user/test.php
+++ b/ext/user/test.php
@@ -62,6 +62,7 @@ class UserPageTest extends ShimmiePHPUnitTestCase
             $this->post_page('user_admin/create_other', [
                 'name' => 'testnew',
                 'pass1' => 'testnew',
+                'pass2' => 'testnew',
                 'email' => '',
             ]);
         });
@@ -71,6 +72,7 @@ class UserPageTest extends ShimmiePHPUnitTestCase
         $this->post_page('user_admin/create_other', [
             'name' => 'testnew',
             'pass1' => 'testnew',
+            'pass2' => 'testnew',
             'email' => '',
         ]);
         $this->assertEquals(302, $page->code);


### PR DESCRIPTION
In `user_admin/create_other`, would just send pass1 twice.