### PR TITLE
Fix a typo in a cache key

### DIFF
--- a/ext/pm/main.php
+++ b/ext/pm/main.php
@@ -293,7 +293,7 @@ class PrivMsg extends Extension
         global $database;
 
         return cache_get_or_set(
-            "pm-count:{$user->id}",
+            "pm-count-{$user->id}",
             fn () => $database->get_one("
                 SELECT count(*)
                 FROM private_message


### PR DESCRIPTION
Message cache was not updating when reading a pm, found the issue to be a mistyped cache key