### PR TITLE
Use HTMLElement for all block bodies

### DIFF
--- a/core/basepage.php
+++ b/core/basepage.php
@@ -652,7 +652,7 @@ class BasePage
             $html->appendChild(H3(["data-toggle-sel" => "#{$block->id}", "class" => $hidable ? "shm-toggler" : ""], $block->header));
         }
         if (!empty($block->body)) {
-            $html->appendChild(DIV(['class' => "blockbody"], rawHTML($block->body)));
+            $html->appendChild(DIV(['class' => "blockbody"], $block->body));
         }
         return $html;
     }

--- a/core/block.php
+++ b/core/block.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{DIV, H3, SECTION, rawHTML};
+use function MicroHTML\{A, DIV, H3, SECTION, rawHTML};
 
 /**
  * Class Block
@@ -23,7 +23,7 @@ class Block
     /**
      * The content of the block.
      */
-    public ?string $body;
+    public HTMLElement $body;
 
     /**
      * Where the block should be placed. The default theme supports
@@ -49,15 +49,15 @@ class Block
      */
     public bool $is_content = true;
 
-    public function __construct(?string $header, string|HTMLElement|null $body, string $section = "main", int $position = 50, ?string $id = null)
+    public function __construct(?string $header, HTMLElement $body, string $section = "main", int $position = 50, ?string $id = null)
     {
         $this->header = $header;
-        $this->body = (string)$body;
+        $this->body = $body;
         $this->section = $section;
         $this->position = $position;
 
         if (is_null($id)) {
-            $id = (empty($header) ? md5($this->body ?? '') : $header) . $section;
+            $id = (empty($header) ? 'unknown' : $header) . $section;
         }
         $str_id = preg_replace_ex('/[^\w-]/', '', str_replace(' ', '_', $id));
         $this->id = $str_id;
@@ -77,6 +77,6 @@ class NavBlock extends Block
 {
     public function __construct()
     {
-        parent::__construct("Navigation", "<a href='".make_link()."'>Index</a>", "left", 0);
+        parent::__construct("Navigation", A(["href" => make_link()], "Index"), "left", 0);
     }
 }

--- a/ext/approval/main.php
+++ b/ext/approval/main.php
@@ -153,7 +153,7 @@ class Approval extends Extension
         global $user, $config;
         if ($event->key === HelpPages::SEARCH) {
             if ($user->can(Permissions::APPROVE_IMAGE) &&  $config->get_bool(ApprovalConfig::IMAGES)) {
-                $event->add_block(new Block("Approval", $this->theme->get_help_html()));
+                $event->add_section("Approval", $this->theme->get_help_html());
             }
         }
     }

--- a/ext/artists/main.php
+++ b/ext/artists/main.php
@@ -71,7 +71,7 @@ class Artists extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Artist", $this->theme->get_help_html()));
+            $event->add_section("Artist", $this->theme->get_help_html());
         }
     }
 

--- a/ext/artists/theme.php
+++ b/ext/artists/theme.php
@@ -6,8 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\emptyHTML;
-use function MicroHTML\{INPUT,P};
+use function MicroHTML\{INPUT,P,rawHTML,emptyHTML};
 
 /**
  * @phpstan-type ArtistArtist array{id:int,artist_id:int,user_name:string,name:string,notes:string,type:string,posts:int}
@@ -72,7 +71,7 @@ class ArtistsTheme extends Themelet
         }
 
         if ($html) {
-            $page->add_block(new Block("Manage Artists", $html, "left", 10));
+            $page->add_block(new Block("Manage Artists", rawHTML($html), "left", 10));
         }
     }
 
@@ -137,7 +136,7 @@ class ArtistsTheme extends Themelet
 		';
 
         global $page;
-        $page->add_block(new Block("Edit artist", $html, "main", 10));
+        $page->add_block(new Block("Edit artist", rawHTML($html), "main", 10));
     }
 
     public function new_artist_composer(): void
@@ -156,7 +155,7 @@ class ArtistsTheme extends Themelet
 		";
 
         $page->set_title("Artists");
-        $page->add_block(new Block("Artists", $html, "main", 10));
+        $page->add_block(new Block("Artists", rawHTML($html), "main", 10));
     }
 
     /**
@@ -235,7 +234,7 @@ class ArtistsTheme extends Themelet
         $html .= "</tbody></table>";
 
         $page->set_title("Artists");
-        $page->add_block(new Block("Artists", $html, "main", 10));
+        $page->add_block(new Block("Artists", rawHTML($html), "main", 10));
 
         $this->display_paginator($page, "artist/list", null, $pageNumber, $totalPages);
     }
@@ -254,7 +253,7 @@ class ArtistsTheme extends Themelet
 		';
 
         global $page;
-        $page->add_block(new Block("Artist Aliases", $html, "main", 20));
+        $page->add_block(new Block("Artist Aliases", rawHTML($html), "main", 20));
     }
 
     public function show_new_member_composer(int $artistID): void
@@ -271,7 +270,7 @@ class ArtistsTheme extends Themelet
 		';
 
         global $page;
-        $page->add_block(new Block("Artist members", $html, "main", 30));
+        $page->add_block(new Block("Artist members", rawHTML($html), "main", 30));
     }
 
     public function show_new_url_composer(int $artistID): void
@@ -288,7 +287,7 @@ class ArtistsTheme extends Themelet
 		';
 
         global $page;
-        $page->add_block(new Block("Artist URLs", $html, "main", 40));
+        $page->add_block(new Block("Artist URLs", rawHTML($html), "main", 40));
     }
 
     /**
@@ -307,7 +306,7 @@ class ArtistsTheme extends Themelet
 		';
 
         global $page;
-        $page->add_block(new Block("Edit Alias", $html, "main", 10));
+        $page->add_block(new Block("Edit Alias", rawHTML($html), "main", 10));
     }
 
     /**
@@ -326,7 +325,7 @@ class ArtistsTheme extends Themelet
 		';
 
         global $page;
-        $page->add_block(new Block("Edit URL", $html, "main", 10));
+        $page->add_block(new Block("Edit URL", rawHTML($html), "main", 10));
     }
 
     /**
@@ -345,7 +344,7 @@ class ArtistsTheme extends Themelet
 		';
 
         global $page;
-        $page->add_block(new Block("Edit Member", $html, "main", 10));
+        $page->add_block(new Block("Edit Member", rawHTML($html), "main", 10));
     }
 
     /**
@@ -407,7 +406,7 @@ class ArtistsTheme extends Themelet
 		</table>";
 
         $page->set_title("Artist");
-        $page->add_block(new Block("Artist", $html, "main", 10));
+        $page->add_block(new Block("Artist", rawHTML($html), "main", 10));
 
         //we show the images for the artist
         $artist_images = "";
@@ -419,7 +418,7 @@ class ArtistsTheme extends Themelet
                 '</span>';
         }
 
-        $page->add_block(new Block("Artist Posts", $artist_images, "main", 20));
+        $page->add_block(new Block("Artist Posts", rawHTML($artist_images), "main", 20));
     }
 
     /**

--- a/ext/auto_tagger/theme.php
+++ b/ext/auto_tagger/theme.php
@@ -6,6 +6,8 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
+use function MicroHTML\rawHTML;
+
 class AutoTaggerTheme extends Themelet
 {
     /**
@@ -33,9 +35,9 @@ class AutoTaggerTheme extends Themelet
 
         $page->set_title("Auto-Tag List");
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Auto-Tag", $html));
+        $page->add_block(new Block("Auto-Tag", rawHTML($html)));
         if ($can_manage) {
-            $page->add_block(new Block("Bulk Upload", $bulk_html, "main", 51));
+            $page->add_block(new Block("Bulk Upload", rawHTML($bulk_html), "main", 51));
         }
     }
 }

--- a/ext/biography/theme.php
+++ b/ext/biography/theme.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\TEXTAREA;
+use function MicroHTML\{TEXTAREA,rawHTML};
 
 class BiographyTheme extends Themelet
 {
     public function display_biography(Page $page, string $bio): void
     {
-        $page->add_block(new Block("About Me", format_text($bio), "main", 30, "about-me"));
+        $page->add_block(new Block("About Me", rawHTML(format_text($bio)), "main", 30, "about-me"));
     }
 
     public function display_composer(Page $page, string $bio): void

--- a/ext/blotter/theme.php
+++ b/ext/blotter/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 /**
  * @phpstan-type BlotterEntry array{id:int,entry_date:string,entry_text:string,important:bool}
  */
@@ -17,8 +19,8 @@ class BlotterTheme extends Themelet
         global $page;
         $html = $this->get_html_for_blotter_editor($entries);
         $page->set_title("Blotter Editor");
-        $page->add_block(new Block("Welcome to the Blotter Editor!", $html, "main", 10));
-        $page->add_block(new Block("Navigation", "<a href='".make_link()."'>Index</a>", "left", 0));
+        $page->add_block(new Block("Welcome to the Blotter Editor!", rawHTML($html), "main", 10));
+        $page->add_block(new NavBlock());
     }
 
     /**
@@ -29,7 +31,7 @@ class BlotterTheme extends Themelet
         global $page;
         $html = $this->get_html_for_blotter_page($entries);
         $page->set_title("Blotter");
-        $page->add_block(new Block("Blotter Entries", $html, "main", 10));
+        $page->add_block(new Block("Blotter Entries", rawHTML($html), "main", 10));
     }
 
     /**
@@ -40,7 +42,7 @@ class BlotterTheme extends Themelet
         global $page, $config;
         $html = $this->get_html_for_blotter($entries);
         $position = $config->get_string("blotter_position", "subheading");
-        $page->add_block(new Block(null, $html, $position, 20));
+        $page->add_block(new Block(null, rawHTML($html), $position, 20));
     }
 
     /**

--- a/ext/bulk_actions/theme.php
+++ b/ext/bulk_actions/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class BulkActionsTheme extends Themelet
 {
     /**
@@ -48,7 +50,7 @@ class BulkActionsTheme extends Themelet
         if (!$hasQuery) {
             $body .= "</div>";
         }
-        $block = new Block("Bulk Actions", $body, "left", 30);
+        $block = new Block("Bulk Actions", rawHTML($body), "left", 30);
         $page->add_block($block);
     }
 

--- a/ext/bulk_add/theme.php
+++ b/ext/bulk_add/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\{UL, LI};
+use function MicroHTML\{UL, LI, rawHTML};
 
 class BulkAddTheme extends Themelet
 {
@@ -49,6 +49,6 @@ class BulkAddTheme extends Themelet
 				</table>
 			</form>
 		";
-        $page->add_block(new Block("Bulk Add", $html));
+        $page->add_block(new Block("Bulk Add", rawHTML($html)));
     }
 }

--- a/ext/bulk_add_csv/theme.php
+++ b/ext/bulk_add_csv/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class BulkAddCSVTheme extends Themelet
 {
     /** @var Block[] */
@@ -41,11 +43,11 @@ class BulkAddCSVTheme extends Themelet
 				</table>
 			</form>
 		";
-        $page->add_block(new Block("Bulk Add CSV", $html));
+        $page->add_block(new Block("Bulk Add CSV", rawHTML($html)));
     }
 
     public function add_status(string $title, string $body): void
     {
-        $this->messages[] = new Block($title, $body);
+        $this->messages[] = new Block($title, rawHTML($body));
     }
 }

--- a/ext/comment/main.php
+++ b/ext/comment/main.php
@@ -398,7 +398,7 @@ class CommentList extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Comments", $this->theme->get_help_html()));
+            $event->add_section("Comments", $this->theme->get_help_html());
         }
     }
 

