### PR TITLE
Generate summary_large_image preview for images

### DIFF
--- a/ext/view/theme.php
+++ b/ext/view/theme.php
@@ -18,8 +18,13 @@ class ViewPostTheme extends Themelet
         $page->add_html_header(META(["name" => "keywords", "content" => $h_metatags]));
         $page->add_html_header(META(["property" => "og:title", "content" => $h_metatags]));
         $page->add_html_header(META(["property" => "og:type", "content" => "article"]));
-        $page->add_html_header(META(["property" => "og:image", "content" => make_http($image->get_thumb_link())]));
+        $page->add_html_header(META(["property" => "og:image", "content" => make_http($image->get_image_link())]));
         $page->add_html_header(META(["property" => "og:url", "content" => make_http(make_link("post/view/{$image->id}"))]));
+        $page->add_html_header(META(["property" => "og:image:width", "content" => $image->width]));
+        $page->add_html_header(META(["property" => "og:image:height", "content" => $image->height]));
+        $page->add_html_header(META(["property" => "twitter:title", "content" => $h_metatags]));
+        $page->add_html_header(META(["property" => "twitter:card", "content" => "summary_large_image"]));
+        $page->add_html_header(META(["property" => "twitter:image:src", "content" => make_http($image->get_image_link())]));
     }
 
     /**


### PR DESCRIPTION
This adds extra `twitter:` and `og:` meta tags for posts (most importantly, `<meta property="twitter:card" content="summary_large_image">`), and changes the thumbnail link to the image link, in order to display full-sized images in embeds. For example, this is what a post looks like on Discord:

![image](https://github.com/user-attachments/assets/daba5fcf-7c43-4825-9b07-2e0467eae2ea)

