### PR TITLE
[danbooru2] add autocomplete to view search field, fixes #1151

### DIFF
--- a/themes/danbooru2/view.theme.php
+++ b/themes/danbooru2/view.theme.php
@@ -72,7 +72,7 @@ class CustomViewPostTheme extends ViewPostTheme
         //$h_pin = $this->build_pin($image);
         $h_search = "
 			<form action='".search_link()."' method='GET'>
-				<input name='search' type='text'  style='width:75%'>
+				<input name='search' type='text' class='autocomplete_tags' style='width:75%'>
 				<input type='submit' value='Go' style='width:20%'>
 				<input type='hidden' name='q' value='post/list'>
 			</form>


### PR DESCRIPTION
Fixes #1151

Danbooru2 theme overrides the search field on the view page, failing to include the autocomplete class.