--- a/ext/comment/theme.php
+++ b/ext/comment/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CommentListTheme extends Themelet
 {
     private bool $show_anon_id = false;
@@ -39,7 +41,7 @@ class CommentListTheme extends Themelet
         $nav = $h_prev.' | '.$h_index.' | '.$h_next;
 
         $page->set_title("Comments");
-        $page->add_block(new Block("Navigation", $nav, "left", 0));
+        $page->add_block(new Block("Navigation", rawHTML($nav), "left", 0));
         $this->display_paginator($page, "comment/list", null, $page_number, $total_pages);
 
         // parts for each image
@@ -89,7 +91,7 @@ class CommentListTheme extends Themelet
 				</tr></table>
 			';
 
-            $page->add_block(new Block($image->id.': '.$image->get_tag_list(), $html, "main", $position++, "comment-list-list"));
+            $page->add_block(new Block($image->id.': '.$image->get_tag_list(), rawHTML($html), "main", $position++, "comment-list-list"));
         }
     }
 
@@ -107,7 +109,7 @@ class CommentListTheme extends Themelet
 				</table>
 			</form>
 		";
-        $page->add_block(new Block("Mass Comment Delete", $html));
+        $page->add_block(new Block("Mass Comment Delete", rawHTML($html)));
     }
 
     /**
@@ -124,7 +126,7 @@ class CommentListTheme extends Themelet
             $html .= $this->comment_to_html($comment, true);
         }
         $html .= "<a class='more' href='".make_link("comment/list")."'>Full List</a>";
-        $page->add_block(new Block("Comments", $html, "left", 70, "comment-list-recent"));
+        $page->add_block(new Block("Comments", rawHTML($html), "left", 70, "comment-list-recent"));
     }
 
     /**
@@ -143,7 +145,7 @@ class CommentListTheme extends Themelet
         if ($postbox) {
             $html .= $this->build_postbox($image->id);
         }
-        $page->add_block(new Block("Comments", $html, "main", 30, "comment-list-image"));
+        $page->add_block(new Block("Comments", rawHTML($html), "main", 30, "comment-list-image"));
     }
 
     /**
@@ -163,7 +165,7 @@ class CommentListTheme extends Themelet
         } else {
             $html .= "<p><a href='".make_link("comment/beta-search/{$user->name}/1")."'>More</a></p>";
         }
-        $page->add_block(new Block("Comments", $html, "left", 70, "comment-list-user"));
+        $page->add_block(new Block("Comments", rawHTML($html), "left", 70, "comment-list-user"));
     }
 
     /**
@@ -180,7 +182,7 @@ class CommentListTheme extends Themelet
         if (empty($html)) {
             $html = '<p>No comments by this user.</p>';
         }
-        $page->add_block(new Block("Comments", $html, "main", 70, "comment-list-user"));
+        $page->add_block(new Block("Comments", rawHTML($html), "main", 70, "comment-list-user"));
 
 
         $prev = $page_number - 1;
@@ -195,7 +197,7 @@ class CommentListTheme extends Themelet
         $h_next = ($page_number >= $total_pages) ? "Next" : "<a href='$next'>Next</a>";
 
         $page->set_title(html_escape($user->name)."'s comments");
-        $page->add_block(new Block("Navigation", $h_prev.' | '.$h_index.' | '.$h_next, "left", 0));
+        $page->add_block(new Block("Navigation", rawHTML($h_prev.' | '.$h_index.' | '.$h_next), "left", 0));
         $this->display_paginator($page, "comment/beta-search/{$user->name}", null, $page_number, $total_pages);
     }
 

--- a/ext/cron_uploader/theme.php
+++ b/ext/cron_uploader/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
 use function MicroHTML\LABEL;
 use function MicroHTML\TABLE;
 use function MicroHTML\TBODY;
@@ -112,9 +114,9 @@ class CronUploaderTheme extends Themelet
         ";
 
 
-        $block = new Block("Cron Uploader", $info_html, "main", 10);
-        $block_install = new Block("Setup Guide", $install_html, "main", 30);
-        $block_usage = new Block("Usage Guide", $usage_html, "main", 20);
+        $block = new Block("Cron Uploader", rawHTML($info_html), "main", 10);
+        $block_install = new Block("Setup Guide", rawHTML($install_html), "main", 30);
+        $block_usage = new Block("Usage Guide", rawHTML($usage_html), "main", 20);
         $page->add_block($block);
         $page->add_block($block_install);
         $page->add_block($block_usage);
@@ -125,12 +127,12 @@ class CronUploaderTheme extends Themelet
                 $log_html .= "<tr><th>{$entry["date_sent"]}</th><td>{$entry["message"]}</td></tr>";
             }
             $log_html .= "</table>";
-            $block = new Block("Log", $log_html, "main", 40);
+            $block = new Block("Log", rawHTML($log_html), "main", 40);
             $page->add_block($block);
         }
     }
 
-    public function get_user_options(): string
+    public function get_user_options(): HTMLElement
     {
         $form = SHM_SIMPLE_FORM(
             "user_admin/cron_uploader",
@@ -161,7 +163,7 @@ class CronUploaderTheme extends Themelet
             )
         );
         $html = emptyHTML($form);
-        return (string)$html;
+        return $html;
     }
 
     /**
@@ -196,6 +198,6 @@ class CronUploaderTheme extends Themelet
             ."<table class='form'><tr><td>"
             ."<input type='submit' value='Clear failed folder'></td></tr></table></form>";
         $html .= "</table>\n";
-        $page->add_block(new Block("Cron Upload", $html));
+        $page->add_block(new Block("Cron Upload", rawHTML($html)));
     }
 }

--- a/ext/et_server/main.php
+++ b/ext/et_server/main.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\{CODE};
+use function MicroHTML\{CODE,rawHTML};
 
 class ETServer extends Extension
 {
@@ -19,7 +19,7 @@ class ETServer extends Extension
                     ["data" => $data]
                 );
                 $page->set_title("Thanks!");
-                $page->add_block(new Block("Thanks!", "Your data has been recorded~"));
+                $page->add_block(new Block("Thanks!", rawHTML("Your data has been recorded~")));
             } elseif ($user->can(Permissions::VIEW_REGISTRATIONS)) {
                 $page->set_title("Registrations");
                 $n = 0;

--- a/ext/favorites/main.php
+++ b/ext/favorites/main.php
@@ -157,7 +157,7 @@ class Favorites extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Favorites", $this->theme->get_help_html()));
+            $event->add_section("Favorites", $this->theme->get_help_html());
         }
     }
 

--- a/ext/favorites/theme.php
+++ b/ext/favorites/theme.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\INPUT;
+use function MicroHTML\{INPUT,rawHTML};
 
 class FavoritesTheme extends Themelet
 {
@@ -27,7 +27,7 @@ class FavoritesTheme extends Themelet
             $html .= "<br><a href='".make_link("user/$username")."'>$username</a>";
         }
 
-        $page->add_block(new Block("Favorited By", $html, "left", 25));
+        $page->add_block(new Block("Favorited By", rawHTML($html), "left", 25));
     }
 
     public function get_help_html(): string

--- a/ext/filter/theme.php
+++ b/ext/filter/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\{META};
+use function MicroHTML\{META,rawHTML};
 
 class FilterTheme extends Themelet
 {
@@ -24,6 +24,6 @@ class FilterTheme extends Themelet
         <a id='re-enable-all-filters' style='display: none;' href='#'>Re-enable all</a>
         ";
         $page->add_html_header(META(['id' => 'filter-tags', 'tags' => $tags]));
-        $page->add_block(new Block("Filters", $html, "left", 10));
+        $page->add_block(new Block("Filters", rawHTML($html), "left", 10));
     }
 }

--- a/ext/forum/theme.php
+++ b/ext/forum/theme.php
@@ -20,7 +20,7 @@ class ForumTheme extends Themelet
     public function display_thread_list(Page $page, array $threads, bool $showAdminOptions, int $pageNumber, int $totalPages): void
     {
         if (count($threads) == 0) {
-            $html = "There are no threads to show.";
+            $html = rawHTML("There are no threads to show.");
         } else {
             $html = $this->make_thread_list($threads, $showAdminOptions);
         }

--- a/ext/four_oh_four/main.php
+++ b/ext/four_oh_four/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class FourOhFour extends Extension
 {
     public function onPageRequest(PageRequestEvent $event): void
@@ -15,7 +17,7 @@ class FourOhFour extends Extension
             $page->set_code(404);
             $page->set_title("404 - No Handler Found");
             $page->add_block(new NavBlock());
-            $page->add_block(new Block("Explanation", "No handler could be found for the page '{$event->path}'"));
+            $page->add_block(new Block("Explanation", rawHTML("No handler could be found for the page '{$event->path}'")));
         }
     }
 

--- a/ext/handle_cbz/theme.php
+++ b/ext/handle_cbz/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CBZFileHandlerTheme extends Themelet
 {
     public function display_image(Image $image): void
@@ -27,6 +29,6 @@ class CBZFileHandlerTheme extends Themelet
             <script src='{$data_href}/ext/handle_cbz/comic.js'></script>
             <script>window.comic = new Comic('comicMain', '$ilink');</script>
         ";
-        $page->add_block(new Block("Comic", $html, "main", 10, "comicBlock"));
+        $page->add_block(new Block("Comic", rawHTML($html), "main", 10, "comicBlock"));
     }
 }

--- a/ext/handle_ico/theme.php
+++ b/ext/handle_ico/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class IcoFileHandlerTheme extends Themelet
 {
     public function display_image(Image $image): void
@@ -14,6 +16,6 @@ class IcoFileHandlerTheme extends Themelet
 			<img id='main_image' class='shm-main-image' alt='main image' src='$ilink'
 			data-width='{$image->width}' data-height='{$image->height}'>
 		";
-        $page->add_block(new Block("Image", $html, "main", 10));
+        $page->add_block(new Block("Image", rawHTML($html), "main", 10));
     }
 }

--- a/ext/handle_mp3/theme.php
+++ b/ext/handle_mp3/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\{SCRIPT};
+use function MicroHTML\{SCRIPT, rawHTML};
 
 class MP3FileHandlerTheme extends Themelet
 {
@@ -26,6 +26,6 @@ class MP3FileHandlerTheme extends Themelet
             'src' => "$data_href/ext/handle_mp3/lib/jsmediatags.min.js",
             'type' => 'text/javascript'
         ]));
-        $page->add_block(new Block("Music", $html, "main", 10));
+        $page->add_block(new Block("Music", rawHTML($html), "main", 10));
     }
 }

--- a/ext/handle_pixel/theme.php
+++ b/ext/handle_pixel/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\IMG;
+use function MicroHTML\{IMG,rawHTML};
 
 class PixelFileHandlerTheme extends Themelet
 {
@@ -46,7 +46,7 @@ class PixelFileHandlerTheme extends Themelet
                     }
                 }
                 if ($head) {
-                    $page->add_block(new Block("EXIF Info", $head, "left"));
+                    $page->add_block(new Block("EXIF Info", rawHTML($head), "left"));
                 }
             }
         }

--- a/ext/handle_svg/theme.php
+++ b/ext/handle_svg/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class SVGFileHandlerTheme extends Themelet
 {
     public function display_image(Image $image): void
@@ -21,6 +23,6 @@ class SVGFileHandlerTheme extends Themelet
 			    data-height='{$image->height}'
 			    />
 		";
-        $page->add_block(new Block("Image", $html, "main", 10));
+        $page->add_block(new Block("Image", rawHTML($html), "main", 10));
     }
 }

--- a/ext/help_pages/main.php
+++ b/ext/help_pages/main.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
+use function MicroHTML\rawHTML;
+
 class HelpPageListBuildingEvent extends Event
 {
     /** @var array<string,string> */
@@ -31,6 +35,14 @@ class HelpPageBuildingEvent extends PartListBuildingEvent
     public function add_block(Block $block, int $position = 50): void
     {
         $this->add_part($block, $position);
+    }
+
+    public function add_section(string $title, string|HTMLElement $html): void
+    {
+        if (is_string($html)) {
+            $html = rawHTML($html);
+        }
+        $this->add_block(new Block($title, $html));
     }
 }
 
