### PR TITLE
[statistics] various fixes

### DIFF
--- a/ext/statistics/main.php
+++ b/ext/statistics/main.php
@@ -95,7 +95,7 @@ class Statistics extends Extension
     {
         global $database;
         // Returns the username and tags from each tag history entry. This includes Anonymous tag histories to prevent their tagging being ignored and credited to the next user to edit.
-        $tag_stats = $database->get_all("SELECT users.class,users.name,tag_histories.tags,tag_histories.image_id FROM tag_histories INNER JOIN users ON users.id = tag_histories.user_id WHERE 1=1 ORDER BY users.id;");
+        $tag_stats = $database->get_all("SELECT users.class,users.name,tag_histories.tags,tag_histories.image_id FROM tag_histories INNER JOIN users ON users.id = tag_histories.user_id WHERE 1=1 ORDER BY tag_histories.id;");
 
         // Group tag history entries by image id
         $tag_histories = [];

--- a/ext/statistics/theme.php
+++ b/ext/statistics/theme.php
@@ -32,7 +32,7 @@ class StatisticsTheme extends Themelet
     }
 
     /**
-     * @param array<string, int> $data
+     * @param array<string, int|string> $data
      */
     public function build_table(array $data, string $id, string $title, ?int $limit = 10): HTMLElement
     {
@@ -42,7 +42,7 @@ class StatisticsTheme extends Themelet
             $rows->appendChild(
                 TR(
                     TD([], $n),
-                    TD([], $value),
+                    TD([], rawHTML((string)$value)),
                     TD([], $user)
                 )
             );

--- a/ext/statistics/theme.php
+++ b/ext/statistics/theme.php
@@ -43,7 +43,7 @@ class StatisticsTheme extends Themelet
                 TR(
                     TD([], $n),
                     TD([], rawHTML((string)$value)),
-                    TD([], $user)
+                    TD([], rawHTML('<a class="username" href="'.make_link('user/'.$user).'">'.$user.'</a>'))
                 )
             );
             $n++;


### PR DESCRIPTION
Commit 1 corrects a major inaccuracy by sorting the data in correct order.

Commit 2 aliases tags before counting changes. This is a bit of a trade-off, it does eliminate changes made before an alias was added, but it does prevent alias changes from counting towards whoever edited the tags next. It also includes the total number of edits made.

Commit 3 makes the names on the stat lists into links for easy of use.