### PR TITLE
[core] Allow relative links for contact link

### DIFF
--- a/core/util.php
+++ b/core/util.php
@@ -41,7 +41,7 @@ function contact_link(?string $contact = null): ?string
         return "mailto:$text";
     }
 
-    if (str_contains($text, "/")) {
+    if (str_contains($text, "/") && mb_substr($text, 0, 1) != "/") {
         return "https://$text";
     }
 


### PR DESCRIPTION
This allows a contact link to be something like "/wiki/contact".

This is better than an absolute links ("https://booru.example.org/wiki/contact"):
- the booru ever changes domain name (or has multiple domain names)
- the booru uses multiple protocols (e.g. has a regular domain and also a Tor .onion address)