@@ -96,13 +108,12 @@ class HelpPages extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key == "licenses") {
-            $block = new Block(
+            $event->add_section(
                 "Software Licenses",
                 "The code in Shimmie is contributed by numerous authors under multiple licenses. For reference, these licenses are listed below. The base software is in general licensed under the GPLv2 license."
             );
-            $event->add_block($block);
 
-            $block = new Block(
+            $event->add_section(
                 ExtensionInfo::LICENSE_GPLV2,
                 "<pre>                    GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
@@ -444,9 +455,8 @@ consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.</pre>"
             );
-            $event->add_block($block);
 
-            $block = new Block(
+            $event->add_section(
                 ExtensionInfo::LICENSE_MIT,
                 "<pre>Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the \"Software\"), to deal
@@ -466,10 +476,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</pre>"
             );
-            $event->add_block($block);
 
-
-            $block = new Block(
+            $event->add_section(
                 ExtensionInfo::LICENSE_WTFPL,
                 "<pre>            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
@@ -487,7 +495,6 @@ SOFTWARE.</pre>"
 
 </pre>"
             );
-            $event->add_block($block);
         }
     }
 }

--- a/ext/help_pages/theme.php
+++ b/ext/help_pages/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\{A, BR, emptyHTML, rawHTML};
+
 class HelpPagesTheme extends Themelet
 {
     /**
@@ -15,14 +17,16 @@ class HelpPagesTheme extends Themelet
 
         $page->set_title("Help Pages");
 
-        $nav_block = new Block("Help", "", "left", 0);
+        $items = emptyHTML();
         foreach ($pages as $link => $desc) {
-            $link = make_link("help/{$link}");
-            $nav_block->body .= "<a href='{$link}'>".html_escape($desc)."</a><br/>";
+            $items->appendChild(
+                A(["href" => make_link("help/{$link}")], $desc),
+                BR(),
+            );
         }
 
-        $page->add_block($nav_block);
-        $page->add_block(new Block("Help Pages", "See list of pages to left"));
+        $page->add_block(new Block("Help", $items, "left", 0));
+        $page->add_block(new Block("Help Pages", rawHTML("See list of pages to left")));
     }
 
     public function display_help_page(string $title): void

--- a/ext/image_view_counter/theme.php
+++ b/ext/image_view_counter/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class ImageViewCounterTheme extends Themelet
 {
     /**
@@ -17,11 +19,9 @@ class ImageViewCounterTheme extends Themelet
             $pop_images .= $this->build_thumb_html($image) . "\n";
         }
 
-        $nav_html = "<a href=".make_link().">Index</a>";
-
         $page->set_title($config->get_string(SetupConfig::TITLE));
-        $page->add_block(new Block("Navigation", $nav_html, "left", 10));
-        $page->add_block(new Block(null, $pop_images, "main", 30));
+        $page->add_block(new NavBlock());
+        $page->add_block(new Block(null, rawHTML($pop_images), "main", 30));
     }
 
     public function get_help_html(): string

--- a/ext/index/main.php
+++ b/ext/index/main.php
@@ -9,6 +9,8 @@ use Symfony\Component\Console\Input\{InputInterface,InputArgument};
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function MicroHTML\rawHTML;
+
 require_once "config.php";
 require_once "events.php";
 

--- a/ext/index/theme.php
+++ b/ext/index/theme.php
@@ -6,8 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\emptyHTML;
-use function MicroHTML\{BR,H3,HR,P,META};
+use function MicroHTML\{BR,H3,HR,P,META,rawHTML,emptyHTML};
 
 class IndexTheme extends Themelet
 {
@@ -42,7 +41,7 @@ and of course start organising your images :-)
 ";
         $page->set_title("Welcome to Shimmie ".VERSION);
         $page->set_heading("Welcome to Shimmie");
-        $page->add_block(new Block("Nothing here yet!", $text, "main", 0));
+        $page->add_block(new Block("Nothing here yet!", rawHTML($text), "main", 0));
     }
 
     /**
@@ -70,14 +69,14 @@ and of course start organising your images :-)
     public function display_admin_block(array $parts): void
     {
         global $page;
-        $page->add_block(new Block("List Controls", join("<br>", $parts), "left", 50));
+        $page->add_block(new Block("List Controls", rawHTML(join("<br>", $parts)), "left", 50));
     }
 
 
     /**
      * @param string[] $search_terms
      */
-    protected function build_navigation(int $page_number, int $total_pages, array $search_terms): string
+    protected function build_navigation(int $page_number, int $total_pages, array $search_terms): HTMLElement
     {
         $prev = $page_number - 1;
         $next = $page_number + 1;
@@ -96,13 +95,13 @@ and of course start organising your images :-)
 			</form>
 		";
 
-        return $h_prev.' | '.$h_index.' | '.$h_next.'<br>'.$h_search;
+        return rawHTML($h_prev.' | '.$h_index.' | '.$h_next.'<br>'.$h_search);
     }
 
     /**
      * @param Image[] $images
      */
-    protected function build_table(array $images, ?string $query): string
+    protected function build_table(array $images, ?string $query): HTMLElement
     {
         $h_query = html_escape($query);
         $table = "<div class='shm-image-list' data-query='$h_query'>";
@@ -110,7 +109,7 @@ and of course start organising your images :-)
             $table .= $this->build_thumb_html($image);
         }
         $table .= "</div>";
-        return $table;
+        return rawHTML($table);
     }
 
     protected function display_shortwiki(Page $page): void
@@ -137,7 +136,7 @@ and of course start organising your images :-)
                     $st = $tagcategories->getTagHtml(html_escape($st), $tag_category_dict);
                 }
                 $short_wiki_description = '<h2>'.$st.'&nbsp;<a href="'.$wikiLink.'"><sup>ⓘ</sup></a></h2>'.$short_wiki_description;
-                $page->add_block(new Block(null, $short_wiki_description, "main", 0, "short-wiki-description"));
+                $page->add_block(new Block(null, rawHTML($short_wiki_description), "main", 0, "short-wiki-description"));
             }
         }
     }

--- a/ext/ipban/main.php
+++ b/ext/ipban/main.php
@@ -12,6 +12,8 @@ use MicroCRUD\TextColumn;
 use MicroCRUD\EnumColumn;
 use MicroCRUD\Table;
 
+use function MicroHTML\rawHTML;
+
 class IPBanTable extends Table
 {
     public function __construct(\FFSPHP\PDO $db)
@@ -157,14 +159,14 @@ class IPBan extends Extension
             $msg .= "<!-- $active_ban_id / {$row["mode"]} -->";
 
             if ($row["mode"] == "ghost") {
-                $b = new Block(null, $msg, "main", 0);
+                $b = new Block(null, rawHTML($msg), "main", 0);
                 $b->is_content = false;
                 $page->add_block($b);
                 $page->add_cookie("nocache", "Ghost Banned", time() + 60 * 60 * 2, "/");
                 $event->user->class = UserClass::$known_classes["ghost"];
             } elseif ($row["mode"] == "anon-ghost") {
                 if ($event->user->is_anonymous()) {
-                    $b = new Block(null, $msg, "main", 0);
+                    $b = new Block(null, rawHTML($msg), "main", 0);
                     $b->is_content = false;
                     $page->add_block($b);
                     $page->add_cookie("nocache", "Ghost Banned", time() + 60 * 60 * 2, "/");

--- a/ext/ipban/test.php
+++ b/ext/ipban/test.php
@@ -37,7 +37,7 @@ class IPBanTest extends ShimmiePHPUnitTestCase
         $page = $this->get_page('ip_ban/list');
         $this->assertStringContainsString(
             "42.42.42.42",
-            $page->find_block("Edit IP Bans")->body ?? ""
+            (string)$page->find_block("Edit IP Bans")->body
         );
 
         // Delete ban
@@ -48,7 +48,7 @@ class IPBanTest extends ShimmiePHPUnitTestCase
         $page = $this->get_page('ip_ban/list');
         $this->assertStringNotContainsString(
             "42.42.42.42",
-            $page->find_block("Edit IP Bans")->body ?? ""
+            (string)$page->find_block("Edit IP Bans")->body
         );
     }
 

--- a/ext/ipban/theme.php
+++ b/ext/ipban/theme.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\emptyHTML;
+use function MicroHTML\rawHTML;
 
 class IPBanTheme extends Themelet
 {
@@ -22,6 +22,6 @@ class IPBanTheme extends Themelet
 		";
         $page->set_title("IP Bans");
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Edit IP Bans", $html));
+        $page->add_block(new Block("Edit IP Bans", rawHTML($html)));
     }
 }

--- a/ext/link_image/theme.php
+++ b/ext/link_image/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class LinkImageTheme extends Themelet
 {
     /**
@@ -18,7 +20,7 @@ class LinkImageTheme extends Themelet
 
         $page->add_block(new Block(
             "Link to Post",
-            "
+            rawHTML("
 			<table><tr>
 
 			<td><fieldset>
@@ -55,7 +57,7 @@ class LinkImageTheme extends Themelet
 			</fieldset></td>
 
 			</tr></table>
-			",
+			"),
             "main",
             50
         ));

--- a/ext/media/main.php
+++ b/ext/media/main.php
@@ -275,7 +275,7 @@ class Media extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Media", $this->theme->get_help_html()));
+            $event->add_section("Media", $this->theme->get_help_html());
         }
     }
 

--- a/ext/mime/main.php
+++ b/ext/mime/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 require_once "mime_map.php";
 require_once "file_extension.php";
 require_once "mime_type.php";
@@ -62,7 +64,7 @@ class MimeSystem extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("File Types", $this->theme->get_help_html()));
+            $event->add_section("File Types", $this->theme->get_help_html());
         }
     }
 

--- a/ext/notes/main.php
+++ b/ext/notes/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class Notes extends Extension
 {
     /** @var NotesTheme */
@@ -198,7 +200,7 @@ class Notes extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Notes", $this->theme->get_help_html()));
+            $event->add_section("Notes", $this->theme->get_help_html());
         }
     }
 

