### PR TITLE
[alias] add info on tag aliases and tag implications

### DIFF
--- a/ext/alias_editor/theme.php
+++ b/ext/alias_editor/theme.php
@@ -7,7 +7,8 @@ namespace Shimmie2;
 use MicroHTML\HTMLElement;
 
 use function MicroHTML\emptyHTML;
-use function MicroHTML\{BR,INPUT};
+use function MicroHTML\rawHTML;
+use function MicroHTML\{BR,CODE,INPUT};
 
 class AliasEditorTheme extends Themelet
 {
@@ -18,7 +19,9 @@ class AliasEditorTheme extends Themelet
     {
         global $page, $user;
 
-        $html = emptyHTML($table, BR(), $paginator, BR(), SHM_A("alias/export/aliases.csv", "Download as CSV", args: ["download" => "aliases.csv"]));
+        $info_html = rawHTML("A tag alias replaces a tag with another tag or tags.".BR()."A tag implication (where the old tag stays and adds a new tag) is made by including the old tag in the list of new tags (".CODE("fox")."&nbsp;→&nbsp;".CODE("fox canine").")".BR());
+
+        $html = emptyHTML($info_html, BR(), $table, BR(), $paginator, BR(), SHM_A("alias/export/aliases.csv", "Download as CSV", args: ["download" => "aliases.csv"]));
 
         $bulk_form = SHM_FORM("alias/import", multipart: true);
         $bulk_form->appendChild(


### PR DESCRIPTION
This commit adds a small message telling users about tag aliases and tag implications. It also gives a hint for how to make a tag implication (which I did not know as a feature of Shimmie until I found https://github.com/shish/shimmie2/issues/320 \o/ )