### PR TITLE
post id avatars

### DIFF
--- a/core/user.php
+++ b/core/user.php
@@ -238,7 +238,11 @@ class User
     {
         // FIXME: configurable
         global $config;
-        if ($config->get_string("avatar_host") === "gravatar") {
+        $avatar_host = $config->get_string("avatar_host");
+        if ($avatar_host === "post"){
+            return $this->get_avatar_post_link();
+        }
+        elseif ($avatar_host === "gravatar") {
             if (!empty($this->email)) {
                 $hash = md5(strtolower($this->email));
                 $s = $config->get_string("avatar_gravatar_size");
@@ -248,6 +252,21 @@ class User
                 return "https://www.gravatar.com/avatar/$hash.jpg?s=$s&d=$d&r=$r&cacheBreak=$cb";
             }
         }
+        return null;
+    }
+
+    public function get_avatar_post_link() : ?string {
+        global $database;
+        $user_config = new DatabaseConfig($database, "user_config", "user_id", (string)$this->id);
+        $id = $user_config->get_int("avatar_post_id");
+        if ($id === 0) {
+            return null;
+        }
+        $image = Image::by_id($id);
+        if ($image) {
+            return $image->get_thumb_link();
+        }
+        $user_config->set_int("avatar_post_id", 0);
         return null;
     }
 

--- a/core/user.php
+++ b/core/user.php
@@ -259,7 +259,7 @@ class User
         global $database;
         $user_config = new DatabaseConfig($database, "user_config", "user_id", (string)$this->id);
         $id = $user_config->get_int("avatar_post_id");
-        if ($id === 0) {
+        if (is_null($id) || $id === 0) {
             return null;
         }
         $image = Image::by_id($id);

--- a/core/user.php
+++ b/core/user.php
@@ -266,7 +266,7 @@ class User
         if ($image) {
             return $image->get_thumb_link();
         }
-        $user_config->set_int("avatar_post_id", 0);
+        $user_config->delete("avatar_post_id");
         return null;
     }
 

--- a/core/user.php
+++ b/core/user.php
@@ -239,10 +239,9 @@ class User
         // FIXME: configurable
         global $config;
         $avatar_host = $config->get_string("avatar_host");
-        if ($avatar_host === "post"){
+        if ($avatar_host === "post") {
             return $this->get_avatar_post_link();
-        }
-        elseif ($avatar_host === "gravatar") {
+        } elseif ($avatar_host === "gravatar") {
             if (!empty($this->email)) {
                 $hash = md5(strtolower($this->email));
                 $s = $config->get_string("avatar_gravatar_size");
@@ -255,11 +254,12 @@ class User
         return null;
     }
 
-    public function get_avatar_post_link() : ?string {
+    public function get_avatar_post_link(): ?string
+    {
         global $database;
         $user_config = new DatabaseConfig($database, "user_config", "user_id", (string)$this->id);
-        $id = $user_config->get_int("avatar_post_id");
-        if (is_null($id) || $id === 0) {
+        $id = $user_config->get_int("avatar_post_id", 0);
+        if ($id === 0) {
             return null;
         }
         $image = Image::by_id($id);

--- a/ext/comment/theme.php
+++ b/ext/comment/theme.php
@@ -243,12 +243,7 @@ class CommentListTheme extends Themelet
 			</div>
 			";
         } else {
-            $h_avatar = "";
-            if (!empty($comment->owner_email)) {
-                $hash = md5(strtolower($comment->owner_email));
-                $cb = date("Y-m-d");
-                $h_avatar = "<img alt='avatar' src=\"//www.gravatar.com/avatar/$hash.jpg?cacheBreak=$cb\"><br>";
-            }
+            $h_avatar = $comment->get_owner()->get_avatar_html();
             $h_reply = " - <a href='javascript: replyTo($i_image_id, $i_comment_id, \"$h_name\")'>Reply</a>";
             $h_ip = $user->can(Permissions::VIEW_IP) ? "<br>".show_ip($comment->poster_ip, "Comment posted {$comment->posted}") : "";
             $h_del = "";

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -409,6 +409,7 @@ class UserPage extends Extension
 
         $hosts = [
             "None" => "none",
+            "Post id" => "post",
             "Gravatar" => "gravatar"
         ];
 
@@ -455,6 +456,15 @@ class UserPage extends Extension
             );
         }
         $sb->end_table();
+    }
+
+    public function onUserOptionsBuilding(UserOptionsBuildingEvent $event): void
+    {
+        global $config;
+        if ($config->get_string("avatar_host") === "post"){
+            $sb = $event->panel->create_new_block("Avatar");
+            $sb->add_int_option("avatar_post_id", 'Avatar post ID: ');
+        }
     }
 
     public function onPageSubNavBuilding(PageSubNavBuildingEvent $event): void

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -461,7 +461,7 @@ class UserPage extends Extension
     public function onUserOptionsBuilding(UserOptionsBuildingEvent $event): void
     {
         global $config;
-        if ($config->get_string("avatar_host") === "post"){
+        if ($config->get_string("avatar_host") === "post") {
             $sb = $event->panel->create_new_block("Avatar");
             $sb->add_int_option("avatar_post_id", 'Avatar post ID: ');
         }

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -409,7 +409,7 @@ class UserPage extends Extension
 
         $hosts = [
             "None" => "none",
-            "Post id" => "post",
+            "Post ID" => "post",
             "Gravatar" => "gravatar"
         ];
 


### PR DESCRIPTION
Wasn't a fan of 'gravatar', an external way to give users avatars, knowing e621 has the ability to set a post as your avatar, i wanted the same, and others might like it too so hence a pr.

since it uses user_config, it has to get the user config every time for the owner of every comment, using user_config::get_for_user($id) seemed slow as it sends a quite large event every time, so it directly gets the config in User::get_avatar_post_link(), but i am not entirely sure if its safe to do it in this way. The url or full html might also be cacheable to increase efficiency a bit thinking about it now.