### PR TITLE
Fix Favorites Bug

### DIFF
--- a/ext/favorites/main.php
+++ b/ext/favorites/main.php
@@ -258,7 +258,7 @@ class Favorites extends Extension
         }
         $database->execute(
             "UPDATE images SET favorites=(SELECT COUNT(*) FROM user_favorites WHERE image_id=:image_id) WHERE id=:image_id",
-            ["image_id" => $image_id, "user_id" => $user_id]
+            ["image_id" => $image_id]
         );
     }
 

--- a/ext/favorites/main.php
+++ b/ext/favorites/main.php
@@ -257,7 +257,7 @@ class Favorites extends Extension
             );
         }
         $database->execute(
-            "UPDATE images SET favorites=(SELECT COUNT(*) FROM user_favorites WHERE image_id=:image_id) WHERE id=:user_id",
+            "UPDATE images SET favorites=(SELECT COUNT(*) FROM user_favorites WHERE image_id=:image_id) WHERE id=:image_id",
             ["image_id" => $image_id, "user_id" => $user_id]
         );
     }

--- a/ext/index/theme.php
+++ b/ext/index/theme.php
@@ -262,7 +262,7 @@ and of course start organising your images :-)
             //
             BR(),
             P("Searching for posts by source."),
-            SHM_COMMAND_EXAMPLE("source=https:///google.com/", 'Returns posts with a source of "https://google.com/".'),
+            SHM_COMMAND_EXAMPLE("source=https://google.com/", 'Returns posts with a source of "https://google.com/".'),
             SHM_COMMAND_EXAMPLE("source=any", "Returns posts with a source set."),
             SHM_COMMAND_EXAMPLE("source=none", "Returns posts without a source set."),
             //


### PR DESCRIPTION
The id of the user was determining the post number that was being updated rather than the post's id. This only affected the `favorites>n` search query which is why it went unnoticed for 13 years.


sql statements for those interested
correct posts that may not have any favorites but whose favorite count was incorrectly updated
`UPDATE images SET favorites=(SELECT COUNT(*) FROM user_favorites WHERE image_id=id) WHERE favorites>0;`

set the correct favorite count for all favorited posts
`UPDATE images SET favorites=(SELECT COUNT(*) FROM user_favorites WHERE image_id=id) WHERE id IN (SELECT image_id FROM user_favorites);`