--- a/ext/notes/theme.php
+++ b/ext/notes/theme.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{INPUT,SCRIPT};
+use function MicroHTML\{INPUT,SCRIPT,rawHTML};
 
 /**
  * @phpstan-type NoteHistory array{image_id:int,note_id:int,review_id:int,user_name:string,note:string,date:string}
@@ -89,7 +89,7 @@ class NotesTheme extends Themelet
         $this->display_paginator($page, "note/list", null, $pageNumber, $totalPages);
 
         $page->set_title("Notes");
-        $page->add_block(new Block("Notes", $pool_images, "main", 20));
+        $page->add_block(new Block("Notes", rawHTML($pool_images), "main", 20));
     }
 
     /**
@@ -109,7 +109,7 @@ class NotesTheme extends Themelet
         $this->display_paginator($page, "requests/list", null, $pageNumber, $totalPages);
 
         $page->set_title("Note Requests");
-        $page->add_block(new Block("Note Requests", $pool_images, "main", 20));
+        $page->add_block(new Block("Note Requests", rawHTML($pool_images), "main", 20));
     }
 
     /**
@@ -167,7 +167,7 @@ class NotesTheme extends Themelet
         $html = $this->get_history($histories);
 
         $page->set_title("Note Updates");
-        $page->add_block(new Block("Note Updates", $html, "main", 10));
+        $page->add_block(new Block("Note Updates", rawHTML($html), "main", 10));
 
         $this->display_paginator($page, "note/updated", null, $pageNumber, $totalPages);
     }
@@ -182,7 +182,7 @@ class NotesTheme extends Themelet
         $html = $this->get_history($histories);
 
         $page->set_title("Note History");
-        $page->add_block(new Block("Note History", $html, "main", 10));
+        $page->add_block(new Block("Note History", rawHTML($html), "main", 10));
 
         $this->display_paginator($page, "note/updated", null, $pageNumber, $totalPages);
     }

--- a/ext/numeric_score/main.php
+++ b/ext/numeric_score/main.php
@@ -8,6 +8,8 @@ use GQLA\Type;
 use GQLA\Field;
 use GQLA\Mutation;
 
+use function MicroHTML\rawHTML;
+
 #[Type(name: "NumericScoreVote")]
 class NumericScoreVote
 {
@@ -307,7 +309,7 @@ class NumericScore extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Numeric Score", $this->theme->get_help_html()));
+            $event->add_section("Numeric Score", $this->theme->get_help_html());
         }
     }
 

--- a/ext/numeric_score/theme.php
+++ b/ext/numeric_score/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class NumericScoreTheme extends Themelet
 {
     public function get_voter(Image $image): void
@@ -47,7 +49,7 @@ class NumericScoreTheme extends Themelet
 			</div>
 			";
         }
-        $page->add_block(new Block("Post Score", $html, "left", 20));
+        $page->add_block(new Block("Post Score", rawHTML($html), "left", 20));
     }
 
     public function get_nuller(User $duser): void
@@ -58,7 +60,7 @@ class NumericScoreTheme extends Themelet
 			<input type='submit' value='Delete all votes by this user'>
 			</form>
 		";
-        $page->add_block(new Block("Votes", $html, "main", 80));
+        $page->add_block(new Block("Votes", rawHTML($html), "main", 80));
     }
 
     /**
@@ -86,8 +88,8 @@ class NumericScoreTheme extends Themelet
         $nav_html = "<a href=".make_link().">Index</a>";
 
         $page->set_title($config->get_string(SetupConfig::TITLE));
-        $page->add_block(new Block("Navigation", $nav_html, "left", 10));
-        $page->add_block(new Block(null, $html, "main", 30));
+        $page->add_block(new Block("Navigation", rawHTML($nav_html), "left", 10));
+        $page->add_block(new Block(null, rawHTML($html), "main", 30));
     }
 
 

--- a/ext/pm/theme.php
+++ b/ext/pm/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class PrivMsgTheme extends Themelet
 {
     /**
@@ -57,7 +59,7 @@ class PrivMsgTheme extends Themelet
 				</tbody>
 			</table>
 		";
-        $page->add_block(new Block("Private Messages", $html, "main", 40, "private-messages"));
+        $page->add_block(new Block("Private Messages", rawHTML($html), "main", 40, "private-messages"));
     }
 
     public function display_composer(Page $page, User $from, User $to, string $subject = ""): void
@@ -77,7 +79,7 @@ $form
 </table>
 </form>
 EOD;
-        $page->add_block(new Block("Write a PM", $html, "main", 50));
+        $page->add_block(new Block("Write a PM", rawHTML($html), "main", 50));
     }
 
     public function display_message(Page $page, User $from, User $to, PM $pm): void
@@ -85,6 +87,6 @@ EOD;
         $page->set_title("Private Message");
         $page->set_heading(html_escape($pm->subject));
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Message from {$from->name}", format_text($pm->message), "main", 10));
+        $page->add_block(new Block("Message from {$from->name}", rawHTML(format_text($pm->message)), "main", 10));
     }
 }

--- a/ext/pools/main.php
+++ b/ext/pools/main.php
@@ -485,7 +485,7 @@ class Pools extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Pools", $this->theme->get_help_html()));
+            $event->add_section("Pools", $this->theme->get_help_html());
         }
     }
 

--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -126,7 +126,7 @@ class PoolsTheme extends Themelet
 
         $page->add_block(new NavBlock());
         $page->add_block(new Block("Pool Navigation", $poolnav, "left", 10));
-        $page->add_block(new Block("Search", $search, "left", 10));
+        $page->add_block(new Block("Search", rawHTML($search), "left", 10));
 
         if (!is_null($pool)) {
             if ($pool->public || $user->can(Permissions::POOLS_ADMIN)) {// IF THE POOL IS PUBLIC OR IS ADMIN SHOW EDIT PANEL
@@ -135,7 +135,7 @@ class PoolsTheme extends Themelet
                 }
             }
             $tfe = send_event(new TextFormattingEvent($pool->description));
-            $page->add_block(new Block(html_escape($pool->title), $tfe->formatted, "main", 10));
+            $page->add_block(new Block(html_escape($pool->title), rawHTML($tfe->formatted), "main", 10));
         }
     }
 

--- a/ext/post_tags/theme.php
+++ b/ext/post_tags/theme.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{joinHTML, A, TEXTAREA, TR, TH, TD, INPUT};
+use function MicroHTML\{joinHTML, A, TEXTAREA, TR, TH, TD, INPUT, rawHTML};
 
 class PostTagsTheme extends Themelet
 {
@@ -22,7 +22,7 @@ class PostTagsTheme extends Themelet
 			</table>
 		</form>
 		";
-        $page->add_block(new Block("Mass Tag Edit", $html));
+        $page->add_block(new Block("Mass Tag Edit", rawHTML($html)));
     }
 
     public function get_tag_editor_html(Image $image): HTMLElement

--- a/ext/private_image/main.php
+++ b/ext/private_image/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 abstract class PrivateImageConfig
 {
     public const VERSION = "ext_private_image_version";
@@ -152,7 +154,7 @@ class PrivateImage extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Private Posts", $this->theme->get_help_html()));
+            $event->add_section("Private Posts", $this->theme->get_help_html());
         }
     }
 

--- a/ext/qr_code/theme.php
+++ b/ext/qr_code/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class QRImageTheme extends Themelet
 {
     public function links_block(string $link): void
@@ -12,7 +14,7 @@ class QRImageTheme extends Themelet
 
         $page->add_block(new Block(
             "QR Code",
-            "<img alt='QR Code' src='//chart.apis.google.com/chart?chs=150x150&amp;cht=qr&amp;chl={$link}' />",
+            rawHTML("<img alt='QR Code' src='//chart.apis.google.com/chart?chs=150x150&amp;cht=qr&amp;chl={$link}' />"),
             "left",
             50
         ));

--- a/ext/random_image/theme.php
+++ b/ext/random_image/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
 use function MicroHTML\DIV;
 use function MicroHTML\A;
 use function MicroHTML\IMG;
@@ -15,11 +17,11 @@ class RandomImageTheme extends Themelet
         $page->add_block(new Block("Random Post", $this->build_random_html($image), "left", 8));
     }
 
-    public function build_random_html(Image $image, ?string $query = null): string
+    public function build_random_html(Image $image, ?string $query = null): HTMLElement
     {
         $tsize = get_thumbnail_size($image->width, $image->height);
 
-        return (string)DIV(
+        return DIV(
             ["style" => "text-align: center;"],
             A(
                 ["href" => make_link("post/view/{$image->id}", $query)],

--- a/ext/random_list/theme.php
+++ b/ext/random_list/theme.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
+use function MicroHTML\rawHTML;
+
 class RandomListTheme extends Themelet
 {
     /** @var string[] */
@@ -37,7 +41,7 @@ class RandomListTheme extends Themelet
             $html .= "<br/><br/>No posts were found to match the search criteria";
         }
 
-        $page->add_block(new Block("Random Posts", $html));
+        $page->add_block(new Block("Random Posts", rawHTML($html)));
 
         $nav = $this->build_navigation($this->search_terms);
         $page->add_block(new Block("Navigation", $nav, "left", 0));
@@ -46,7 +50,7 @@ class RandomListTheme extends Themelet
     /**
      * @param string[] $search_terms
      */
-    protected function build_navigation(array $search_terms): string
+    protected function build_navigation(array $search_terms): HTMLElement
     {
         $h_search_string = html_escape(Tag::implode($search_terms));
         $h_search_link = make_link("random");
@@ -58,6 +62,6 @@ class RandomListTheme extends Themelet
 			</form>
 		";
 
-        return $h_search;
+        return rawHTML($h_search);
     }
 }

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -255,7 +255,7 @@ class Ratings extends Extension
     {
         if ($event->key === HelpPages::SEARCH) {
             $ratings = self::get_sorted_ratings();
-            $event->add_block(new Block("Ratings", $this->theme->get_help_html($ratings)));
+            $event->add_section("Ratings", $this->theme->get_help_html($ratings));
         }
     }
 

--- a/ext/regen_thumb/theme.php
+++ b/ext/regen_thumb/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\META;
+use function MicroHTML\{META,rawHTML};
 
 class RegenThumbTheme extends Themelet
 {
@@ -61,6 +61,6 @@ class RegenThumbTheme extends Themelet
 				</table>
             </form></p>
             		";
-        $page->add_block(new Block("Regen Thumbnails", $html));
+        $page->add_block(new Block("Regen Thumbnails", rawHTML($html)));
     }
 }

--- a/ext/relationships/main.php
+++ b/ext/relationships/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class ImageRelationshipSetEvent extends Event
 {
     public int $child_id;
@@ -96,7 +98,7 @@ class Relationships extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Relationships", $this->theme->get_help_html()));
+            $event->add_section("Relationships", $this->theme->get_help_html());
         }
     }
 

--- a/ext/relationships/theme.php
+++ b/ext/relationships/theme.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{TR, TH, TD, emptyHTML, DIV, INPUT};
+use function MicroHTML\{TR, TH, TD, emptyHTML, DIV, INPUT, rawHTML};
 
 class RelationshipsTheme extends Themelet
 {
@@ -37,7 +37,7 @@ class RelationshipsTheme extends Themelet
             $parent_summary_html .= "<a href='#' id='relationships-parent-toggle' class='shm-relationships-parent-toggle'>« hide</a>";
             $parent_thumb_html .= "</div>";
             $html = $parent_summary_html . $parent_thumb_html;
-            $page->add_block(new Block(null, $html, "main", 5, "PostRelationshipsParent"));
+            $page->add_block(new Block(null, rawHTML($html), "main", 5, "PostRelationshipsParent"));
         }
 
         if (bool_escape($image['has_children'])) {
@@ -54,7 +54,7 @@ class RelationshipsTheme extends Themelet
                 $child_summary_html .= "</span><a href='#' id='relationships-child-toggle' class='shm-relationships-child-toggle'>« hide</a>";
                 $child_thumb_html .= "</div></div>";
                 $html = $child_summary_html . $child_thumb_html;
-                $page->add_block(new Block(null, $html, "main", 5, "PostRelationshipsChildren"));
+                $page->add_block(new Block(null, rawHTML($html), "main", 5, "PostRelationshipsChildren"));
             }
         }
     }

