### PR TITLE
Replace flexihash with weighted rendezvous hashing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
 		"ext-pdo": "*",
 		"ext-json": "*",
 		"ext-fileinfo": "*",
-		"flexihash/flexihash": "^2.0",
 		"ifixit/php-akismet": "^1.0",
 		"google/recaptcha": "^1.1",
 		"shish/eventtracer-php": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e9088a6918304948514af77236756dd",
+    "content-hash": "ea210c5a35b525e8872550bc7c1cc3a8",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -321,63 +321,6 @@
                 "source": "https://github.com/ezyang/htmlpurifier/tree/v4.17.0"
             },
             "time": "2023-11-17T15:01:25+00:00"
-        },
-        {
-            "name": "flexihash/flexihash",
-            "version": "v2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pda/flexihash.git",
-                "reference": "497ba5782606d998f8ab0b4e5942e3a799bec018"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pda/flexihash/zipball/497ba5782606d998f8ab0b4e5942e3a799bec018",
-                "reference": "497ba5782606d998f8ab0b4e5942e3a799bec018",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8",
-                "satooshi/php-coveralls": "~1.0",
-                "squizlabs/php_codesniffer": "^2.3",
-                "symfony/config": "^2.0.0",
-                "symfony/console": "^2.0.0",
-                "symfony/filesystem": "^2.0.0",
-                "symfony/stopwatch": "^2.0.0",
-                "symfony/yaml": "^2.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Flexihash\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paul Annesley",
-                    "email": "paul@annesley.cc",
-                    "homepage": "http://paul.annesley.cc"
-                },
-                {
-                    "name": "Dom Morgan",
-                    "email": "dom@d3r.com",
-                    "homepage": "https://d3r.com"
-                }
-            ],
-            "description": "Flexihash is a small PHP library which implements consistent hashing",
-            "homepage": "https://github.com/pda/flexihash",
-            "support": {
-                "issues": "https://github.com/pda/flexihash/issues",
-                "source": "https://github.com/pda/flexihash/tree/v2.0.2"
-            },
-            "time": "2016-04-22T21:03:23+00:00"
         },
         {
             "name": "google/recaptcha",
@@ -6012,7 +5955,7 @@
         "naroga/redis-cache": 20,
         "symfony/console": 20
     },
-    "prefer-stable": true,
+    "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2",

--- a/core/tests/UtilTest.php
+++ b/core/tests/UtilTest.php
@@ -105,21 +105,57 @@ class UtilTest extends TestCase
         );
     }
 
-    public function test_load_balance_url(): void
+    public function test_load_balancing_parse(): void
+    {
+        $this->assertEquals(
+            ["foo" => 10, "bar" => 5, "baz" => 5, "quux" => 0],
+            parse_load_balancer_config("foo=10,bar=5,baz=5,quux=0")
+        );
+    }
+
+    public function test_load_balancing_choose(): void
+    {
+        $string_config = "foo=10,bar=5,baz=5,quux=0";
+        $array_config = ["foo" => 10, "bar" => 5, "baz" => 5, "quux" => 0];
+        $hash = "7ac19c10d6859415";
+
+        $this->assertEquals(
+            $array_config,
+            parse_load_balancer_config($string_config)
+        );
+        $this->assertEquals(
+            "foo",
+            choose_load_balancer_node($array_config, $hash)
+        );
+
+        // Check that the balancing gives results in approximately
+        // the right ratio (compatible implmentations should give
+        // exactly these results)
+        $results = ["foo" => 0, "bar" => 0, "baz" => 0, "quux" => 0];
+        for ($i = 0; $i < 2000; $i++) {
+            $results[choose_load_balancer_node($array_config, (string)$i)]++;
+        }
+        $this->assertEquals(
+            ["foo" => 1001, "bar" => 502, "baz" => 497, "quux" => 0],
+            $results
+        );
+    }
+
+    public function test_load_balancing_url(): void
     {
         $hash = "7ac19c10d6859415";
         $ext = "jpg";
 
         // pseudo-randomly select one of the image servers, balanced in given ratio
         $this->assertEquals(
-            "https://baz.mycdn.com/7ac19c10d6859415.jpg",
-            load_balance_url("https://{foo=10,bar=5,baz=5}.mycdn.com/$hash.$ext", $hash)
+            "https://foo.mycdn.com/7ac19c10d6859415.jpg",
+            load_balance_url("https://{foo=10,bar=5,baz=5,quux=0}.mycdn.com/$hash.$ext", $hash)
         );
 
         // N'th and N+1'th results should be different
         $this->assertNotEquals(
-            load_balance_url("https://{foo=10,bar=5,baz=5}.mycdn.com/$hash.$ext", $hash, 0),
-            load_balance_url("https://{foo=10,bar=5,baz=5}.mycdn.com/$hash.$ext", $hash, 1)
+            load_balance_url("https://{foo=10,bar=5,baz=5,quux=0}.mycdn.com/$hash.$ext", $hash, 0),
+            load_balance_url("https://{foo=10,bar=5,baz=5,quux=0}.mycdn.com/$hash.$ext", $hash, 1)
         );
     }
 


### PR DESCRIPTION
Replace flexihash with weighted rendezvous hashing

`Flexihash.php` hasn't been maintained for years and isn't php8.4 compatible; WRH is much simpler, and much better balanced, and nearly as fast
