### PR TITLE
[user] Post avatars with cropping

### DIFF
--- a/core/polyfills.php
+++ b/core/polyfills.php
@@ -459,7 +459,7 @@ function truncate(string $string, int $limit, string $break = " ", string $pad =
  */
 function parse_shorthand_int(string $limit): int
 {
-    if (preg_match('/^([\d\.]+)([tgmk])?b?$/i', (string)$limit, $m)) {
+    if (preg_match('/^(-?[\d\.]+)([tgmk])?b?$/i', (string)$limit, $m)) {
         $value = (float)$m[1];
         if (isset($m[2])) {
             switch (strtolower($m[2])) {

--- a/ext/user/config.php
+++ b/ext/user/config.php
@@ -22,4 +22,8 @@ class AvatarConfig extends ConfigGroup
     public const GRAVATAR_SIZE = "avatar_gravatar_size";
     public const GRAVATAR_DEFAULT = "avatar_gravatar_default";
     public const GRAVATAR_RATING = "avatar_gravatar_rating";
+    public const POST_AVATAR_ID = "avatar_post_id";
+    public const POST_AVATAR_SCALE = "avatar_post_scale";
+    public const POST_AVATAR_X = "avatar_post_x";
+    public const POST_AVATAR_Y = "avatar_post_y";
 }

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -339,23 +339,19 @@ class UserPage extends Extension
         }
 
         if ($event->page_matches("set_avatar/{image_id}", method: "GET", permission: Permissions::CHANGE_USER_SETTING)) {
-            if (!$user->is_anonymous()) {
-                $image_id = int_escape($event->get_arg('image_id'));
-                $this->theme->display_avatar_edit_page($page, $image_id);
-            }
+            $image_id = int_escape($event->get_arg('image_id'));
+            $this->theme->display_avatar_edit_page($page, $image_id);
         }
 
         if ($event->page_matches("save_avatar", method: "POST", permission: Permissions::CHANGE_USER_SETTING)) {
-            if (!$user->is_anonymous()) {
-                $settings = ConfigSaveEvent::postToSettings($event->POST);
-                send_event(new ConfigSaveEvent($user_config, $settings));
-                $page->flash("Image set as avatar");
-                $page->set_mode(PageMode::REDIRECT);
-                if (key_exists(AvatarConfig::POST_AVATAR_ID, $settings) && is_int($settings[AvatarConfig::POST_AVATAR_ID])) {
-                    $page->set_redirect(make_link("post/view/".$settings[AvatarConfig::POST_AVATAR_ID]));
-                } else {
-                    $page->set_redirect(make_link("user_config"));
-                }
+            $settings = ConfigSaveEvent::postToSettings($event->POST);
+            send_event(new ConfigSaveEvent($user_config, $settings));
+            $page->flash("Image set as avatar");
+            $page->set_mode(PageMode::REDIRECT);
+            if (key_exists(AvatarConfig::POST_AVATAR_ID, $settings) && is_int($settings[AvatarConfig::POST_AVATAR_ID])) {
+                $page->set_redirect(make_link("post/view/".$settings[AvatarConfig::POST_AVATAR_ID]));
+            } else {
+                $page->set_redirect(make_link("user_config"));
             }
         }
     }
@@ -541,7 +537,7 @@ class UserPage extends Extension
     public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
     {
         global $user, $config;
-        if ($config->get_string(AvatarConfig::HOST) === "post" && !$user->is_anonymous()) {
+        if ($config->get_string(AvatarConfig::HOST) === "post" && $user->can(Permissions::CHANGE_USER_SETTING)) {
             $event->add_button("Set Image As Avatar", "set_avatar/".$event->image->id);
         }
     }

--- a/ext/user/script.js
+++ b/ext/user/script.js
@@ -1,6 +1,6 @@
 // only run on the right page
 if (window.location.pathname.startsWith("/set_avatar") // clean urls
-    || /q=([^&#=]*)/.exec(window.location.search)[1].startsWith("set_avatar")) // ?q= urls
+    || window.location.search.startsWith("?q=set_avatar")) // ?q= urls
 {
 let image;
 let zoom_slider;

--- a/ext/user/script.js
+++ b/ext/user/script.js
@@ -1,0 +1,108 @@
+// only run on the right page
+if (window.location.pathname.startsWith("/set_avatar") // clean urls
+    || /q=([^&#=]*)/.exec(window.location.search)[1].startsWith("set_avatar")) // ?q= urls
+{
+let image;
+let zoom_slider;
+
+let scale_input;
+let x_input;
+let y_input;
+let zooming = false;
+
+let previous = null;
+const zps = 1000/30;
+function zoom(timestamp) {
+    if (zooming) {
+        if (previous === null) {
+            previous = timestamp-10;
+        }
+        const delta = (timestamp - previous)/zps;
+        const val = zoom_slider.valueAsNumber;
+
+        image.scale += val*delta;
+        const scale = Math.round(image.scale);
+        image.style.transform = `scale(${scale/100})`;
+
+        requestAnimationFrame(zoom);
+        previous = timestamp;
+    }
+}
+
+function zoom_input(e) {
+    if (!zooming){
+        zooming = true;
+        requestAnimationFrame(zoom);
+    }
+}
+
+function zoom_change(e) {
+    zooming = false;
+    previous = null;
+    e.target.value = 0;
+
+    const scale = Math.round(image.scale);
+    image.style.transform = `scale(${scale/100})`;
+    scale_input.value = Math.round(scale);
+}
+
+function zoom_init() {
+    zoom_slider.addEventListener("change",zoom_change);
+    zoom_slider.addEventListener("input",zoom_input);
+}
+
+let dragging = false;
+let prev_coords = [0,0];
+function start_image_drag(e) {
+    dragging = true;
+    image.style.cursor = "grabbing";
+    const clientX = e.clientX || e.touches[0].clientX;
+    const clientY = e.clientY || e.touches[0].clientY;
+    prev_coords = [clientX, clientY];
+    e.preventDefault();
+}
+
+function image_drag(e) {
+    if (!dragging) return;
+
+    const clientX = e.clientX || e.touches[0].clientX;
+    const clientY = e.clientY || e.touches[0].clientY;
+
+    image.cx += clientX - prev_coords[0];
+    image.cy += clientY - prev_coords[1];
+    image.style.translate = `${image.cx}% ${image.cy}%`
+    prev_coords = [clientX, clientY];
+}
+
+function stop_image_drag() {
+    if (dragging) {
+        dragging = false;
+        image.style.cursor = "grab";
+        x_input.value = Math.round(image.cx);
+        y_input.value = Math.round(image.cy);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    zoom_slider = document.getElementById("zoom-slider");
+    image = document.getElementById("avatar-edit");
+    scale_input = document.getElementById("avatar-post-scale");
+    x_input = document.getElementById("avatar-post-x");
+    y_input = document.getElementById("avatar-post-y");
+    if (!(zoom_slider && image && scale_input && x_input && y_input)) return;
+    image.scale = 100;
+    image.cx = 0;
+    image.cy = 0;
+    image.style.cursor = "grab";
+    zoom_init();
+
+    image.addEventListener('mousedown', start_image_drag);
+    document.addEventListener('mousemove', image_drag);
+    document.addEventListener('mouseup', stop_image_drag);
+
+    // Touch events for mobile
+    image.addEventListener('touchstart', start_image_drag);
+    document.addEventListener('touchmove', image_drag);
+    document.addEventListener('touchend', stop_image_drag);
+});
+}

--- a/ext/user/style.css
+++ b/ext/user/style.css
@@ -1,3 +1,7 @@
+.avatar-editor .avatar-container {
+	border: 2px solid var(--text);
+}
+
 #Statsmain .avatar-container, .avatar-editor .avatar-container{
 	margin: 0 auto;
 	width: min(var(--pavatar-width),192px);

--- a/ext/user/style.css
+++ b/ext/user/style.css
@@ -1,0 +1,25 @@
+#Statsmain .avatar-container, .avatar-editor .avatar-container{
+	margin: 0 auto;
+	width: min(var(--pavatar-width),192px);
+	height: min(var(--pavatar-height),192px);
+	max-width: 192px;
+	max-height: 192px;
+}
+
+#Statsmain .avatar, .avatar-editor .avatar {
+	max-width: 192px;
+	max-height: 192px;
+}
+
+.avatar-container {
+	overflow: hidden;
+	width: min(var(--pavatar-width),96px);
+	height: min(var(--pavatar-height),96px);
+	max-width: 96px;
+	max-height: 96px;
+}
+
+.avatar {
+	max-width: 96px;
+	max-height: 96px;
+}


### PR DESCRIPTION
- Add a button in post controls to set the image as avatar.
- Add a page to set the avatar cropping easily.
This page should make it easy for the user to crop their avatar to their liking, they can drag it around and zoom in using the slider. And if they do not have JavaScript enabled, it can be manually changed on the user options page.

All the cropping is done by CSS and does not require any changes to be made to the actual images, nor copying and resizing.

I also included the parse_shorthand_int change i mentioned in https://github.com/shish/shimmie2/issues/1390 because it does rely on that right now. A workaround would be to parse some values as string instead, then cast it to integer afterwards manually but i don't see issue in having parse_shorthand_int be able to parse negative values as well.