--- a/ext/report_image/theme.php
+++ b/ext/report_image/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\INPUT;
+use function MicroHTML\{INPUT,rawHTML};
 
 /**
  * @phpstan-type Report array{id: int, image: Image, reason: string, reporter_name: string}
@@ -56,7 +56,7 @@ class ReportImageTheme extends Themelet
 
         $page->set_title("Reported Posts");
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Reported Posts", $html));
+        $page->add_block(new Block("Reported Posts", rawHTML($html)));
     }
 
     /**
@@ -92,7 +92,7 @@ class ReportImageTheme extends Themelet
 				<input type='submit' value='Report'>
 			</form>
 		";
-        $page->add_block(new Block("Report Post", $html, "left"));
+        $page->add_block(new Block("Report Post", rawHTML($html), "left"));
     }
 
     public function get_nuller(User $duser): void
@@ -103,6 +103,6 @@ class ReportImageTheme extends Themelet
             INPUT(["type" => 'hidden', "name" => 'user_id', "value" => $duser->id]),
             SHM_SUBMIT('Delete all reports by this user')
         );
-        $page->add_block(new Block("Reports", $html, "main", 80));
+        $page->add_block(new Block("Reports", rawHTML($html), "main", 80));
     }
 }

--- a/ext/reverse_search_links/theme.php
+++ b/ext/reverse_search_links/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class ReverseSearchLinksTheme extends Themelet
 {
     public function reverse_search_block(Page $page, Image $image): void
@@ -29,6 +31,6 @@ class ReverseSearchLinksTheme extends Themelet
             }
         }
 
-        $page->add_block(new Block("Reverse Image Search", $html, "main", 20));
+        $page->add_block(new Block("Reverse Image Search", rawHTML($html), "main", 20));
     }
 }

--- a/ext/setup/main.php
+++ b/ext/setup/main.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\{InputInterface,InputArgument};
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function MicroHTML\rawHTML;
+
 require_once "config.php";
 
 /*
@@ -115,44 +117,44 @@ class SetupPanel
 
 class SetupBlock extends Block
 {
-    public ?string $header;
-    public ?string $body;
+    public ?string $str_body;
     public Config $config;
 
     public function __construct(string $title, Config $config)
     {
-        parent::__construct($title, "", "main", 50);
+        parent::__construct($title, rawHTML(""), "main", 50);
         $this->config = $config;
+        $this->str_body = "";
     }
 
     public function add_label(string $text): void
     {
-        $this->body .= $text;
+        $this->str_body .= $text;
     }
 
     public function start_table(): void
     {
-        $this->body .= "<table class='form'>";
+        $this->str_body .= "<table class='form'>";
     }
     public function end_table(): void
     {
-        $this->body .= "</table>";
+        $this->str_body .= "</table>";
     }
     public function start_table_row(): void
     {
-        $this->body .= "<tr>";
+        $this->str_body .= "<tr>";
     }
     public function end_table_row(): void
     {
-        $this->body .= "</tr>";
+        $this->str_body .= "</tr>";
     }
     public function start_table_head(): void
     {
-        $this->body .= "<thead>";
+        $this->str_body .= "<thead>";
     }
     public function end_table_head(): void
     {
-        $this->body .= "</thead>";
+        $this->str_body .= "</thead>";
     }
     public function add_table_header(string $content, int $colspan = 2): void
     {
@@ -165,30 +167,30 @@ class SetupBlock extends Block
 
     public function start_table_cell(int $colspan = 1): void
     {
-        $this->body .= "<td colspan='$colspan'>";
+        $this->str_body .= "<td colspan='$colspan'>";
     }
     public function end_table_cell(): void
     {
-        $this->body .= "</td>";
+        $this->str_body .= "</td>";
     }
     public function add_table_cell(string $content, int $colspan = 1): void
     {
         $this->start_table_cell($colspan);
-        $this->body .= $content;
+        $this->str_body .= $content;
         $this->end_table_cell();
     }
     public function start_table_header_cell(int $colspan = 1, string $align = 'right'): void
     {
-        $this->body .= "<th colspan='$colspan' style='text-align: $align'>";
+        $this->str_body .= "<th colspan='$colspan' style='text-align: $align'>";
     }
     public function end_table_header_cell(): void
     {
-        $this->body .= "</th>";
+        $this->str_body .= "</th>";
     }
     public function add_table_header_cell(string $content, int $colspan = 1): void
     {
         $this->start_table_header_cell($colspan);
-        $this->body .= $content;
+        $this->str_body .= $content;
         $this->end_table_header_cell();
     }
 
@@ -206,7 +208,7 @@ class SetupBlock extends Block
             $this->start_table_header_cell($label_row ? 2 : 1, $label_row ? 'center' : 'right');
         }
         if (!is_null($label)) {
-            $this->body .= "<label for='{$name}'>{$label}</label>";
+            $this->str_body .= "<label for='{$name}'>{$label}</label>";
         }
 
         if ($table_row) {
@@ -221,7 +223,7 @@ class SetupBlock extends Block
         if ($table_row) {
             $this->start_table_cell($label_row ? 2 : 1);
         }
-        $this->body .= $html;
+        $this->str_body .= $html;
         if ($table_row) {
             $this->end_table_cell();
         }
@@ -273,7 +275,7 @@ class SetupBlock extends Block
     //	public function add_hidden_option($name) {
     //		global $config;
     //		$val = $config->get_string($name);
-    //		$this->body .= "<input type='hidden' id='$name' name='$name' value='$val'>";
+    //		$this->str_body .= "<input type='hidden' id='$name' name='$name' value='$val'>";
     //	}
 
     public function add_int_option(string $name, ?string $label = null, bool $table_row = false): void

--- a/ext/setup/theme.php
+++ b/ext/setup/theme.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
+use function MicroHTML\rawHTML;
+
 class SetupTheme extends Themelet
 {
     /*
@@ -39,7 +43,7 @@ class SetupTheme extends Themelet
 
         $page->set_title("Shimmie Setup");
         $page->add_block(new Block("Navigation", $this->build_navigation(), "left", 0));
-        $page->add_block(new Block("Setup", $table));
+        $page->add_block(new Block("Setup", rawHTML($table)));
     }
 
     /**
@@ -79,28 +83,25 @@ class SetupTheme extends Themelet
 
         $page->set_title("Shimmie Setup");
         $page->add_block(new Block("Navigation", $this->build_navigation(), "left", 0));
-        $page->add_block(new Block("Setup", $table));
+        $page->add_block(new Block("Setup", rawHTML($table)));
     }
 
-    protected function build_navigation(): string
+    protected function build_navigation(): HTMLElement
     {
-        return "
+        return rawHTML("
 			<a href='".make_link()."'>Index</a>
 			<br><a href='https://github.com/shish/shimmie2/wiki/Settings'>Help</a>
 			<br><a href='".make_link("setup/advanced")."'>Advanced</a>
-		";
+		");
     }
 
     protected function sb_to_html(SetupBlock $block): string
     {
-        $h = $block->header;
-        $b = $block->body;
-        $html = "
+        return "
 			<section class='setupblock'>
-				<b>$h</b>
-				<br>$b
+				<b>{$block->header}</b>
+				<br>{$block->str_body}
 			</section>
 		";
-        return $html;
     }
 }

--- a/ext/source_history/theme.php
+++ b/ext/source_history/theme.php
@@ -28,7 +28,7 @@ class SourceHistoryTheme extends Themelet
         $page->set_title('Post '.$image_id.' Source History');
         $page->set_heading('Source History: '.$image_id);
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Source History", $history_html, "main", 10));
+        $page->add_block(new Block("Source History", rawHTML($history_html), "main", 10));
     }
 
     /**
@@ -39,7 +39,7 @@ class SourceHistoryTheme extends Themelet
         $history_html = $this->history_list($history, false);
 
         $page->set_title("Global Source History");
-        $page->add_block(new Block("Source History", $history_html, "main", 10));
+        $page->add_block(new Block("Source History", rawHTML($history_html), "main", 10));
 
         $h_prev = ($page_number <= 1) ? "Prev" :
             '<a href="'.make_link('source_history/all/'.($page_number - 1)).'">Prev</a>';
@@ -47,7 +47,7 @@ class SourceHistoryTheme extends Themelet
         $h_next = '<a href="'.make_link('source_history/all/'.($page_number + 1)).'">Next</a>';
 
         $nav = $h_prev.' | '.$h_index.' | '.$h_next;
-        $page->add_block(new Block("Navigation", $nav, "left"));
+        $page->add_block(new Block("Navigation", rawHTML($nav), "left"));
     }
 
     /**
@@ -74,7 +74,7 @@ class SourceHistoryTheme extends Themelet
 				</table>
 			</form>
 		";
-        $page->add_block(new Block("Mass Source Revert", $html));
+        $page->add_block(new Block("Mass Source Revert", rawHTML($html)));
     }
 
     /*
@@ -84,7 +84,7 @@ class SourceHistoryTheme extends Themelet
     {
         global $page;
         $html = implode("\n", $this->messages);
-        $page->add_block(new Block("Bulk Revert Results", $html));
+        $page->add_block(new Block("Bulk Revert Results", rawHTML($html)));
     }
 
     public function add_status(string $title, string $body): void

--- a/ext/tag_categories/main.php
+++ b/ext/tag_categories/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 require_once "config.php";
 
 class TagCategories extends Extension
@@ -111,7 +113,7 @@ class TagCategories extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Tag Categories", $this->theme->get_help_html()));
+            $event->add_section("Tag Categories", $this->theme->get_help_html());
         }
     }
 

--- a/ext/tag_categories/theme.php
+++ b/ext/tag_categories/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class TagCategoriesTheme extends Themelet
 {
     /**
@@ -105,7 +107,7 @@ class TagCategoriesTheme extends Themelet
         // add html to stuffs
         $page->set_title("Tag Categories");
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Editing", $html, "main", 10));
+        $page->add_block(new Block("Editing", rawHTML($html), "main", 10));
     }
 
     public function get_help_html(): string

--- a/ext/tag_history/theme.php
+++ b/ext/tag_history/theme.php
@@ -29,7 +29,7 @@ class TagHistoryTheme extends Themelet
         $page->set_title('Post '.$image_id.' Tag History');
         $page->set_heading('Tag History: '.$image_id);
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Tag History", $history_html, "main", 10));
+        $page->add_block(new Block("Tag History", rawHTML($history_html), "main", 10));
     }
 
     /**
@@ -40,7 +40,7 @@ class TagHistoryTheme extends Themelet
         $history_html = $this->history_list($history, false);
 
         $page->set_title("Global Tag History");
-        $page->add_block(new Block("Tag History", $history_html, "main", 10));
+        $page->add_block(new Block("Tag History", rawHTML($history_html), "main", 10));
 
         $h_prev = ($page_number <= 1) ? "Prev" :
             '<a href="'.make_link('tag_history/all/'.($page_number - 1)).'">Prev</a>';
@@ -48,7 +48,7 @@ class TagHistoryTheme extends Themelet
         $h_next = '<a href="'.make_link('tag_history/all/'.($page_number + 1)).'">Next</a>';
 
         $nav = $h_prev.' | '.$h_index.' | '.$h_next;
-        $page->add_block(new Block("Navigation", $nav, "left", 0));
+        $page->add_block(new Block("Navigation", rawHTML($nav), "left", 0));
     }
 
     /**
@@ -75,7 +75,7 @@ class TagHistoryTheme extends Themelet
 				</table>
 			</form>
 		";
-        $page->add_block(new Block("Mass Tag Revert", $html));
+        $page->add_block(new Block("Mass Tag Revert", rawHTML($html)));
     }
 
     /*
@@ -85,7 +85,7 @@ class TagHistoryTheme extends Themelet
     {
         global $page;
         $html = implode("\n", $this->messages);
-        $page->add_block(new Block("Bulk Revert Results", $html));
+        $page->add_block(new Block("Bulk Revert Results", rawHTML($html)));
     }
 
     public function add_status(string $title, string $body): void

--- a/ext/tag_list/main.php
+++ b/ext/tag_list/main.php
@@ -32,7 +32,6 @@ class TagList extends Extension
         global $config, $page;
 
         if ($event->page_matches("tags/{sub}", method: "GET")) {
-            $this->theme->set_navigation($this->build_navigation());
             $sub = $event->get_arg('sub');
 
             if ($event->get_GET('starts_with')) {
@@ -217,16 +216,6 @@ class TagList extends Extension
         $html .= "</span>\n<p><hr>";
 
         return $html;
-    }
-
-    private function build_navigation(): string
-    {
-        $h_index = "<a href='".make_link()."'>Index</a>";
-        $h_map = "<a href='".make_link("tags/map")."'>Map</a>";
-        $h_alphabetic = "<a href='".make_link("tags/alphabetic")."'>Alphabetic</a>";
-        $h_popularity = "<a href='".make_link("tags/popularity")."'>Popularity</a>";
-        $h_all = "<a href='".modify_current_url(["mincount" => 1])."'>Show All</a>";
-        return "$h_index<br>&nbsp;<br>$h_map<br>$h_alphabetic<br>$h_popularity<br>&nbsp;<br>$h_all";
     }
 
     private function build_tag_map(string $starts_with, int $tags_min): string

--- a/ext/tag_list/theme.php
+++ b/ext/tag_list/theme.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\{A, BR, rawHTML, emptyHTML};
+
 class TagListTheme extends Themelet
 {
     public string $heading = "";
     public string $list = "";
-    public ?string $navigation;
     private mixed $tagcategories = null;
 
     public function set_heading(string $text): void
@@ -21,17 +22,29 @@ class TagListTheme extends Themelet
         $this->list = $list;
     }
 
-    public function set_navigation(string $nav): void
-    {
-        $this->navigation = $nav;
-    }
-
     public function display_page(Page $page): void
     {
         $page->set_title("Tag List");
         $page->set_heading($this->heading);
-        $page->add_block(new Block("Tags", $this->list));
-        $page->add_block(new Block("Navigation", $this->navigation, "left", 0));
+        $page->add_block(new Block("Tags", rawHTML($this->list)));
+
+        $nav = emptyHTML(
+            A(["href" => make_link()], "Index"),
+            BR(),
+            rawHTML("&nbsp;"),
+            BR(),
+            A(["href" => make_link("tags/map")], "Map"),
+            BR(),
+            A(["href" => make_link("tags/alphabetic")], "Alphabetic"),
+            BR(),
+            A(["href" => make_link("tags/popularity")], "Popularity"),
+            BR(),
+            rawHTML("&nbsp;"),
+            BR(),
+            A(["href" => modify_current_url(["mincount" => 1])], "Show All"),
+        );
+
+        $page->add_block(new Block("Navigation", $nav, "left", 0));
     }
 
     // =======================================================================
@@ -113,11 +126,11 @@ class TagListTheme extends Themelet
             } else {
                 $category_display_name = html_escape($tag_category_dict[$category]['display_multiple']);
             }
-            $page->add_block(new Block($category_display_name, $tag_categories_html[$category], "left", 9));
+            $page->add_block(new Block($category_display_name, rawHTML($tag_categories_html[$category]), "left", 9));
         }
 
         if ($main_html !== null) {
-            $page->add_block(new Block("Tags", $main_html, "left", 10));
+            $page->add_block(new Block("Tags", rawHTML($main_html), "left", 10));
         }
     }
 
@@ -162,7 +175,7 @@ class TagListTheme extends Themelet
             $config->get_string(TagListConfig::RELATED_SORT)
         );
 
-        $page->add_block(new Block($block_name, $main_html, "left", 10));
+        $page->add_block(new Block($block_name, rawHTML($main_html), "left", 10));
     }
 
     /**
@@ -178,7 +191,7 @@ class TagListTheme extends Themelet
         );
         $main_html .= "&nbsp;<br><a class='more' href='".make_link("tags")."'>Full List</a>\n";
 
-        $page->add_block(new Block("Popular Tags", $main_html, "left", 60));
+        $page->add_block(new Block("Popular Tags", rawHTML($main_html), "left", 60));
     }
 
     /**
@@ -195,7 +208,7 @@ class TagListTheme extends Themelet
         );
         $main_html .= "&nbsp;<br><a class='more' href='".make_link("tags")."'>Full List</a>\n";
 
-        $page->add_block(new Block("Refine Search", $main_html, "left", 60));
+        $page->add_block(new Block("Refine Search", rawHTML($main_html), "left", 60));
     }
 
     /**

--- a/ext/tag_tools/theme.php
+++ b/ext/tag_tools/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\INPUT;
+use function MicroHTML\{INPUT,rawHTML};
 
 class TagToolsTheme extends Themelet
 {
@@ -35,13 +35,13 @@ class TagToolsTheme extends Themelet
         $html = "";
         $html .= $this->button("All tags to lowercase", "lowercase_all_tags", true);
         $html .= $this->button("Recount tag use", "recount_tag_use", false);
-        $page->add_block(new Block("Misc Admin Tools", $html));
+        $page->add_block(new Block("Misc Admin Tools", rawHTML($html)));
 
         $html = (string)SHM_SIMPLE_FORM(
             "admin/set_tag_case",
             INPUT(["type" => 'text', "name" => 'tag', "placeholder" => 'Enter tag with correct case', "autocomplete" => 'off']),
             SHM_SUBMIT('Set Tag Case'),
         );
-        $page->add_block(new Block("Set Tag Case", $html));
+        $page->add_block(new Block("Set Tag Case", rawHTML($html)));
     }
 }

--- a/ext/terms/theme.php
+++ b/ext/terms/theme.php
@@ -20,6 +20,6 @@ class TermsTheme extends Themelet
 				</form>
 			</dialog>
 		</div>";
-        $page->add_block(new Block(null, $html, "main", 1));
+        $page->add_block(new Block(null, rawHTML($html), "main", 1));
     }
 }

--- a/ext/tips/theme.php
+++ b/ext/tips/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 /**
  * @phpstan-type Tip array{id: int, image: string, text: string, enable: bool}
  */
