### PR TITLE
[themes] add search link to rating

### DIFF
--- a/themes/danbooru/view.theme.php
+++ b/themes/danbooru/view.theme.php
@@ -53,11 +53,12 @@ class CustomViewPostTheme extends ViewPostTheme
         }
 
         if (Extension::is_enabled(RatingsInfo::KEY)) {
-            if ($image['rating'] === null || $image['rating'] == "?") {
-                $image['rating'] = "?";
+            $rating = $image['rating'];
+            if ($rating === null) {
+                $rating = "?";
             }
-            $h_rating = Ratings::rating_to_human($image['rating']);
-            $html .= "<br>Rating: $h_rating";
+            $h_rating = Ratings::rating_to_human($rating);
+            $html .= "<br>Rating: <a href='".search_link(["rating=$rating"])."'>$h_rating</a>";
         }
 
         return $html;

--- a/themes/danbooru2/view.theme.php
+++ b/themes/danbooru2/view.theme.php
@@ -54,14 +54,12 @@ class CustomViewPostTheme extends ViewPostTheme
         }
 
         if (Extension::is_enabled(RatingsInfo::KEY)) {
-            if ($image['rating'] === null || $image['rating'] == "?") {
-                $image['rating'] = "?";
+            $rating = $image['rating'];
+            if ($rating === null) {
+                $rating = "?";
             }
-            // @phpstan-ignore-next-line - ???
-            if (Extension::is_enabled(RatingsInfo::KEY)) {
-                $h_rating = Ratings::rating_to_human($image['rating']);
-                $html .= "<br>Rating: $h_rating";
-            }
+            $h_rating = Ratings::rating_to_human($rating);
+            $html .= "<br>Rating: <a href='".search_link(["rating=$rating"])."'>$h_rating</a>";
         }
 
         return $html;

--- a/themes/lite/view.theme.php
+++ b/themes/lite/view.theme.php
@@ -58,11 +58,12 @@ class CustomViewPostTheme extends ViewPostTheme
         }
 
         if (Extension::is_enabled(RatingsInfo::KEY)) {
-            if ($image['rating'] === null || $image['rating'] == "?") {
-                $image['rating'] = "?";
+            $rating = $image['rating'];
+            if ($rating === null) {
+                $rating = "?";
             }
-            $h_rating = Ratings::rating_to_human($image['rating']);
-            $html .= "<br>Rating: $h_rating";
+            $h_rating = Ratings::rating_to_human($rating);
+            $html .= "<br>Rating: <a href='".search_link(["rating=$rating"])."'>$h_rating</a>";
         }
 
         return $html;


### PR DESCRIPTION
Danbooru* and Lite themes add an image metadata section listing the rating. This is updated to have a search link, like the rating listing on the post metadata.

![image](https://github.com/shish/shimmie2/assets/83621080/afe893b2-4302-42a1-b5c8-b9e522a92c57)

This also removes a redundant condition.
