### PR TITLE
[style] various word wrapping changes

### DIFF
--- a/ext/bbcode/style.css
+++ b/ext/bbcode/style.css
@@ -1,5 +1,5 @@
 .bbcode {
-	word-break: break-all;
+	overflow-wrap: anywhere;
 }
 .bbcode BLOCKQUOTE {
 	border: 1px solid black;

--- a/ext/comment/style.css
+++ b/ext/comment/style.css
@@ -2,7 +2,7 @@
 .comment {
 	text-align: left;
 	position: relative;
-	word-wrap: break-word;
+	overflow-wrap: anywhere;
 }
 .comment IMG {
 	max-width: 100%;

--- a/ext/forum/style.css
+++ b/ext/forum/style.css
@@ -1,6 +1,6 @@
 TABLE#threadPosts {
 	table-layout:fixed;
-	word-wrap:break-word;
+	overflow-wrap:anywhere;
 	text-align:left;
 	width: 100%;
 }

--- a/ext/report_image/style.css
+++ b/ext/report_image/style.css
@@ -1,7 +1,6 @@
 #reportedimage .reason {
 	max-width: 30em;
-	overflow-wrap: break-word;
-	word-wrap: break-word;
+	overflow-wrap: anywhere;
 }
 #reportedimage .formstretch INPUT {
 	width: 100%;

--- a/ext/static_files/style.css
+++ b/ext/static_files/style.css
@@ -17,6 +17,10 @@ TABLE.form SELECT,
 TABLE.form TEXTAREA,
 TABLE.form BUTTON {width: 100%;}
 
+H1, H2, H3 {
+	overflow-wrap: anywhere;
+}
+
 *[onclick],
 H3[class~="shm-toggler"] {
 	cursor: pointer;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -58,7 +58,6 @@
 H1, H2, H3 {
 	margin: 0;
 	text-align: center;
-	word-break: break-all;
 	/* not sure why top-padding appears visually larger than other padding in headers...
 	reducing top-padding to compensate */
 	padding: calc(var(--block-padding) * 0.5) var(--block-padding) var(--block-padding) var(--block-padding);


### PR DESCRIPTION
Prevents words being broken unnecessarily in places like comments and wiki pages, plus general clean up of wrapping CSS rules.

- Convert alias property `word-wrap` to `overflow-wrap` for consistency
- Use `overflow-wrap: anywhere;` instead of `word-wrap: break-all;` to prevent words being broken unnecessarily
- Use `overflow-wrap: anywhere;` instead of `overflow-wrap: break-word;` to work better with flex
- Move H1, H2, H3 wrapping rule in default theme to static css rule on all themes

All the existing word wrapping CSS rules become `overflow-wrap: anywhere;`. I am not confident with simply replacing all these rules with one global root declaration, as the default wrapping behavior was chosen to avoid any chance of overflowing data being hidden.