### PR TITLE
Allow larger random seeds

### DIFF
--- a/ext/index/main.php
+++ b/ext/index/main.php
@@ -224,7 +224,7 @@ class Index extends Extension
             $default_order_for_column = \Safe\preg_match("/^(id|filename)$/", $matches[1]) ? "ASC" : "DESC";
             $sort = isset($matches[2]) ? strtoupper($matches[2]) : $default_order_for_column;
             $event->order = "images.$ord $sort";
-        } elseif ($matches = $event->matches("/^order[=|:]random[_]([0-9]{1,4})$/i")) {
+        } elseif ($matches = $event->matches("/^order[=|:]random[_]([0-9]{1,8})$/i")) {
             // requires a seed to avoid duplicates
             // since the tag can't be changed during the parseevent, we instead generate the seed during submit using js
             $seed = (int)$matches[1];


### PR DESCRIPTION
This patch allows specifying larger random seeds. Current value only allows for 10k possible variations, which is quite short considering these boards may contain millions of pictures.

The new value allows for 10^8 variations, so I am more likely to get a truly random image using the Danbooru/Ouroboros API with large data sets.

In order to keep autogenerated seeds short, the JS code that inserts the value will still produce only 4-digit sequences.

This should not cause any compatibility issues as [MySQL uses a 32-bit field for the seed](https://github.com/mysql/mysql-server/blob/61a3a1d8ef15512396b4c2af46e922a19bf2b174/sql/item_func.cc#L3674-L3682), which allows for log10(2**32) = ~9.6 digit seeds. The other engines fall back to the hash DRBG which accept arbitrary lengths.