### PR TITLE
microhtml for everything in <head>

### DIFF
--- a/core/basethemelet.php
+++ b/core/basethemelet.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{A,B,BR,IMG,emptyHTML,joinHTML};
+use function MicroHTML\{A,B,BR,IMG,emptyHTML,joinHTML,LINK};
 
 /**
  * Class BaseThemelet
@@ -112,15 +112,15 @@ class BaseThemelet
         $body = $this->build_paginator($page_number, $total_pages, $base, $query, $show_random);
         $page->add_block(new Block(null, $body, "main", 90, "paginator"));
 
-        $page->add_html_header("<link rel='first' href='".make_http(make_link($base.'/1', $query))."'>");
+        $page->add_html_header(LINK(['rel' => 'first', 'href' => make_link($base.'/1', $query)]));
         if ($page_number < $total_pages) {
-            $page->add_html_header("<link rel='prefetch' href='".make_http(make_link($base.'/'.($page_number + 1), $query))."'>");
-            $page->add_html_header("<link rel='next' href='".make_http(make_link($base.'/'.($page_number + 1), $query))."'>");
+            $page->add_html_header(LINK(['rel' => 'prefetch', 'href' => make_link($base.'/'.($page_number + 1), $query)]));
+            $page->add_html_header(LINK(['rel' => 'next', 'href' => make_link($base.'/'.($page_number + 1), $query)]));
         }
         if ($page_number > 1) {
-            $page->add_html_header("<link rel='previous' href='".make_http(make_link($base.'/'.($page_number - 1), $query))."'>");
+            $page->add_html_header(LINK(['rel' => 'previous', 'href' => make_link($base.'/'.($page_number - 1), $query)]));
         }
-        $page->add_html_header("<link rel='last' href='".make_http(make_link($base.'/'.$total_pages, $query))."'>");
+        $page->add_html_header(LINK(['rel' => 'last', 'href' => make_link($base.'/'.$total_pages, $query)]));
     }
 
     private function gen_page_link(string $base_url, ?string $query, int $page, string $name): HTMLElement

--- a/ext/browser_search/main.php
+++ b/ext/browser_search/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\LINK;
+
 class BrowserSearch extends Extension
 {
     public function onInitExt(InitExtEvent $event): void
@@ -20,7 +22,12 @@ class BrowserSearch extends Extension
         // We need to build the data for the header
         $search_title = $config->get_string(SetupConfig::TITLE);
         $search_file_url = make_link('browser_search.xml');
-        $page->add_html_header("<link rel='search' type='application/opensearchdescription+xml' title='$search_title' href='$search_file_url'>");
+        $page->add_html_header(LINK([
+            'rel' => 'search',
+            'type' => 'application/opensearchdescription+xml',
+            'title' => $search_title,
+            'href' => $search_file_url
+        ]));
 
         // The search.xml file that is generated on the fly
         if ($event->page_matches("browser_search.xml")) {

--- a/ext/custom_html_headers/main.php
+++ b/ext/custom_html_headers/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CustomHtmlHeaders extends Extension
 {
     # Adds setup block for custom <head> content
@@ -44,7 +46,7 @@ class CustomHtmlHeaders extends Extension
 
         $header = $config->get_string('custom_html_headers', '');
         if ($header != '') {
-            $page->add_html_header($header);
+            $page->add_html_header(rawHTML($header));
         }
     }
 

--- a/ext/downtime/theme.php
+++ b/ext/downtime/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\{emptyHTML, TITLE, LINK};
+
 class DowntimeTheme extends Themelet
 {
     /**
@@ -30,45 +32,40 @@ class DowntimeTheme extends Themelet
         $login_link = make_link("user_admin/login");
         $form = make_form($login_link);
 
+        $head = emptyHTML(
+            TITLE("Downtime"),
+            LINK(["rel" => "stylesheet", "href" => "$data_href/themes/$theme_name/style.css", "type" => "text/css"])
+        );
+        $body = <<<EOD
+<div id="downtime">
+	<section>
+		<h1 style="text-align: center;">Down for Maintenance</h1>
+		<div id="message" class="blockbody">
+			$message
+		</div>
+	</section>
+	<section>
+		<h3>Admin Login</h3>
+		<div id="login" class="blockbody">
+			$form
+				<table id="login_table" summary="Login Form">
+					<tr>
+						<td width="70"><label for="user">Name</label></td>
+						<td width="70"><input id="user" type="text" name="user"></td>
+					</tr>
+					<tr>
+						<td><label for="pass">Password</label></td>
+						<td><input id="pass" type="password" name="pass"></td>
+					</tr>
+					<tr><td colspan="2"><input type="submit" value="Log In"></td></tr>
+				</table>
+			</form>
+		</div>
+	</section>
+</div>
+EOD;
         $page->set_mode(PageMode::DATA);
         $page->set_code(503);
-        $page->set_data(
-            <<<EOD
-<html lang="en">
-	<head>
-		<title>Downtime</title>
-		<link rel="stylesheet" href="$data_href/themes/$theme_name/style.css" type="text/css">
-	</head>
-	<body>
-		<div id="downtime">
-			<section>
-				<h1 style="text-align: center;">Down for Maintenance</h1>
-				<div id="message" class="blockbody">
-					$message
-				</div>
-			</section>
-			<section>
-				<h3>Admin Login</h3>
-				<div id="login" class="blockbody">
-					$form
-						<table id="login_table" summary="Login Form">
-							<tr>
-								<td width="70"><label for="user">Name</label></td>
-								<td width="70"><input id="user" type="text" name="user"></td>
-							</tr>
-							<tr>
-								<td><label for="pass">Password</label></td>
-								<td><input id="pass" type="password" name="pass"></td>
-							</tr>
-							<tr><td colspan="2"><input type="submit" value="Log In"></td></tr>
-						</table>
-					</form>
-				</div>
-			</section>
-		</div>
-	</body>
-</html>
-EOD
-        );
+        $page->set_data((string)$page->html_html($head, $body));
     }
 }

--- a/ext/emoticons_list/theme.php
+++ b/ext/emoticons_list/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\TITLE;
+
 class EmoticonListTheme extends Themelet
 {
     /**
@@ -13,19 +15,21 @@ class EmoticonListTheme extends Themelet
     {
         global $page;
         $data_href = get_base_href();
-        $html = "<html lang='en'><head><title>Emoticon list</title></head><body>";
-        $html .= "<table><tr>";
+        $body = "<table><tr>";
         $n = 1;
         foreach ($list as $item) {
             $name = pathinfo($item, PATHINFO_FILENAME);
-            $html .= "<td><img alt='$name' src='$data_href/$item'> :$name:</td>";
+            $body .= "<td><img alt='$name' src='$data_href/$item'> :$name:</td>";
             if ($n++ % 3 == 0) {
-                $html .= "</tr><tr>";
+                $body .= "</tr><tr>";
             }
         }
-        $html .= "</tr></table>";
-        $html .= "</body></html>";
+        $body .= "</tr></table>";
+
         $page->set_mode(PageMode::DATA);
-        $page->set_data($html);
+        $page->set_data((string)$page->html_html(
+            TITLE("Emoticon list"),
+            $body
+        ));
     }
 }

--- a/ext/filter/main.php
+++ b/ext/filter/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\SCRIPT;
+
 class Filter extends Extension
 {
     /** @var FilterTheme */
