### PR TITLE
[terms] add terms and conditions gate

### DIFF
--- a/core/testcase.php
+++ b/core/testcase.php
@@ -110,6 +110,7 @@ if(class_exists("\\PHPUnit\\Framework\\TestCase")) {
             $_SERVER['REQUEST_URI'] = make_link($page_name, http_build_query($get_args));
             $_GET = $get_args;
             $_POST = $post_args;
+            $_COOKIE['shm_accepted_terms'] = "true";
             $page = new Page();
             send_event(new PageRequestEvent($method, $page_name, $get_args, $post_args));
             if ($page->mode == PageMode::REDIRECT) {

--- a/ext/terms/info.php
+++ b/ext/terms/info.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+class TermsInfo extends ExtensionInfo
+{
+    public const KEY = "terms";
+
+    public string $key = self::KEY;
+    public string $name = "Terms & Conditions Gate";
+    public array $authors = ["discomrade" => ""];
+    public string $license = "GPLv2";
+    public string $description = "Show a page of terms which must be accepted before continuing";
+}

--- a/ext/terms/main.php
+++ b/ext/terms/main.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+class Terms extends Extension
+{
+    /** @var TermsTheme */
+    protected Themelet $theme;
+
+    public function onInitExt(InitExtEvent $event): void
+    {
+        global $config;
+        $config->set_default_string("terms_message", "Cookies may be used. Please read our [url=site://wiki/privacy]privacy policy[/url] for more information.\nBy accepting to enter you agree to our [url=site://wiki/rules]rules[/url] and [url=site://wiki/terms_of_service]terms of service[/url].");
+    }
+
+    public function onSetupBuilding(SetupBuildingEvent $event): void
+    {
+        $sb = $event->panel->create_new_block("Terms & Conditions Gate");
+        $sb->add_longtext_option("terms_message", 'Message (Use BBCode)');
+    }
+
+    public function onPageRequest(PageRequestEvent $event): void
+    {
+        global $config, $page, $user;
+        if ($event->page_starts_with("accept_terms")) {
+            $page->add_cookie("accepted_terms", "true", time() + 60 * 60 * 24 * $config->get_int('login_memory'), "/");
+            $page->set_mode(PageMode::REDIRECT);
+            $page->set_redirect(make_link(explode('/', $event->path, 2)[1]));
+        } else {
+            // run on all pages unless logged in or cookie exists
+            if ($user->is_anonymous() && !isset($_COOKIE[$config->get_string('cookie_prefix', 'shm') . '_' . 'accepted_terms'])) {
+                $sitename = $config->get_string(SetupConfig::TITLE);
+                $body = format_text($config->get_string("terms_message"));
+                $this->theme->display_page($page, $sitename, $event->path, $body);
+            }
+        }
+    }
+}

--- a/ext/terms/theme.php
+++ b/ext/terms/theme.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+class TermsTheme extends Themelet
+{
+    public function display_page(Page $page, string $sitename, string $path, string $body): void
+    {
+        $page->set_mode(PageMode::DATA);
+        $page->add_auto_html_headers();
+        $hh = $page->get_all_html_headers();
+        $page->set_data(
+            <<<EOD
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>$sitename</title>
+		<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		$hh
+	</head>
+	<body>
+		<div id="front-page">
+			<h1><span>$sitename</span></h1>
+			$body
+			<form action="/accept_terms/$path" method="POST">
+				<button>Enter</button>
+			</form>
+		</div>
+	</body>
+</html>
+EOD
+        );
+    }
+}


### PR DESCRIPTION
This extension replaces pages with a terms and conditions message until they accept it (or login). The message can be customised e.g. to include an 18+ age limit.

It also adds the cookie to test requests to prevent them getting this page.

![image](https://github.com/shish/shimmie2/assets/83621080/433869a3-1864-4b34-9da6-b3862ee5c680)
