### PR TITLE
[themes] only apply grid layout to pages generated using the default Page::body_html, fixes #1272

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -572,32 +572,38 @@ class Page
         );
     }
 
-    public function html_html(HTMLElement $head, string|HTMLElement $body): HTMLElement
+    public function html_html(HTMLElement $head, HTMLElement $body): HTMLElement
     {
-        global $user;
-
-        $body_attrs = [
-            "data-userclass" => $user->class->name,
-            "data-base-href" => get_base_href(),
-            "data-base-link" => make_link(""),
-        ];
-
         return emptyHTML(
             rawHTML("<!doctype html>"),
             HTML(
                 ["lang" => "en"],
-                HEAD($head),
-                BODY($body_attrs, $body)
+                $head,
+                $body,
             )
         );
     }
 
     protected function head_html(): HTMLElement
     {
-        return emptyHTML(
+        return HEAD(
             TITLE($this->title),
             $this->get_all_html_headers(),
         );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function body_attrs(string $class): array
+    {
+        global $user;
+        return [
+            "class" => $class,
+            "data-userclass" => $user->class->name,
+            "data-base-href" => get_base_href(),
+            "data-base-link" => make_link(""),
+        ];
     }
 
     protected function body_html(): HTMLElement
@@ -625,7 +631,8 @@ class Page
 
         $footer_html = $this->footer_html();
         $flash_html = $this->flash_html();
-        return emptyHTML(
+        return BODY(
+            $this->body_attrs("grid"),
             HTML_HEADER(
                 H1($this->heading),
                 ...$sub_block_html

--- a/ext/ext_manager/theme.php
+++ b/ext/ext_manager/theme.php
@@ -115,7 +115,7 @@ class ExtManagerTheme extends Themelet
 
         $cat_html = [
             A(["href" => make_link()], "Index"),
-            BR(),
+            " ",
         ];
         foreach ($categories as $cat) {
             $cat_html[] = A(["href" => "#".$cat->value], $cat->value);

--- a/ext/home/main.php
+++ b/ext/home/main.php
@@ -15,13 +15,11 @@ class Home extends Extension
     {
         global $config, $page;
         if ($event->page_matches("home")) {
-            $base_href = get_base_href();
             $sitename = $config->get_string(SetupConfig::TITLE);
-            $theme_name = $config->get_string(SetupConfig::THEME);
 
             $body = $this->get_body();
 
-            $this->theme->display_page($page, $sitename, $base_href, $theme_name, $body);
+            $this->theme->display_page($page, $sitename, $body);
         }
     }
 

--- a/ext/home/theme.php
+++ b/ext/home/theme.php
@@ -6,11 +6,11 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{emptyHTML, TITLE, META, rawHTML};
+use function MicroHTML\{BODY, emptyHTML, TITLE, META, rawHTML};
 
 class HomeTheme extends Themelet
 {
-    public function display_page(Page $page, string $sitename, string $base_href, string $theme_name, HTMLElement $body): void
+    public function display_page(Page $page, string $sitename, HTMLElement $body): void
     {
         $page->set_mode(PageMode::DATA);
         $page->add_auto_html_headers();
@@ -28,6 +28,8 @@ class HomeTheme extends Themelet
 
     public function build_body(string $sitename, string $main_links, string $main_text, string $contact_link, string $num_comma, string $counter_text): HTMLElement
     {
+        global $page;
+
         $main_links_html = empty($main_links) ? "" : "<div class='space' id='links'>$main_links</div>";
         $message_html = empty($main_text) ? "" : "<div class='space' id='message'>$main_text</div>";
         $counter_html = empty($counter_text) ? "" : "<div class='space' id='counter'>$counter_text</div>";
@@ -41,7 +43,9 @@ class HomeTheme extends Themelet
 				</form>
 			</div>
 		";
-        return rawHTML("
+        return BODY(
+            $page->body_attrs("home"),
+            rawHTML("
 		<div id='front-page'>
 			<h1><a style='text-decoration: none;' href='".make_link()."'><span>$sitename</span></a></h1>
 			$main_links_html
@@ -54,6 +58,7 @@ class HomeTheme extends Themelet
 				Running <a href='https://code.shishnet.org/shimmie2/'>Shimmie2</a>
 				</small></small>
 			</div>
-		</div>");
+		</div>")
+        );
     }
 }

--- a/themes/danbooru/page.class.php
+++ b/themes/danbooru/page.class.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{DIV, LI, A, rawHTML, emptyHTML, UL, ARTICLE, FOOTER, EM, HEADER, H1, NAV};
+use function MicroHTML\{BODY, DIV, LI, A, rawHTML, emptyHTML, UL, ARTICLE, FOOTER, EM, HEADER, H1, NAV};
 
 /**
  * Name: Danbooru Theme
@@ -121,7 +121,8 @@ class DanbooruPage extends Page
         $flash_html = $this->flash_html();
         $footer_html = $this->footer_html();
 
-        return emptyHTML(
+        return BODY(
+            $this->body_attrs("grid"),
             HEADER(
                 $title_link,
                 UL(["id" => "navbar", "class" => "flat-list"], $custom_links),

--- a/themes/danbooru2/page.class.php
+++ b/themes/danbooru2/page.class.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{DIV, LI, A, rawHTML, emptyHTML, UL, ARTICLE, FOOTER, EM, HEADER, H1, NAV};
+use function MicroHTML\{BODY, DIV, LI, A, rawHTML, emptyHTML, UL, ARTICLE, FOOTER, EM, HEADER, H1, NAV};
 
 /**
  * Name: Danbooru 2 Theme
@@ -122,7 +122,8 @@ class Danbooru2Page extends Page
         $flash_html = $this->flash_html();
         $footer_html = $this->footer_html();
 
-        return emptyHTML(
+        return BODY(
+            $this->body_attrs("grid"),
             HEADER(
                 $title_link,
                 UL(["id" => "navbar", "class" => "flat-list"], $custom_links),

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -61,12 +61,14 @@ HEADER H1 {
 	overflow: hidden;
 }
 BODY {
-	display: grid;
-	grid-template-columns: 216px auto;
-	grid-gap: 0 10px;
 	background: var(--page);
 	color: var(--text);
 	margin: 0;	
+}
+BODY.grid {
+	display: grid;
+	grid-template-columns: 216px auto;
+	grid-gap: 0 10px;
 }
 H1 {
 	background: var(--title);

--- a/themes/futaba/page.class.php
+++ b/themes/futaba/page.class.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{DIV, LI, A, rawHTML, emptyHTML, UL, ARTICLE, FOOTER, HR, HEADER, H1, NAV};
+use function MicroHTML\{BODY, DIV, LI, A, rawHTML, emptyHTML, UL, ARTICLE, FOOTER, HR, HEADER, H1, NAV};
 
 class FutabaPage extends Page
 {
@@ -48,7 +48,8 @@ class FutabaPage extends Page
         $flash_html = $this->flash_html();
         $footer_html = $this->footer_html();
 
-        return emptyHTML(
+        return BODY(
+            $this->body_attrs("grid"),
             HEADER(
                 H1($this->heading),
                 $subheading,

--- a/themes/lite/page.class.php
+++ b/themes/lite/page.class.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{emptyHTML, HEADER, FOOTER, DIV, SCRIPT, A, B, IMG, NAV, ARTICLE, rawHTML, SECTION};
+use function MicroHTML\{BODY, emptyHTML, HEADER, FOOTER, DIV, SCRIPT, A, B, IMG, NAV, ARTICLE, rawHTML, SECTION};
 
 /**
  * Name: Lite Theme
@@ -94,7 +94,8 @@ class LitePage extends Page
 
         $footer_html = $this->footer_html();
 
-        return emptyHTML(
+        return BODY(
+            $this->body_attrs("grid"),
             HEADER(
                 $menu,
                 $custom_sublinks,

--- a/themes/warm/page.class.php
+++ b/themes/warm/page.class.php
@@ -6,7 +6,7 @@ namespace Shimmie2;
 
 use MicroHTML\HTMLElement;
 
-use function MicroHTML\{A, TABLE, TR, TD, SMALL, rawHTML, emptyHTML, DIV, ARTICLE, FOOTER, HEADER, H1, NAV};
+use function MicroHTML\{BODY, A, TABLE, TR, TD, SMALL, rawHTML, emptyHTML, DIV, ARTICLE, FOOTER, HEADER, H1, NAV};
 
 class WarmPage extends Page
 {
@@ -46,7 +46,8 @@ class WarmPage extends Page
         $flash_html = $this->flash_html();
         $footer_html = $this->footer_html();
 
-        return emptyHTML(
+        return BODY(
+            $this->body_attrs("grid"),
             HEADER(
                 DIV(
                     ["style" => "text-align: center;"],


### PR DESCRIPTION
[themes] only apply grid layout to pages generated using the default Page::body_html, fixes #1272
