### PR TITLE
[setup] allow setting bool option to false if default is true

### DIFF
--- a/ext/setup/main.php
+++ b/ext/setup/main.php
@@ -406,7 +406,12 @@ class Setup extends Extension
                             break;
                     }
                 } else {
-                    $config->delete($name);
+                    // browsers don't send empty checkboxes, false value must be stored in case default is true
+                    if ($type == "bool") {
+                        $config->set_bool($name, false);
+                    } else {
+                        $config->delete($name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes issue where a checkbox cannot be set as false if the default value is true (for example, the "Allow new signups" setting could not be disabled).