@@ -47,7 +49,7 @@ class TipsTheme extends Themelet
 
         $page->set_title("Tips List");
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Add Tip", $html, "main", 10));
+        $page->add_block(new Block("Add Tip", rawHTML($html), "main", 10));
     }
 
     /**
@@ -62,7 +64,7 @@ class TipsTheme extends Themelet
             $img = "<img src=".$url.url_escape($tip['image'])." /> ";
         }
         $html = "<div id='tips'>".$img.html_escape($tip['text'])."</div>";
-        $page->add_block(new Block(null, $html, "subheading", 10));
+        $page->add_block(new Block(null, rawHTML($html), "subheading", 10));
     }
 
     /**
@@ -109,6 +111,6 @@ class TipsTheme extends Themelet
         }
         $html .= "</tbody></table>";
 
-        $page->add_block(new Block("All Tips", $html, "main", 20));
+        $page->add_block(new Block("All Tips", rawHTML($html), "main", 20));
     }
 }

--- a/ext/transcode/main.php
+++ b/ext/transcode/main.php
@@ -210,13 +210,9 @@ class TranscodeImage extends Extension
         if ($event->page_matches("transcode/{image_id}", method: "POST", permission: Permissions::EDIT_FILES)) {
             $image_id = $event->get_iarg('image_id');
             $image_obj = Image::by_id_ex($image_id);
-            try {
-                $this->transcode_and_replace_image($image_obj, $event->req_POST('transcode_mime'));
-                $page->set_mode(PageMode::REDIRECT);
-                $page->set_redirect(make_link("post/view/".$image_id));
-            } catch (ImageTranscodeException $e) {
-                $this->theme->display_transcode_error($page, "Error Transcoding", $e->getMessage());
-            }
+            $this->transcode_and_replace_image($image_obj, $event->req_POST('transcode_mime'));
+            $page->set_mode(PageMode::REDIRECT);
+            $page->set_redirect(make_link("post/view/".$image_id));
         }
     }
 

--- a/ext/transcode/theme.php
+++ b/ext/transcode/theme.php
@@ -39,11 +39,4 @@ class TranscodeImageTheme extends Themelet
         }
         return $html."</select>";
     }
-
-    public function display_transcode_error(Page $page, string $title, string $message): void
-    {
-        $page->set_title("Transcode Image");
-        $page->add_block(new NavBlock());
-        $page->add_block(new Block($title, $message));
-    }
 }

--- a/ext/transcode_video/main.php
+++ b/ext/transcode_video/main.php
@@ -104,13 +104,9 @@ class TranscodeVideo extends Extension
         if ($event->page_matches("transcode_video/{image_id}", method: "POST", permission: Permissions::EDIT_FILES)) {
             $image_id = $event->get_iarg('image_id');
             $image_obj = Image::by_id_ex($image_id);
-            try {
-                $this->transcode_and_replace_video($image_obj, $event->req_POST('transcode_format'));
-                $page->set_mode(PageMode::REDIRECT);
-                $page->set_redirect(make_link("post/view/".$image_id));
-            } catch (VideoTranscodeException $e) {
-                $this->theme->display_transcode_error($page, "Error Transcoding", $e->getMessage());
-            }
+            $this->transcode_and_replace_video($image_obj, $event->req_POST('transcode_format'));
+            $page->set_mode(PageMode::REDIRECT);
+            $page->set_redirect(make_link("post/view/".$image_id));
         }
     }
 

--- a/ext/transcode_video/theme.php
+++ b/ext/transcode_video/theme.php
@@ -39,11 +39,4 @@ class TranscodeVideoTheme extends Themelet
         }
         return $html."</select>";
     }
-
-    public function display_transcode_error(Page $page, string $title, string $message): void
-    {
-        $page->set_title("Transcode Video");
-        $page->add_block(new NavBlock());
-        $page->add_block(new Block($title, $message));
-    }
 }

--- a/ext/trash/main.php
+++ b/ext/trash/main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 abstract class TrashConfig
 {
     public const VERSION = "ext_trash_version";
@@ -119,7 +121,7 @@ class Trash extends Extension
         global $user;
         if ($event->key === HelpPages::SEARCH) {
             if ($user->can(Permissions::VIEW_TRASH)) {
-                $event->add_block(new Block("Trash", $this->theme->get_help_html()));
+                $event->add_section("Trash", $this->theme->get_help_html());
             }
         }
     }

--- a/ext/upload/theme.php
+++ b/ext/upload/theme.php
@@ -26,14 +26,14 @@ class UploadTheme extends Themelet
 {
     public function display_block(Page $page): void
     {
-        $b = new Block("Upload", (string)$this->build_upload_block(), "left", 20);
+        $b = new Block("Upload", $this->build_upload_block(), "left", 20);
         $b->is_content = false;
         $page->add_block($b);
     }
 
     public function display_full(Page $page): void
     {
-        $page->add_block(new Block("Upload", "Disk nearly full, uploads disabled", "left", 20));
+        $page->add_block(new Block("Upload", rawHTML("Disk nearly full, uploads disabled"), "left", 20));
     }
 
     public function display_page(Page $page): void
@@ -226,12 +226,12 @@ class UploadTheme extends Themelet
             $page->set_title("Upload Status");
             $page->add_block(new NavBlock());
             foreach ($errors as $error) {
-                $page->add_block(new Block($error->name, format_text($error->error)));
+                $page->add_block(new Block($error->name, rawHTML(format_text($error->error))));
             }
         } elseif (count($successes) == 0) {
             $page->set_title("No images uploaded");
             $page->add_block(new NavBlock());
-            $page->add_block(new Block("No images uploaded", "Upload attempted, but nothing succeeded and nothing failed?"));
+            $page->add_block(new Block("No images uploaded", rawHTML("Upload attempted, but nothing succeeded and nothing failed?")));
         } elseif (count($successes) == 1) {
             $page->set_mode(PageMode::REDIRECT);
             $page->set_redirect(make_link("post/view/{$successes[0]->image_id}"));

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -599,7 +599,7 @@ class UserPage extends Extension
     public function onHelpPageBuilding(HelpPageBuildingEvent $event): void
     {
         if ($event->key === HelpPages::SEARCH) {
-            $event->add_block(new Block("Users", $this->theme->get_help_html()));
+            $event->add_section("Users", $this->theme->get_help_html());
         }
     }
 

--- a/ext/user/theme.php
+++ b/ext/user/theme.php
@@ -31,7 +31,7 @@ class UserPageTheme extends Themelet
         $page->add_block(new NavBlock());
         $page->add_block(new Block(
             "Login There",
-            "There should be a login box to the left"
+            rawHTML("There should be a login box to the left")
         ));
     }
 
@@ -147,7 +147,7 @@ class UserPageTheme extends Themelet
                 )
             )
         );
-        $page->add_block(new Block("Create User", (string)$form, "main", 75));
+        $page->add_block(new Block("Create User", $form, "main", 75));
     }
 
     public function display_signups_disabled(Page $page): void
@@ -156,7 +156,7 @@ class UserPageTheme extends Themelet
         $page->add_block(new NavBlock());
         $page->add_block(new Block(
             "Signups Disabled",
-            "The board admin has disabled the ability to create new accounts~"
+            rawHTML("The board admin has disabled the ability to create new accounts~")
         ));
     }
 
@@ -248,11 +248,11 @@ class UserPageTheme extends Themelet
 
         $page->set_title(html_escape($duser->name)."'s Page");
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Stats", join("<br>", $stats), "main", 10));
+        $page->add_block(new Block("Stats", rawHTML(join("<br>", $stats)), "main", 10));
     }
 
 
-    public function build_operations(User $duser, UserOperationsBuildingEvent $event): string
+    public function build_operations(User $duser, UserOperationsBuildingEvent $event): HTMLElement
     {
         global $config, $user;
         $html = emptyHTML();
@@ -333,10 +333,10 @@ class UserPageTheme extends Themelet
             }
 
             foreach ($event->get_parts() as $part) {
-                $html .= $part;
+                $html->appendChild($part);
             }
         }
-        return (string)$html;
+        return $html;
     }
 
     public function get_help_html(): HTMLElement

--- a/ext/user_config/theme.php
+++ b/ext/user_config/theme.php
@@ -66,21 +66,17 @@ class UserConfigTheme extends Themelet
 
         $page->set_title("User Options");
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("User Options", $table));
+        $page->add_block(new Block("User Options", rawHTML($table)));
         $page->set_mode(PageMode::PAGE);
     }
 
     protected function sb_to_html(SetupBlock $block): string
     {
-        $h = $block->header;
-        $b = $block->body;
-        $i = preg_replace_ex('/[^a-zA-Z0-9]/', '_', $h ?? "") . "-setup";
-        $html = "
+        return "
 			<section class='setupblock'>
-				<b class='shm-toggler' data-toggle-sel='#$i'>$h</b>
-				<br><div id='$i'>$b</div>
+				<b>{$block->header}</b>
+				<br>{$block->str_body}
 			</section>
 		";
-        return $html;
     }
 }

--- a/ext/view/theme.php
+++ b/ext/view/theme.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{A, joinHTML, TABLE, TR, TD, INPUT, emptyHTML, DIV, BR, META, LINK};
+use function MicroHTML\{A, joinHTML, TABLE, TR, TD, INPUT, emptyHTML, rawHTML, DIV, BR, META, LINK};
 
 class ViewPostTheme extends Themelet
 {
@@ -99,7 +99,7 @@ class ViewPostTheme extends Themelet
         }
     }
 
-    protected function build_navigation(Image $image): string
+    protected function build_navigation(Image $image): HTMLElement
     {
         $h_pin = $this->build_pin($image);
         $h_search = "
@@ -110,7 +110,7 @@ class ViewPostTheme extends Themelet
 			</form>
 		";
 
-        return "$h_pin<br>$h_search";
+        return rawHTML("$h_pin<br>$h_search");
     }
 
     /**

--- a/ext/wiki/theme.php
+++ b/ext/wiki/theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
 use function MicroHTML\{FORM, INPUT, TABLE, TR, TD, emptyHTML, rawHTML, BR, TEXTAREA, DIV, HR, P, A};
 
 class WikiTheme extends Themelet
@@ -44,7 +46,7 @@ class WikiTheme extends Themelet
 
         $page->set_title(html_escape($wiki_page->title));
         $page->add_block(new NavBlock());
-        $page->add_block(new Block("Wiki Index", $tfe->formatted, "left", 20));
+        $page->add_block(new Block("Wiki Index", rawHTML($tfe->formatted), "left", 20));
         $page->add_block(new Block($title_html, $this->create_display_html($wiki_page)));
     }
 
@@ -62,7 +64,7 @@ class WikiTheme extends Themelet
         $html .= "</table>";
         $page->set_title(html_escape($title));
         $page->add_block(new NavBlock());
-        $page->add_block(new Block(html_escape($title), $html));
+        $page->add_block(new Block(html_escape($title), rawHTML($html)));
     }
 
     public function display_page_editor(Page $page, WikiPage $wiki_page): void
@@ -72,7 +74,7 @@ class WikiTheme extends Themelet
         $page->add_block(new Block("Editor", $this->create_edit_html($wiki_page)));
     }
 
-    protected function create_edit_html(WikiPage $page): string
+    protected function create_edit_html(WikiPage $page): HTMLElement
     {
         global $user;
 
@@ -85,7 +87,7 @@ class WikiTheme extends Themelet
             emptyHTML();
 
         $u_title = url_escape($page->title);
-        return (string)SHM_SIMPLE_FORM(
+        return SHM_SIMPLE_FORM(
             "wiki/$u_title/save",
             INPUT(["type" => "hidden", "name" => "revision", "value" => $page->revision + 1]),
             TEXTAREA(["name" => "body", "style" => "width: 100%", "rows" => 20], $page->body),
@@ -95,7 +97,7 @@ class WikiTheme extends Themelet
         );
     }
 
-    protected function create_display_html(WikiPage $page): string
+    protected function create_display_html(WikiPage $page): HTMLElement
     {
         global $user;
 
@@ -125,7 +127,7 @@ class WikiTheme extends Themelet
             )));
         }
 
-        return (string)DIV(
+        return DIV(
             ["class" => "wiki-page"],
             $formatted_body,
             HR(),

--- a/themes/danbooru/comment.theme.php
+++ b/themes/danbooru/comment.theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CustomCommentListTheme extends CommentListTheme
 {
     /**
@@ -28,7 +30,7 @@ class CustomCommentListTheme extends CommentListTheme
         $nav = "$h_prev | $h_index | $h_next";
 
         $page->set_title("Comments");
-        $page->add_block(new Block("Navigation", $nav, "left"));
+        $page->add_block(new Block("Navigation", rawHTML($nav), "left"));
         $this->display_paginator($page, "comment/list", null, $page_number, $total_pages);
 
         // parts for each image
@@ -84,7 +86,7 @@ class CustomCommentListTheme extends CommentListTheme
 			";
 
 
-            $page->add_block(new Block("&nbsp;", $html, "main", $position++));
+            $page->add_block(new Block(null, rawHTML($html), "main", $position++));
         }
     }
 

--- a/themes/danbooru/index.theme.php
+++ b/themes/danbooru/index.theme.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
+use function MicroHTML\rawHTML;
+
 class CustomIndexTheme extends IndexTheme
 {
     /**
@@ -36,27 +40,27 @@ class CustomIndexTheme extends IndexTheme
                 $this->display_paginator($page, "post/list", null, $this->page_number, $this->total_pages);
             }
         } else {
-            $page->add_block(new Block("No Posts Found", "No images were found to match the search criteria"));
+            throw new PostNotFound("No posts were found to match the search criteria");
         }
     }
 
     /**
      * @param string[] $search_terms
      */
