### PR TITLE
[statistics] remove unused stub option

### DIFF
--- a/ext/statistics/main.php
+++ b/ext/statistics/main.php
@@ -77,12 +77,6 @@ class Statistics extends Extension
         }
     }
 
-    public function onSetupBuilding(SetupBuildingEvent $event): void
-    {
-        $sb = $event->panel->create_new_block("Stats Page");
-        $sb->add_longtext_option("stats_text", "<br>Page Text:<br>");
-    }
-
     public function onPageNavBuilding(PageNavBuildingEvent $event): void
     {
         $event->add_nav_link("stats", new Link('stats'), "Stats");


### PR DESCRIPTION
This function was added by mistake. It only adds a useless text box and section to the admin panel.