### PR TITLE
[tag_history] show colour-coded tag changes, remove tag aliasing

### DIFF
--- a/ext/tag_history/main.php
+++ b/ext/tag_history/main.php
@@ -302,6 +302,22 @@ class TagHistory extends Extension
     }
 
     /**
+     * @return array<string, mixed>|null
+     */
+    public function get_previous_tags(int $image_id, int $id): ?array
+    {
+        global $database;
+        $row = $database->get_row("
+				SELECT tags
+				FROM tag_histories
+				WHERE image_id = :image_id AND id < :id
+				ORDER BY id DESC
+				LIMIT 1
+		", ["image_id" => $image_id, "id" => $id]);
+        return ($row ? $row : null);
+    }
+
+    /**
      * This function attempts to revert all changes by a given IP within an (optional) timeframe.
      */
     public function process_revert_all_changes(?string $name, ?string $ip, ?string $date): void

--- a/ext/tag_history/style.css
+++ b/ext/tag_history/style.css
@@ -1,0 +1,2 @@
+.added-tag{background:lightgreen;}
+.deleted-tag{background:pink;text-decoration:line-through;}

--- a/ext/tag_history/theme.php
+++ b/ext/tag_history/theme.php
@@ -132,10 +132,30 @@ class TagHistoryTheme extends Themelet
             : null;
         $setter = A(["href" => make_link("user/" . url_escape($name))], $name);
 
+        $th = new TagHistory();
+        $pt = $th->get_previous_tags($image_id, $current_id);
+        if ($pt) {
+            $previous_tags = Tag::explode($pt["tags"]);
+        }
         $current_tags = Tag::explode($current_tags);
+        if ($pt) {
+            $tags = array_unique(array_merge($current_tags, $previous_tags));
+            sort($tags);
+        } else {
+            $tags = $current_tags;
+        }
         $taglinks = SPAN();
-        foreach ($current_tags as $tag) {
-            $taglinks->appendChild(A(["href" => search_link([$tag])], $tag));
+        foreach ($tags as $tag) {
+            $class = "";
+            if ($pt) {
+                if (!in_array($tag, $previous_tags)) {
+                    $class = "added-tag";
+                }
+                if (!in_array($tag, $current_tags)) {
+                    $class = "deleted-tag";
+                }
+            }
+            $taglinks->appendChild(A(["href" => search_link([$tag]), "class" => $class], $tag));
             $taglinks->appendChild(" ");
         }
 

--- a/ext/tag_history/theme.php
+++ b/ext/tag_history/theme.php
@@ -135,9 +135,9 @@ class TagHistoryTheme extends Themelet
         $th = new TagHistory();
         $pt = $th->get_previous_tags($image_id, $current_id);
         if ($pt) {
-            $previous_tags = Tag::explode($pt["tags"]);
+            $previous_tags = explode(" ", $pt["tags"]);
         }
-        $current_tags = Tag::explode($current_tags);
+        $current_tags = explode(" ", $current_tags);
         if ($pt) {
             $tags = array_unique(array_merge($current_tags, $previous_tags));
             sort($tags);


### PR DESCRIPTION
![image](https://github.com/shish/shimmie2/assets/83621080/2b72b9b1-2ddb-4f09-94c4-6f2e037ff49b)

This makes it much easier to see when a tag was introduced in each entry.

Using `explode` instead of `Tag::explode` prevents tags being aliased in the tag history, which could make some entries identical (consider the example, where the aliases `stirner`->`max_stirner` and `anarchist`->`anarchism` were introduced. If `Tag::explode` were used, it would not show any change as the tags in the old entry would be aliased to be the same as the newer ones).
This also prevents the database being queried on each tag, massively improving performance on tag history pages.