### PR TITLE
[docker] Build image for amd64 and arm64

### DIFF
--- a/.github/get-tags.py
+++ b/.github/get-tags.py
@@ -7,14 +7,17 @@ branch = check_output(["git", "branch", "--show-current"], text=True).strip()
 describe = check_output(["git", "describe", "--tags"], text=True).strip()
 tag = describe.split("-")[0][1:]
 a, b, c = tag.split(".")
+docker_username = sys.argv[1]
+docker_image = sys.argv[2] if len(sys.argv) > 2 else "shimmie2"
+image_name = f"{docker_username}/{docker_image}"
 
 if branch == "main":
-    print("tags=latest")
+    print(f"tags={image_name}:latest")
 elif branch.startswith("branch-2."):
     if "-" in describe:
-        print(f"tags={a},{a}.{b}")
+        print(f"tags={image_name}:{a},{image_name}:{a}.{b}")
     else:
-        print(f"tags={a},{a}.{b},{a}.{b}.{c}")
+        print(f"tags={image_name}:{a},{image_name}:{a}.{b},{image_name}:{a}.{b}.{c}")
 else:
     print("Only run from main or branch-2.X")
     sys.exit(1)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,14 +158,27 @@ jobs:
       run: |
         echo "BUILD_TIME=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
         echo "BUILD_HASH=$GITHUB_SHA" >> $GITHUB_ENV
-        ./.github/get-tags.py | tee -a $GITHUB_OUTPUT
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@main
+        ./.github/get-tags.py ${{ secrets.DOCKER_USERNAME }} ${{ secrets.DOCKER_IMAGE }} | tee -a $GITHUB_OUTPUT
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker registry
+      uses: docker/login-action@v3
       with:
-        name: shish2k/shimmie2
+        registry: ${{ secrets.DOCKER_REGISTRY }}
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        cache: ${{ github.event_name != 'schedule' }}
-        buildoptions: "--build-arg RUN_TESTS=false"
-        buildargs: BUILD_TIME,BUILD_HASH
+    - name: Build and push to registry
+      uses: docker/build-push-action@v6
+      with:
+        push: true
+        platforms: |
+          linux/amd64
+          linux/arm64
+        build-args: |
+          RUN_TESTS=false
+          BUILD_TIME=${{ env.BUILD_TIME }}
+          BUILD_HASH=${{ env.BUILD_HASH }}
+        no-cache: ${{ github.event_name == 'schedule' }}
         tags: "${{ steps.get-vars.outputs.tags }}"


### PR DESCRIPTION
This modifies the Github Workflow steps by using Docker's official images for building to multiple architectures. I tried to keep parity with the current format, but I also added some new (optional) parameters for envvars that allow the user to choose a different image name and registry.

In order to test this, I created [a non-fork repo](https://github.com/BadMannersXYZ/shimmie2-test) (by default, Github doesn't allow forks to share secrets to workflows). This has [built an image](https://hub.docker.com/layers/badmanners/shimmie2/latest/images/sha256-066fcf3a1cd455e53d926ecc8c2a07ea00ad24f4bf370b0401ec3a46432a6de4?context=repo) that I've tested on my Raspberry Pi, and it seems to work perfectly, although I haven't tested the corresponding amd64 image yet.