@@ -19,10 +21,10 @@ class Filter extends Extension
     {
         global $page;
         $this->theme->addFilterBox();
-        $page->add_html_header("<script>
+        $page->add_html_header(SCRIPT("
         Array.from(document.getElementsByClassName('thumb')).forEach(function(post) {
             post.style.display='none';
-        });</script>");
+        });"));
     }
 
     public function onSetupBuilding(SetupBuildingEvent $event): void

--- a/ext/filter/theme.php
+++ b/ext/filter/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\{META};
+
 class FilterTheme extends Themelet
 {
     public function addFilterBox(): void
@@ -21,7 +23,7 @@ class FilterTheme extends Themelet
         <a id='disable-all-filters' style='display: none;' href='#'>Disable all</a>
         <a id='re-enable-all-filters' style='display: none;' href='#'>Re-enable all</a>
         ";
-        $page->add_html_header("<meta id='filter-tags' tags='$tags'>");
+        $page->add_html_header(META(['id' => 'filter-tags', 'tags' => $tags]));
         $page->add_block(new Block("Filters", $html, "left", 10));
     }
 }

--- a/ext/google_analytics/main.php
+++ b/ext/google_analytics/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\SCRIPT;
+
 class GoogleAnalytics extends Extension
 {
     # Add analytics to config
@@ -21,15 +23,16 @@ class GoogleAnalytics extends Extension
 
         $google_analytics_id = $config->get_string('google_analytics_id', '');
         if (stristr($google_analytics_id, "UA-")) {
-            $page->add_html_header("<script type='text/javascript'>
-                    var _gaq = _gaq || [];
-                    _gaq.push(['_setAccount', '$google_analytics_id']);
-                    _gaq.push(['_trackPageview']);
-                    (function() {
-                      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                      ga.src = ('https:' === document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-                    })();</script>");
+            $page->add_html_header(SCRIPT(["type" => 'text/javascript'], "
+                var _gaq = _gaq || [];
+                _gaq.push(['_setAccount', '$google_analytics_id']);
+                _gaq.push(['_trackPageview']);
+                (function() {
+                    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+                    ga.src = ('https:' === document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+                })();
+            "));
         }
     }
 }

--- a/ext/handle_mp3/theme.php
+++ b/ext/handle_mp3/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\{SCRIPT};
+
 class MP3FileHandlerTheme extends Themelet
 {
     public function display_image(Image $image): void
@@ -20,7 +22,10 @@ class MP3FileHandlerTheme extends Themelet
 
 			<p><a href='$ilink' id='audio-download'>Download</a>";
 
-        $page->add_html_header("<script src='{$data_href}/ext/handle_mp3/lib/jsmediatags.min.js' type='text/javascript'></script>");
+        $page->add_html_header(SCRIPT([
+            'src' => "$data_href/ext/handle_mp3/lib/jsmediatags.min.js",
+            'type' => 'text/javascript'
+        ]));
         $page->add_block(new Block("Music", $html, "main", 10));
     }
 }

--- a/ext/holiday/main.php
+++ b/ext/holiday/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\LINK;
+
 class Holiday extends Extension
 {
     public function onInitExt(InitExtEvent $event): void
@@ -22,9 +24,11 @@ class Holiday extends Extension
     {
         global $config, $page;
         if (date('d/m') == '01/04' && $config->get_bool("holiday_aprilfools")) {
-            $page->add_html_header(
-                "<link rel='stylesheet' href='".get_base_href()."/ext/holiday/stylesheets/aprilfools.css' type='text/css'>"
-            );
+            $page->add_html_header(LINK([
+                'rel' => 'stylesheet',
+                'href' => get_base_href() . '/ext/holiday/stylesheets/aprilfools.css',
+                'type' => 'text/css'
+            ]));
         }
     }
 }

--- a/ext/home/theme.php
+++ b/ext/home/theme.php
@@ -4,29 +4,24 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\{emptyHTML, TITLE, META, rawHTML};
+
 class HomeTheme extends Themelet
 {
     public function display_page(Page $page, string $sitename, string $base_href, string $theme_name, string $body): void
     {
         $page->set_mode(PageMode::DATA);
         $page->add_auto_html_headers();
-        $hh = $page->get_all_html_headers();
-        $page->set_data(
-            <<<EOD
-<!doctype html>
-<html lang="en">
-	<head>
-		<title>$sitename</title>
-		<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		$hh
-	</head>
-	<body>
-		$body
-	</body>
-</html>
-EOD
-        );
+
+        $page->set_data((string)$page->html_html(
+            emptyHTML(
+                TITLE($sitename),
+                META(["http-equiv" => "Content-Type", "content" => "text/html;charset=utf-8"]),
+                META(["name" => "viewport", "content" => "width=device-width, initial-scale=1"]),
+                $page->get_all_html_headers(),
+            ),
+            $body
+        ));
     }
 
     public function build_body(string $sitename, string $main_links, string $main_text, string $contact_link, string $num_comma, string $counter_text): string

--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\{InputInterface,InputArgument};
 use Symfony\Component\Console\Output\OutputInterface;
 
-use function MicroHTML\{INPUT, emptyHTML};
+use function MicroHTML\{INPUT, emptyHTML, STYLE};
 
 require_once "config.php";
 
@@ -86,7 +86,7 @@ class ImageIO extends Extension
 
         $thumb_width = $config->get_int(ImageConfig::THUMB_WIDTH, 192);
         $thumb_height = $config->get_int(ImageConfig::THUMB_HEIGHT, 192);
-        $page->add_html_header("<style>:root {--thumb-width: {$thumb_width}px; --thumb-height: {$thumb_height}px;}</style>");
+        $page->add_html_header(STYLE(":root {--thumb-width: {$thumb_width}px; --thumb-height: {$thumb_height}px;}"));
 
         if ($event->page_matches("image/delete", method: "POST", permission: Permissions::DELETE_IMAGE)) {
             global $page, $user;

--- a/ext/index/theme.php
+++ b/ext/index/theme.php
@@ -7,7 +7,7 @@ namespace Shimmie2;
 use MicroHTML\HTMLElement;
 
 use function MicroHTML\emptyHTML;
-use function MicroHTML\{BR,H3,HR,P};
+use function MicroHTML\{BR,H3,HR,P,META};
 
 class IndexTheme extends Themelet
 {
@@ -176,7 +176,7 @@ and of course start organising your images :-)
         if (count($this->search_terms) > 0) {
             if ($this->page_number > 3) {
                 // only index the first pages of each term
-                $page->add_html_header('<meta name="robots" content="noindex, nofollow">');
+                $page->add_html_header(META(["name" => "robots", "content" => "noindex, nofollow"]));
             }
             $query = url_escape(Tag::implode($this->search_terms));
             $page->add_block(new Block("Posts", $this->build_table($images, "#search=$query"), "main", 10, "image-list"));

--- a/ext/notes/theme.php
+++ b/ext/notes/theme.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\INPUT;
+use function MicroHTML\{INPUT,SCRIPT};
 
 /**
  * @phpstan-type NoteHistory array{image_id:int,note_id:int,review_id:int,user_name:string,note:string,date:string}
@@ -61,12 +61,15 @@ class NotesTheme extends Themelet
                 'note_id' => $note["id"],
             ];
         }
-        $page->add_html_header("<script type='text/javascript'>
-        window.notes = ".\Safe\json_encode($to_json).";
-        window.notes_image_id = $image_id;
-        window.notes_admin = ".($adminOptions ? "true" : "false").";
-        window.notes_edit = ".($editOptions ? "true" : "false").";
-        </script>");
+        $page->add_html_header(SCRIPT(
+            ["type" => "text/javascript"],
+            "
+            window.notes = ".\Safe\json_encode($to_json).";
+            window.notes_image_id = $image_id;
+            window.notes_admin = ".($adminOptions ? "true" : "false").";
+            window.notes_edit = ".($editOptions ? "true" : "false").";
+            "
+        ));
     }
 
     /**

--- a/ext/regen_thumb/theme.php
+++ b/ext/regen_thumb/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\INPUT;
+use function MicroHTML\META;
 
 class RegenThumbTheme extends Themelet
 {
@@ -15,7 +15,7 @@ class RegenThumbTheme extends Themelet
     {
         $page->set_title("Thumbnail Regenerated");
         $page->set_heading("Thumbnail Regenerated");
-        $page->add_html_header("<meta http-equiv=\"cache-control\" content=\"no-cache\">");
+        $page->add_html_header(META(['http-equiv' => 'cache-control', 'content' => 'no-cache']));
         $page->add_block(new NavBlock());
         $page->add_block(new Block("Thumbnail", $this->build_thumb_html($image)));
     }

--- a/ext/rss_comments/main.php
+++ b/ext/rss_comments/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\LINK;
+
 class RSSComments extends Extension
 {
     public function onPostListBuilding(PostListBuildingEvent $event): void
@@ -11,8 +13,12 @@ class RSSComments extends Extension
         global $config, $page;
         $title = $config->get_string(SetupConfig::TITLE);
 
-        $page->add_html_header("<link rel=\"alternate\" type=\"application/rss+xml\" ".
-            "title=\"$title - Comments\" href=\"".make_link("rss/comments")."\" />");
+        $page->add_html_header(LINK([
+            'rel' => 'alternate',
+            'type' => 'application/rss+xml',
+            'title' => "$title - Comments",
+            'href' => make_link("rss/comments")
+        ]));
     }
 
     public function onPageRequest(PageRequestEvent $event): void

--- a/ext/rss_images/main.php
+++ b/ext/rss_images/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\{LINK};
+
 class RSSImages extends Extension
 {
     public function onPostListBuilding(PostListBuildingEvent $event): void
@@ -13,11 +15,19 @@ class RSSImages extends Extension
 
         if (count($event->search_terms) > 0) {
             $search = url_escape(Tag::implode($event->search_terms));
-            $page->add_html_header("<link id=\"images\" rel=\"alternate\" type=\"application/rss+xml\" ".
-                "title=\"$title - Posts with tags: $search\" href=\"".make_link("rss/images/$search/1")."\" />");
+            $page->add_html_header(LINK([
+                'rel' => 'alternate',
+                'type' => 'application/rss+xml',
+                'title' => "$title - Posts with tags: $search",
+                'href' => make_link("rss/images/$search/1")
+            ]));
         } else {
-            $page->add_html_header("<link id=\"images\" rel=\"alternate\" type=\"application/rss+xml\" ".
-                "title=\"$title - Posts\" href=\"".make_link("rss/images/1")."\" />");
+            $page->add_html_header(LINK([
+                'rel' => 'alternate',
+                'type' => 'application/rss+xml',
+                'title' => "$title - Posts",
+                'href' => make_link("rss/images/1")
+            ]));
         }
     }
 

--- a/ext/site_description/main.php
+++ b/ext/site_description/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\{META};
+
 class SiteDescription extends Extension
 {
     public function onPageRequest(PageRequestEvent $event): void
@@ -11,11 +13,17 @@ class SiteDescription extends Extension
         global $config, $page;
         if (!empty($config->get_string("site_description"))) {
             $description = $config->get_string("site_description");
-            $page->add_html_header("<meta name=\"description\" content=\"$description\">");
+            $page->add_html_header(META([
+                'name' => 'description',
+                'content' => $description
+            ]));
         }
         if (!empty($config->get_string("site_keywords"))) {
             $keywords = $config->get_string("site_keywords");
-            $page->add_html_header("<meta name=\"keywords\" content=\"$keywords\">");
+            $page->add_html_header(META([
+                'name' => 'keywords',
+                'content' => $keywords
+            ]));
         }
     }
 

--- a/ext/site_description/test.php
+++ b/ext/site_description/test.php
@@ -12,8 +12,8 @@ class SiteDescriptionTest extends ShimmiePHPUnitTestCase
         $config->set_string("site_description", "A Shimmie testbed");
         $this->get_page("post/list");
         $this->assertStringContainsString(
-            '<meta name="description" content="A Shimmie testbed">',
-            $page->get_all_html_headers()
+            "<meta name='description' content='A Shimmie testbed' />",
+            (string)$page->get_all_html_headers()
         );
     }
 
@@ -23,8 +23,8 @@ class SiteDescriptionTest extends ShimmiePHPUnitTestCase
         $config->set_string("site_keywords", "foo,bar,baz");
         $this->get_page("post/list");
         $this->assertStringContainsString(
-            '<meta name="keywords" content="foo,bar,baz">',
-            $page->get_all_html_headers()
+            "<meta name='keywords' content='foo,bar,baz' />",
+            (string)$page->get_all_html_headers()
         );
     }
 }

--- a/ext/terms/theme.php
+++ b/ext/terms/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\{emptyHTML, TITLE, META, rawHTML};
+
 class TermsTheme extends Themelet
 {
     public function display_page(Page $page, string $sitename, string $path, string $body): void

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -18,7 +18,7 @@ use MicroCRUD\TextColumn;
 use MicroCRUD\DateColumn;
 use MicroCRUD\Table;
 
-use function MicroHTML\A;
+use function MicroHTML\{A, STYLE};
 
 class UserNameColumn extends TextColumn
 {
@@ -160,9 +160,9 @@ class UserPage extends Extension
         $this->show_user_info();
 
         if ($user->can(Permissions::VIEW_HELLBANNED)) {
-            $page->add_html_header("<style>DIV.hb, TR.hb TD {border: 1px solid red !important;}</style>");
+            $page->add_html_header(STYLE("DIV.hb, TR.hb TD {border: 1px solid red !important;}"));
         } elseif (!$user->can(Permissions::HELLBANNED)) {
-            $page->add_html_header("<style>.hb {display: none !important;}</style>");
+            $page->add_html_header(STYLE(".hb {display: none !important;}"));
         }
 
         if ($event->page_matches("user_admin/login", method: "GET")) {

--- a/ext/view/theme.php
+++ b/ext/view/theme.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{A, joinHTML, TABLE, TR, TD, INPUT, emptyHTML, DIV, BR};
+use function MicroHTML\{A, joinHTML, TABLE, TR, TD, INPUT, emptyHTML, DIV, BR, META, LINK};
 
 class ViewPostTheme extends Themelet
 {
@@ -14,12 +14,12 @@ class ViewPostTheme extends Themelet
     {
         global $page;
 
-        $h_metatags = str_replace(" ", ", ", html_escape($image->get_tag_list()));
-        $page->add_html_header("<meta name=\"keywords\" content=\"$h_metatags\">");
-        $page->add_html_header("<meta property=\"og:title\" content=\"$h_metatags\">");
-        $page->add_html_header("<meta property=\"og:type\" content=\"article\">");
-        $page->add_html_header("<meta property=\"og:image\" content=\"".make_http($image->get_thumb_link())."\">");
-        $page->add_html_header("<meta property=\"og:url\" content=\"".make_http(make_link("post/view/{$image->id}"))."\">");
+        $h_metatags = str_replace(" ", ", ", $image->get_tag_list());
+        $page->add_html_header(META(["name" => "keywords", "content" => $h_metatags]));
+        $page->add_html_header(META(["property" => "og:title", "content" => $h_metatags]));
+        $page->add_html_header(META(["property" => "og:type", "content" => "article"]));
+        $page->add_html_header(META(["property" => "og:image", "content" => make_http($image->get_thumb_link())]));
+        $page->add_html_header(META(["property" => "og:url", "content" => make_http(make_link("post/view/{$image->id}"))]));
     }
 
     /**
@@ -38,8 +38,8 @@ class ViewPostTheme extends Themelet
 
         $query = $this->get_query();
         if(!$this->is_ordered_search()) {
-            $page->add_html_header("<link id='nextlink' rel='next' href='".make_link("post/next/{$image->id}", $query)."'>");
-            $page->add_html_header("<link id='prevlink' rel='previous' href='".make_link("post/prev/{$image->id}", $query)."'>");
+            $page->add_html_header(LINK(["id" => "nextlink", "rel" => "next", "href" => make_link("post/next/{$image->id}", $query)]));
+            $page->add_html_header(LINK(["id" => "prevlink", "rel" => "previous", "href" => make_link("post/prev/{$image->id}", $query)]));
         }
     }
 


### PR DESCRIPTION

I wanted to ensure that all pages (even the downtime page, terms page, home page, etc) had the appropriate `data-` attributes on `<body>` (because those are required for certain javascript, eg autocomplete, to work). One thing led to another and now everything in `head` is microhtml'ed
