### PR TITLE
[comment] move recent comments below tags on post list

### DIFF
--- a/ext/comment/theme.php
+++ b/ext/comment/theme.php
@@ -125,7 +125,7 @@ class CommentListTheme extends Themelet
             $html .= $this->comment_to_html($comment, true);
         }
         $html .= "<a class='more' href='".make_link("comment/list")."'>Full List</a>";
-        $page->add_block(new Block("Comments", $html, "left", 50, "comment-list-recent"));
+        $page->add_block(new Block("Comments", $html, "left", 70, "comment-list-recent"));
     }
 
     /**


### PR DESCRIPTION
Lowers the priority of tall "Comments" box on the `post/list` pages, so the more critical fields "Popular Tags" and "Refine Search" are clearly visible to the user.