### PR TITLE
[core] have User::by_session() check session ID on the PHP side

### DIFF
--- a/core/user.php
+++ b/core/user.php
@@ -83,14 +83,15 @@ class User
     public static function by_session(string $name, string $session): ?User
     {
         global $cache, $config, $database;
-        $row = $cache->get("user-session:$name-$session");
-        if (is_null($row)) {
-            $args = ["name" => $name, "ip" => get_session_ip($config), "sess" => $session];
-            $query = "SELECT * FROM users WHERE name = :name AND md5(pass || :ip) = :sess";
-            $row = $database->get_row($query, $args);
-            $cache->set("user-session:$name-$session", $row, 600);
+        $user = $cache->get("user-session-obj:$name-$session");
+        if (is_null($user)) {
+            $user_by_name = User::by_name($name);
+            if($user_by_name->get_session_id() === $session) {
+                $user = $user_by_name;
+            }
+            $cache->set("user-session-obj:$name-$session", $user, 600);
         }
-        return is_null($row) ? null : new User($row);
+        return $user;
     }
 
     public static function by_id(int $id): ?User


### PR DESCRIPTION
Every database has its own unique way of hashing data (md5 is _mostly_ consistent, but stronger hashes vary a lot more) - doing it on the PHP side means we only need to write the code once