### PR TITLE
[core] Config unit tests, and fixes for get_int/float

### DIFF
--- a/core/config.php
+++ b/core/config.php
@@ -162,7 +162,11 @@ abstract class Config
      */
     public function get_int(string $name, ?int $default = null): ?int
     {
-        return (int)($this->get($name, $default));
+        $val = $this->get($name, $default);
+        if (is_null($val) || !is_numeric($val)) {
+            return $default;
+        }
+        return (int)$val;
     }
 
     /**
@@ -174,7 +178,11 @@ abstract class Config
      */
     public function get_float(string $name, ?float $default = null): ?float
     {
-        return (float)($this->get($name, $default));
+        $val = $this->get($name, $default);
+        if (is_null($val) || !is_numeric($val)) {
+            return $default;
+        }
+        return (float)$val;
     }
 
     /**
@@ -198,7 +206,11 @@ abstract class Config
      */
     public function get_bool(string $name, ?bool $default = null): ?bool
     {
-        return bool_escape($this->get($name, $default));
+        $val = $this->get($name, $default);
+        if (is_null($val)) {
+            return $default;
+        }
+        return bool_escape($val);
     }
 
     /**

--- a/core/tests/ConfigTest.php
+++ b/core/tests/ConfigTest.php
@@ -6,6 +6,21 @@ namespace Shimmie2;
 
 require_once "core/imageboard/image.php";
 
+class TestConfig extends Config
+{
+    /**
+     * @param array<string, string> $values
+     */
+    public function __construct(array $values)
+    {
+        $this->values = $values;
+    }
+
+    public function save(string $name): void
+    {
+    }
+}
+
 class ConfigTest extends ShimmiePHPUnitTestCase
 {
     public function testConfigGroup(): void
@@ -13,5 +28,32 @@ class ConfigTest extends ShimmiePHPUnitTestCase
         $conf = ConfigGroup::get_group_for_entry_by_name("comment_limit");
         $this->assertNotNull($conf);
         $this->assertEquals(CommentConfig::class, $conf::class);
+    }
+
+    public function testGetInt(): void
+    {
+        $this->assertEquals(
+            (new TestConfig(["foo" => "42"]))->get_int("foo"),
+            42,
+            "get_int should return the value of a setting when it is set correctly"
+        );
+
+        $config = new TestConfig(["foo" => "waffo"]);
+        $this->assertNull(
+            (new TestConfig(["foo" => "waffo"]))->get_int("foo"),
+            "get_int should return null when a setting is set incorrectly"
+        );
+
+        $config = new TestConfig([]);
+        $this->assertEquals(
+            (new TestConfig([]))->get_int("foo", 42),
+            42,
+            "get_int should return the default value when a setting is not set"
+        );
+
+        $this->assertNull(
+            (new TestConfig([]))->get_int("foo"),
+            "get_int should return null when a setting is not set and no default is specified"
+        );
     }
 }


### PR DESCRIPTION

if an invalid value is set, we should return the default, not 0
