### PR TITLE
[WIP] limit=X meta-tag, see #1153

### DIFF
--- a/core/imageboard/search.php
+++ b/core/imageboard/search.php
@@ -134,6 +134,9 @@ class Search
         }
 
         $params = SearchParameters::from_terms($tags);
+        if($params->limit !== null) {
+            $limit = $limit ? min($params->limit, $limit) : $params->limit;
+        }
         $querylet = self::build_search_querylet($params, $limit, $start);
         return $database->get_all_iterable($querylet->sql, $querylet->variables);
     }
@@ -453,7 +456,9 @@ class Search
 
         if (!is_null($limit)) {
             $query->append(new Querylet(" LIMIT :limit ", ["limit" => $limit]));
-            $query->append(new Querylet(" OFFSET :offset ", ["offset" => $offset]));
+            if(!is_null($offset)) {
+                $query->append(new Querylet(" OFFSET :offset ", ["offset" => $offset]));
+            }
         }
 
         return $query;

--- a/ext/index/events.php
+++ b/ext/index/events.php
@@ -24,6 +24,7 @@ class SearchTermParseEvent extends Event
     /** @var TagCondition[] */
     public array $tag_conditions = [];
     public ?string $order = null;
+    public ?int $limit = null;
 
     /**
      * @param string[] $context

--- a/ext/index/main.php
+++ b/ext/index/main.php
@@ -240,10 +240,13 @@ class Index extends Extension
             // recommended to change homepage to "post/list/order:dailyshuffle/1"
             $seed = (int)date("Ymd");
             $event->order = $database->seeded_random($seed, "images.id");
+        } elseif (preg_match("/^limit[=:](\d+)$/i", $event->term, $matches)) {
+            $limit = intval($matches[1]);
+            $event->limit = $limit;
         }
 
         // If we've reached this far, and nobody else has done anything with this term, then treat it as a tag
-        if ($event->order === null && $event->img_conditions == [] && $event->tag_conditions == []) {
+        if ($event->order === null && $event->limit === null && $event->img_conditions == [] && $event->tag_conditions == []) {
             assert(is_string($event->term));
             $event->add_tag_condition(new TagCondition($event->term, !$event->negative));
         }


### PR DESCRIPTION
[WIP] limit=X meta-tag, see #1153

This seems close to working, except that "page size" and "total number of search results" are two distinct concepts, and SQL LIMIT is used for page size already, so it doesn't work to also use it for total number of search results...