-    protected function build_navigation(int $page_number, int $total_pages, array $search_terms): string
+    protected function build_navigation(int $page_number, int $total_pages, array $search_terms): HTMLElement
     {
         $h_search_string = count($search_terms) == 0 ? "" : html_escape(implode(" ", $search_terms));
         $h_search_link = search_link();
-        return "
+        return rawHTML("
 			<p><form action='$h_search_link' method='GET'>
 				<input name='search' type='text' value='$h_search_string' class='autocomplete_tags' placeholder='Search' />
 				<input type='hidden' name='q' value='post/list'>
 				<input type='submit' value='Find' style='display: none;' />
 			</form>
-			<div id='search_completions'></div>";
+			<div id='search_completions'></div>");
     }
 
-    protected function build_table(array $images, ?string $query): string
+    protected function build_table(array $images, ?string $query): HTMLElement
     {
         $h_query = html_escape($query);
         $table = "<div class='shm-image-list' data-query='$h_query'>";
@@ -64,6 +68,6 @@ class CustomIndexTheme extends IndexTheme
             $table .= $this->build_thumb_html($image) . "\n";
         }
         $table .= "</div>";
-        return $table;
+        return rawHTML($table);
     }
 }

--- a/themes/danbooru/page.class.php
+++ b/themes/danbooru/page.class.php
@@ -69,10 +69,10 @@ class Page extends BasePage
                     $left_block_html[] = $this->block_html($block, true);
                     break;
                 case "user":
-                    $user_block_html[] = rawHTML($block->body ?? "");
+                    $user_block_html[] = $block->body;
                     break;
                 case "subheading":
-                    $sub_block_html[] = rawHTML($block->body ?? "");
+                    $sub_block_html[] = $block->body;
                     break;
                 case "main":
                     if ($block->header == "Posts") {

--- a/themes/danbooru/user.theme.php
+++ b/themes/danbooru/user.theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CustomUserPageTheme extends UserPageTheme
 {
     public function display_login_page(Page $page): void
@@ -29,7 +31,7 @@ class CustomUserPageTheme extends UserPageTheme
         if ($config->get_bool("login_signup_enabled")) {
             $html .= "<small><a href='".make_link("user_admin/create")."'>Create Account</a></small>";
         }
-        $page->add_block(new Block("Login", $html, "main", 90));
+        $page->add_block(new Block("Login", rawHTML($html), "main", 90));
     }
 
     /**
@@ -57,7 +59,7 @@ class CustomUserPageTheme extends UserPageTheme
             }
             $html .= "<li><a href='{$part["link"]}'>{$part["name"]}</a>";
         }
-        $b = new Block("User Links", $html, "user", 90);
+        $b = new Block("User Links", rawHTML($html), "user", 90);
         $b->is_content = false;
         $page->add_block($b);
     }
@@ -92,7 +94,7 @@ class CustomUserPageTheme extends UserPageTheme
 
         $page->set_title("Create Account");
         $page->disable_left();
-        $page->add_block(new Block("Signup", $html));
+        $page->add_block(new Block("Signup", rawHTML($html)));
     }
 
     /**
@@ -114,7 +116,7 @@ class CustomUserPageTheme extends UserPageTheme
         $html .= "</td></tr>";
         $html .= "<tr><td colspan='2'>(Most recent at top)</td></tr></table>";
 
-        $page->add_block(new Block("IPs", $html));
+        $page->add_block(new Block("IPs", rawHTML($html)));
     }
 
     /**

--- a/themes/danbooru/view.theme.php
+++ b/themes/danbooru/view.theme.php
@@ -6,6 +6,8 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
+use function MicroHTML\rawHTML;
+
 class CustomViewPostTheme extends ViewPostTheme
 {
     /**
@@ -21,7 +23,7 @@ class CustomViewPostTheme extends ViewPostTheme
         $page->add_block(new Block(null, $this->build_pin($image), "main", 11));
     }
 
-    private function build_stats(Image $image): string
+    private function build_stats(Image $image): HTMLElement
     {
         $h_owner = html_escape($image->get_owner()->name);
         $h_ownerlink = "<a href='".make_link("user/$h_owner")."'>$h_owner</a>";
@@ -61,6 +63,6 @@ class CustomViewPostTheme extends ViewPostTheme
             $html .= "<br>Rating: <a href='".search_link(["rating=$rating"])."'>$h_rating</a>";
         }
 
-        return $html;
+        return rawHTML($html);
     }
 }

--- a/themes/danbooru2/comment.theme.php
+++ b/themes/danbooru2/comment.theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CustomCommentListTheme extends CommentListTheme
 {
     /**
@@ -28,7 +30,7 @@ class CustomCommentListTheme extends CommentListTheme
         $nav = "$h_prev | $h_index | $h_next";
 
         $page->set_title("Comments");
-        $page->add_block(new Block("Navigation", $nav, "left"));
+        $page->add_block(new Block("Navigation", rawHTML($nav), "left"));
         $this->display_paginator($page, "comment/list", null, $page_number, $total_pages);
 
         // parts for each image
@@ -83,7 +85,7 @@ class CustomCommentListTheme extends CommentListTheme
 			";
 
 
-            $page->add_block(new Block("&nbsp;", $html, "main", $position++));
+            $page->add_block(new Block(null, rawHTML($html), "main", $position++));
         }
     }
 

--- a/themes/danbooru2/index.theme.php
+++ b/themes/danbooru2/index.theme.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
+use function MicroHTML\rawHTML;
+
 class CustomIndexTheme extends IndexTheme
 {
     /**
@@ -28,23 +32,23 @@ class CustomIndexTheme extends IndexTheme
     /**
      * @param string[] $search_terms
      */
-    protected function build_navigation(int $page_number, int $total_pages, array $search_terms): string
+    protected function build_navigation(int $page_number, int $total_pages, array $search_terms): HTMLElement
     {
         $h_search_string = count($search_terms) == 0 ? "" : html_escape(implode(" ", $search_terms));
         $h_search_link = search_link();
-        return "
+        return rawHTML("
 			<p><form action='$h_search_link' method='GET'>
 				<input name='search' type='text' value='$h_search_string' class='autocomplete_tags' placeholder=''  style='width:75%'/>
 				<input type='submit' value='Go' style='width:20%'>
 				<input type='hidden' name='q' value='post/list'>
 			</form>
-			<div id='search_completions'></div>";
+			<div id='search_completions'></div>");
     }
 
     /**
      * @param Image[] $images
      */
-    protected function build_table(array $images, ?string $query): string
+    protected function build_table(array $images, ?string $query): HTMLElement
     {
         $h_query = html_escape($query);
         $table = "<div class='shm-image-list' data-query='$h_query'>";
@@ -52,6 +56,6 @@ class CustomIndexTheme extends IndexTheme
             $table .= $this->build_thumb_html($image) . "\n";
         }
         $table .= "</div>";
-        return $table;
+        return rawHTML($table);
     }
 }

