### PR TITLE
[blur] blur thumbs with explicit rating

### DIFF
--- a/core/basethemelet.php
+++ b/core/basethemelet.php
@@ -69,6 +69,12 @@ class BaseThemelet
                 $custom_classes .= "shm-thumb-has_child ";
             }
         }
+        if(Extension::is_enabled(RatingsInfo::KEY) && Extension::is_enabled(RatingsBlurInfo::KEY)) {
+            $rb = new RatingsBlur();
+            if ($rb->blur($image['rating'])) {
+                $custom_classes .= "blur ";
+            }
+        }
 
         $attrs = [
             "href" => $view_link,

--- a/ext/ratings_blur/info.php
+++ b/ext/ratings_blur/info.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+class RatingsBlurInfo extends ExtensionInfo
+{
+    public const KEY = "ratings_blur";
+
+    public string $key = self::KEY;
+    public string $name = "Ratings Blur";
+    public array $authors = ["Discomrade" => ""];
+    public string $license = self::LICENSE_WTFPL;
+    public string $description = "Blurs thumbs based on rating, users can override. Requires 'Post Ratings'.";
+    public array $dependencies = [RatingsInfo::KEY];
+}

--- a/ext/ratings_blur/main.php
+++ b/ext/ratings_blur/main.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+abstract class RatingsBlurConfig
+{
+    public const VERSION = "ext_ratings_blur_version";
+    public const GLOBAL_DEFAULTS = "ext_ratings_blur_defaults";
+    public const USER_DEFAULTS = "ratings_blur_default";
+    public const DEFAULT_OPTIONS = ["e"];
+    public const NULL_OPTION = "[none]";
+}
+
+class RatingsBlur extends Extension
+{
+    public function onInitExt(InitExtEvent $event): void
+    {
+        global $config;
+
+        $config->set_default_array(RatingsBlurConfig::GLOBAL_DEFAULTS, RatingsBlurConfig::DEFAULT_OPTIONS);
+    }
+
+    public function onInitUserConfig(InitUserConfigEvent $event): void
+    {
+        global $config;
+
+        $event->user_config->set_default_array(RatingsBlurConfig::USER_DEFAULTS, $config->get_array(RatingsBlurConfig::GLOBAL_DEFAULTS));
+    }
+
+    public function onUserOptionsBuilding(UserOptionsBuildingEvent $event): void
+    {
+        global $user;
+
+        $levels = Ratings::get_user_class_privs($user);
+        $options = [];
+        foreach ($levels as $level) {
+            $options[ImageRating::$known_ratings[$level]->name] = $level;
+        }
+        $null_option = RatingsBlurConfig::NULL_OPTION;
+        $options[$null_option] = $null_option;
+
+        $sb = $event->panel->create_new_block("Rating Blur Filter");
+        $sb->start_table();
+        $sb->add_multichoice_option(RatingsBlurConfig::USER_DEFAULTS, $options, "Blurred Ratings: ", true);
+        $sb->end_table();
+        $sb->add_label("This controls which posts will be blurred. Unselecting all will revert to default settings, so select '$null_option' to blur no images.");
+    }
+
+    public function onSetupBuilding(SetupBuildingEvent $event): void
+    {
+        $ratings = Ratings::get_sorted_ratings();
+
+        $options = [];
+        foreach ($ratings as $key => $rating) {
+            $options[$rating->name] = $rating->code;
+        }
+        $null_option = RatingsBlurConfig::NULL_OPTION;
+        $options[$null_option] = $null_option;
+
+        $sb = $event->panel->create_new_block("Post Rating Blur Defaults");
+        $sb->start_table();
+        $sb->add_multichoice_option(RatingsBlurConfig::GLOBAL_DEFAULTS, $options, "Default blurred ratings", true);
+        $sb->end_table();
+        $sb->add_label("Unselecting all will revert to default settings, so select '$null_option' to blur no images.");
+    }
+
+    public function blur(string $rating): bool
+    {
+        global $user_config;
+
+        $blur_ratings = $user_config->get_array(RatingsBlurConfig::USER_DEFAULTS);
+        if (in_array(RatingsBlurConfig::NULL_OPTION, $blur_ratings)) {
+            return false;
+        }
+        return in_array($rating, $blur_ratings);
+    }
+}

--- a/ext/ratings_blur/style.css
+++ b/ext/ratings_blur/style.css
@@ -1,0 +1,7 @@
+.blur IMG {
+	filter: blur(5px);
+	transition: all .3s ease-in;
+}
+.blur IMG:hover {
+	filter: blur(0px);
+}

--- a/ext/ratings_blur/test.php
+++ b/ext/ratings_blur/test.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+class RatingsBlurTest extends ShimmiePHPUnitTestCase
+{
+    private string $username = "test_ratings";
+
+    public function testRatingBlurDefault(): void
+    {
+        $this->log_in_as_user();
+        $image_id_s = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
+        $image_s = Image::by_id_ex($image_id_s);
+        send_event(new RatingSetEvent($image_s, "s"));
+
+        // the safe image should not insert a blur class
+        $this->get_page("post/list");
+        $this->assert_no_text("blur");
+
+        $image_id_e = $this->post_image("tests/bedroom_workshop.jpg", "bedroom");
+        $image_e = Image::by_id_ex($image_id_e);
+        send_event(new RatingSetEvent($image_e, "e"));
+
+        // the explicit image should insert a blur class
+        $this->get_page("post/list");
+        $this->assert_text("blur");
+    }
+
+    public function testRatingBlurGlobalConfig(): void
+    {
+        global $config, $user_config;
+
+        // change global setting: don't blur explict, only blur safe
+        $config->set_array(RatingsBlurConfig::GLOBAL_DEFAULTS, ["s"]);
+        // create a new user to simulate inheriting the global default without manually setting the user default
+        $this->create_test_user($this->username);
+
+        $image_id_e = $this->post_image("tests/bedroom_workshop.jpg", "bedroom");
+        $image_e = Image::by_id_ex($image_id_e);
+        send_event(new RatingSetEvent($image_e, "e"));
+
+        // the explicit image should not insert a blur class
+        $this->get_page("post/list");
+        $this->assert_no_text("blur");
+
+        $image_id_s = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
+        $image_s = Image::by_id_ex($image_id_s);
+        send_event(new RatingSetEvent($image_s, "s"));
+
+        // the safe image should insert a blur class
+        $this->get_page("post/list");
+        $this->assert_text("blur");
+
+        // change global setting: don't blur any
+        $config->set_array(RatingsBlurConfig::GLOBAL_DEFAULTS, [RatingsBlurConfig::NULL_OPTION]);
+        // create a new user to simulate inheriting the global default without manually setting the user default
+        $this->delete_test_user($this->username);
+        $this->create_test_user($this->username);
+
+        $this->get_page("post/list");
+        $this->assert_no_text("blur");
+
+        $this->delete_test_user($this->username);
+    }
+
+    public function testRatingBlurUserConfig(): void
+    {
+        global $config, $user_config;
+        // set global default to blur all, so we can test it is overriden
+        $config->set_array(RatingsBlurConfig::GLOBAL_DEFAULTS, array_keys(ImageRating::$known_ratings));
+
+        $this->log_in_as_user();
+
+        // don't blur explict, blur safe
+        $user_config->set_array(RatingsBlurConfig::USER_DEFAULTS, ["s"]);
+
+        $image_id_e = $this->post_image("tests/bedroom_workshop.jpg", "bedroom");
+        $image_e = Image::by_id_ex($image_id_e);
+        send_event(new RatingSetEvent($image_e, "e"));
+
+        // the explicit image should not insert a blur class
+        $this->get_page("post/list");
+        $this->assert_no_text("blur");
+
+        $image_id_s = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
+        $image_s = Image::by_id_ex($image_id_s);
+        send_event(new RatingSetEvent($image_s, "s"));
+
+        // the safe image should insert a blur class
+        $this->get_page("post/list");
+        $this->assert_text("blur");
+
+        // don't blur any
+        $user_config->set_array(RatingsBlurConfig::USER_DEFAULTS, [RatingsBlurConfig::NULL_OPTION]);
+
+        $this->get_page("post/list");
+        $this->assert_no_text("blur");
+    }
+
+    private function create_test_user(string $username): void
+    {
+        send_event(new UserCreationEvent($username, $username, $username, "$username@test.com", false));
+        send_event(new UserLoginEvent(User::by_name($username)));
+    }
+
+    private function delete_test_user(string $username): void
+    {
+        $this->log_out();
+        $this->log_in_as_admin();
+        send_event(new PageRequestEvent(
+            "POST",
+            "user_admin/delete_user",
+            [],
+            ['id' => (string)User::by_name($username)->id, 'with_images' => '', 'with_comments' => '']
+        ));
+        $this->log_out();
+    }
+
+    // reset the user config to defaults at the end of every test so
+    // that it doesn't mess with other unrelated tests
+    public function tearDown(): void
+    {
+        global $config, $user_config;
+        $config->set_array(RatingsBlurConfig::GLOBAL_DEFAULTS, RatingsBlurConfig::DEFAULT_OPTIONS);
+
+        $this->log_in_as_user();
+        $user_config->set_array(RatingsBlurConfig::USER_DEFAULTS, RatingsBlurConfig::DEFAULT_OPTIONS);
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
This allows thumbs with certain ratings to be blurred until hovered over (or long-tapped on a touchscreen). This is made for boorus where explicit content should be available, but blurred out by default.

![image](https://github.com/shish/shimmie2/assets/83621080/46d26177-979b-46d4-87a2-1834aaeffda4)

The admin can set the global default level to blur (e.g. Explicit, Questionable & Explicit, none) and user accounts can override it in their settings. Anon users receive the global default.

The second test function (`testRatingBlurGlobalConfig`) creates and deletes a test account. This is to simulate an anon user loading the global config. If there is a better way to do this, I can try and improve it.