### PR TITLE
[log_console] improve format

### DIFF
--- a/ext/log_console/main.php
+++ b/ext/log_console/main.php
@@ -58,40 +58,50 @@ class LogConsole extends Extension
 
     private function log(LogEvent $event): void
     {
+        if (defined("UNITTEST") || PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
+            return;
+        }
+
         global $config, $user;
         $username = ($user && $user->name) ? $user->name : "Anonymous";
+
+        $levelName = "[unknown]";
+        $color = "\033[0;35m"; # purple for unknown levels
+        if ($event->priority >= SCORE_LOG_CRITICAL) {
+            $levelName = "[critical]";
+            $color = "\033[0;31m"; # red
+        } elseif ($event->priority >= SCORE_LOG_ERROR) {
+            $levelName = "[error]";
+            $color = "\033[0;91m"; # high intensity red
+        } elseif ($event->priority >= SCORE_LOG_WARNING) {
+            $levelName = "[warning]";
+            $color = "\033[0;33m"; # yellow
+        } elseif ($event->priority >= SCORE_LOG_INFO) {
+            $levelName = "[info]";
+            $color = ""; # none for info
+        } elseif ($event->priority >= SCORE_LOG_DEBUG) {
+            $levelName = "[debug]";
+            $color = "\033[0;94m"; # high intensity blue
+        }
+
         $str = join(" ", [
-            date(DATE_ISO8601),
-            get_real_ip(),
-            $event->section,
-            $username,
+            date("Y-m-d H:i:s"),
+            "[".$event->section."]",
+            $levelName,
+            "[".get_real_ip()." (".$username.")]",
             $event->message
         ]);
-        if ($config->get_bool(LogConsoleConfig::COLOUR)) {
-            if ($event->priority >= SCORE_LOG_WARNING) {
-                // red
-                $COL = "\033[0;31m";
-            } elseif ($event->priority >= SCORE_LOG_INFO) {
-                // default
-                $COL = "";
-            } elseif ($event->priority >= SCORE_LOG_NOTSET) {
-                // blue
-                $COL = "\033[0;34m";
-            } else {
-                // priority < 0 ???
-                // magenta
-                $COL = "\033[0;35m";
-            }
-            $str = "$COL$str\033[0m\n";
+
+        if (strlen($color) > 0 && $config->get_bool(LogConsoleConfig::COLOUR)) {
+            $str = "$color$str\033[0m\n";
         } else {
             $str = "$str\n";
         }
-        if (!defined("UNITTEST") && PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') {
-            $fp = @fopen("php://stdout", "w");
-            if ($fp) {
-                fwrite($fp, $str);
-                fclose($fp);
-            }
+
+        $fp = @fopen("php://stdout", "w");
+        if ($fp) {
+            fwrite($fp, $str);
+            fclose($fp);
         }
     }
 }


### PR DESCRIPTION
Just some little improvements to the logger format resulting in:
![firefox_2025-02-08_21-50-14_(Portainer__local_—_Mozilla_Firefox)_055D](https://github.com/user-attachments/assets/b0b66954-3818-490b-a349-553b59ff3605)

The log levels are checked against the defined `SCORE_LOG_*` values, where a priority is considered in a specific log level when it is at or above the `SCORE_LOG_*` value, with the highest taking precedence over the lower values.