### PR TITLE
[filter] fix thumb display css

### DIFF
--- a/ext/filter/style.css
+++ b/ext/filter/style.css
@@ -1,4 +1,3 @@
 #filter-list{padding:revert; text-align:left;}
-.thumb.filtered{display:unset}
 .thumb.filtered.filtered-active{display:none;}
 .filter-inactive,.filter-inactive:hover{text-decoration: line-through;}


### PR DESCRIPTION
Unsetting the display option can disable `display: block`, which allows the thumbnails to be centred in their container