--- a/themes/danbooru2/page.class.php
+++ b/themes/danbooru2/page.class.php
@@ -70,10 +70,10 @@ class Page extends BasePage
                     $left_block_html[] = $this->block_html($block, true);
                     break;
                 case "user":
-                    $user_block_html[] = rawHTML($block->body ?? "");
+                    $user_block_html[] = $block->body;
                     break;
                 case "subheading":
-                    $sub_block_html[] = rawHTML($block->body ?? "");
+                    $sub_block_html[] = $block->body;
                     break;
                 case "main":
                     if ($block->header == "Posts") {

--- a/themes/danbooru2/user.theme.php
+++ b/themes/danbooru2/user.theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CustomUserPageTheme extends UserPageTheme
 {
     public function display_login_page(Page $page): void
@@ -29,7 +31,7 @@ class CustomUserPageTheme extends UserPageTheme
         if ($config->get_bool("login_signup_enabled")) {
             $html .= "<small><a href='".make_link("user_admin/create")."'>Create Account</a></small>";
         }
-        $page->add_block(new Block("Login", $html, "main", 90));
+        $page->add_block(new Block("Login", rawHTML($html), "main", 90));
     }
 
     /**
@@ -57,7 +59,7 @@ class CustomUserPageTheme extends UserPageTheme
             }
             $html .= "<li><a href='{$part["link"]}'>{$part["name"]}</a>";
         }
-        $b = new Block("User Links", $html, "user", 90);
+        $b = new Block("User Links", rawHTML($html), "user", 90);
         $b->is_content = false;
         $page->add_block($b);
     }
@@ -98,7 +100,7 @@ class CustomUserPageTheme extends UserPageTheme
 
         $page->set_title("Create Account");
         $page->disable_left();
-        $page->add_block(new Block("Signup", $html));
+        $page->add_block(new Block("Signup", rawHTML($html)));
     }
 
     /**
@@ -120,7 +122,7 @@ class CustomUserPageTheme extends UserPageTheme
         $html .= "</td></tr>";
         $html .= "<tr><td colspan='2'>(Most recent at top)</td></tr></table>";
 
-        $page->add_block(new Block("IPs", $html));
+        $page->add_block(new Block("IPs", rawHTML($html)));
     }
 
     /**

--- a/themes/danbooru2/view.theme.php
+++ b/themes/danbooru2/view.theme.php
@@ -6,6 +6,8 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
+use function MicroHTML\rawHTML;
+
 class CustomViewPostTheme extends ViewPostTheme
 {
     /**
@@ -20,7 +22,7 @@ class CustomViewPostTheme extends ViewPostTheme
         $page->add_block(new Block(null, $this->build_info($image, $editor_parts), "main", 15));
     }
 
-    private function build_information(Image $image): string
+    private function build_information(Image $image): HTMLElement
     {
         $h_owner = html_escape($image->get_owner()->name);
         $h_ownerlink = "<a href='".make_link("user/$h_owner")."'>$h_owner</a>";
@@ -62,10 +64,10 @@ class CustomViewPostTheme extends ViewPostTheme
             $html .= "<br>Rating: <a href='".search_link(["rating=$rating"])."'>$h_rating</a>";
         }
 
-        return $html;
+        return rawHTML($html);
     }
 
-    protected function build_navigation(Image $image): string
+    protected function build_navigation(Image $image): HTMLElement
     {
         //$h_pin = $this->build_pin($image);
         $h_search = "
@@ -76,6 +78,6 @@ class CustomViewPostTheme extends ViewPostTheme
 			</form>
 		";
 
-        return "$h_search";
+        return rawHTML($h_search);
     }
 }

--- a/themes/futaba/comment.theme.php
+++ b/themes/futaba/comment.theme.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use MicroHTML\HTMLElement;
+
+use function MicroHTML\rawHTML;
+
 class CustomCommentListTheme extends CommentListTheme
 {
     public int $inner_id = 0;
@@ -23,7 +27,7 @@ class CustomCommentListTheme extends CommentListTheme
         $page->set_title($page_title);
         $page->disable_left();
         $page->add_block(new Block(null, $this->build_upload_box(), "main", 0));
-        $page->add_block(new Block(null, "<hr>", "main", 80));
+        $page->add_block(new Block(null, rawHTML("<hr>"), "main", 80));
         $this->display_paginator($page, "comment/list", null, $page_number, $total_pages);
         $this->post_page = false;
 
@@ -53,7 +57,7 @@ class CustomCommentListTheme extends CommentListTheme
             $html .=   "<div class='commentset'>$comment_html</div>";
             $html .= "</div>";
 
-            $page->add_block(new Block(null, $html, "main", $position++));
+            $page->add_block(new Block(null, rawHTML($html), "main", $position++));
         }
     }
 
@@ -63,9 +67,9 @@ class CustomCommentListTheme extends CommentListTheme
         parent::display_recent_comments($comments);
     }
 
-    public function build_upload_box(): string
+    public function build_upload_box(): HTMLElement
     {
-        return "[[ insert upload-and-comment extension here ]]";
+        return rawHTML("[[ insert upload-and-comment extension here ]]");
     }
 
 

--- a/themes/futaba/page.class.php
+++ b/themes/futaba/page.class.php
@@ -25,7 +25,7 @@ class Page extends BasePage
                     $main_block_html[] = $this->block_html($block, false);
                     break;
                 case "subheading":
-                    $sub_block_html[] = rawHTML($block->body ?? "");
+                    $sub_block_html[] = $block->body;
                     break;
                 default:
                     print "<p>error: {$block->header} using an unknown section ({$block->section})";

--- a/themes/futaba/themelet.class.php
+++ b/themes/futaba/themelet.class.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class Themelet extends BaseThemelet
 {
     /**
@@ -15,7 +17,7 @@ class Themelet extends BaseThemelet
             $total_pages = 1;
         }
         $body = $this->futaba_build_paginator($page_number, $total_pages, $base, $query);
-        $page->add_block(new Block(null, $body, "main", 90));
+        $page->add_block(new Block(null, rawHTML($body), "main", 90));
     }
 
     /**

--- a/themes/lite/page.class.php
+++ b/themes/lite/page.class.php
@@ -109,15 +109,13 @@ class Page extends BasePage
         $h = $block->header;
         $i = $block->id;
         if ($h == "Paginator") {
-            return rawHTML($block->body ?? "");
+            return $block->body;
         }
         $html = SECTION(["id" => $i]);
         if (!is_null($block->header)) {
             $html->appendChild(DIV(["class" => "navtop navside tab shm-toggler", "data-toggle-sel" => "#{$i}"], $block->header));
         }
-        if (!is_null($block->body)) {
-            $html->appendChild(DIV(["class" => "navside tab".($hidable ? " blockbody" : "")], rawHTML($block->body)));
-        }
+        $html->appendChild(DIV(["class" => "navside tab".($hidable ? " blockbody" : "")], $block->body));
         return $html;
     }
 

--- a/themes/lite/user.theme.php
+++ b/themes/lite/user.theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CustomUserPageTheme extends UserPageTheme
 {
     public function display_login_page(Page $page): void
@@ -29,7 +31,7 @@ class CustomUserPageTheme extends UserPageTheme
         if ($config->get_bool("login_signup_enabled")) {
             $html .= "<small><a href='".make_link("user_admin/create")."'>Create Account</a></small>";
         }
-        $page->add_block(new Block("Login", $html, "main", 90));
+        $page->add_block(new Block("Login", rawHTML($html), "main", 90));
     }
 
     /**
@@ -57,7 +59,7 @@ class CustomUserPageTheme extends UserPageTheme
             }
             $html .= "<a href='{$part["link"]}' class='tab'>{$part["name"]}</a>";
         }
-        $b = new Block("User Links", $html, "user", 90);
+        $b = new Block("User Links", rawHTML($html), "user", 90);
         $b->is_content = false;
         $page->add_block($b);
     }
@@ -87,7 +89,7 @@ class CustomUserPageTheme extends UserPageTheme
         $html .= "</td></tr>";
         $html .= "<tr><td colspan='2'>(Most recent at top)</td></tr></table>";
 
-        $page->add_block(new Block("IPs", $html));
+        $page->add_block(new Block("IPs", rawHTML($html)));
     }
 
     /**

--- a/themes/lite/view.theme.php
+++ b/themes/lite/view.theme.php
@@ -6,6 +6,8 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
+use function MicroHTML\rawHTML;
+
 class CustomViewPostTheme extends ViewPostTheme
 {
     /**
@@ -22,7 +24,7 @@ class CustomViewPostTheme extends ViewPostTheme
         $page->add_block(new Block(null, $this->build_pin($image), "main", 11));
     }
 
-    private function build_stats(Image $image): string
+    private function build_stats(Image $image): HTMLElement
     {
         $h_owner = html_escape($image->get_owner()->name);
         $h_ownerlink = "<a href='".make_link("user/$h_owner")."'>$h_owner</a>";
@@ -66,6 +68,6 @@ class CustomViewPostTheme extends ViewPostTheme
             $html .= "<br>Rating: <a href='".search_link(["rating=$rating"])."'>$h_rating</a>";
         }
 
-        return $html;
+        return rawHTML($html);
     }
 }

--- a/themes/warm/page.class.php
+++ b/themes/warm/page.class.php
@@ -35,7 +35,7 @@ class Page extends BasePage
                     $main_block_html[] = $this->block_html($block, false);
                     break;
                 case "subheading":
-                    $sub_block_html[] = rawHTML($block->body ?? "");
+                    $sub_block_html[] = $block->body;
                     break;
                 default:
                     print "<p>error: {$block->header} using an unknown section ({$block->section})";

--- a/themes/warm/upload.theme.php
+++ b/themes/warm/upload.theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CustomUploadTheme extends UploadTheme
 {
     public function display_block(Page $page): void
@@ -13,6 +15,6 @@ class CustomUploadTheme extends UploadTheme
 
     public function display_full(Page $page): void
     {
-        $page->add_block(new Block("Upload", "Disk nearly full, uploads disabled", "head", 20));
+        $page->add_block(new Block("Upload", rawHTML("Disk nearly full, uploads disabled"), "head", 20));
     }
 }

--- a/themes/warm/user.theme.php
+++ b/themes/warm/user.theme.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
+use function MicroHTML\rawHTML;
+
 class CustomUserPageTheme extends UserPageTheme
 {
     /**
@@ -16,7 +18,7 @@ class CustomUserPageTheme extends UserPageTheme
         foreach ($parts as $part) {
             $html .= "<a href='{$part["link"]}'>{$part["name"]}</a> | ";
         }
-        $page->add_block(new Block("Logged in as $h_name", $html, "head", 90));
+        $page->add_block(new Block("Logged in as $h_name", rawHTML($html), "head", 90));
     }
 
     public function display_login_block(Page $page): void
@@ -34,6 +36,6 @@ class CustomUserPageTheme extends UserPageTheme
         if ($config->get_bool("login_signup_enabled")) {
             $html .= "<small><a href='".make_link("user_admin/create")."'>Create Account</a></small>";
         }
-        $page->add_block(new Block("Login", $html, "head", 90));
+        $page->add_block(new Block("Login", rawHTML($html), "head", 90));
     }
 }


### PR DESCRIPTION
Use HTMLElement for all block bodies

Safety as the default, extensions can opt-in to string concatenation with rawHTML()
