### PR TITLE
do a global config rollback at the end of every test

### DIFF
--- a/core/testcase.php
+++ b/core/testcase.php
@@ -24,6 +24,8 @@ abstract class ShimmiePHPUnitTestCase extends TestBase
     protected static string $admin_name = "demo";
     protected static string $user_name = "test";
     protected string $wipe_time = "test";
+    /** @var array<string, string> */
+    private array $config_snapshot = [];
 
     /**
      * Start a DB transaction for each test class
@@ -41,7 +43,7 @@ abstract class ShimmiePHPUnitTestCase extends TestBase
      */
     public function setUp(): void
     {
-        global $database, $_tracer, $page;
+        global $database, $_tracer, $page, $config;
         $_tracer->begin($this->name());
         $_tracer->begin("setUp");
         $class = str_replace("Test", "", get_class($this));
@@ -60,6 +62,7 @@ abstract class ShimmiePHPUnitTestCase extends TestBase
             send_event(new ImageDeletionEvent(Image::by_id_ex((int)$image_id), true));
         }
         $page = new Page();
+        $this->config_snapshot = $config->values;
 
         $_tracer->end();  # setUp
         $_tracer->begin("test");
@@ -67,8 +70,9 @@ abstract class ShimmiePHPUnitTestCase extends TestBase
 
     public function tearDown(): void
     {
-        global $_tracer, $database;
+        global $_tracer, $config, $database;
         $database->execute("ROLLBACK TO test_start");
+        $config->values = $this->config_snapshot;
         $_tracer->end();  # test
         $_tracer->end();  # $this->getName()
     }

--- a/ext/approval/test.php
+++ b/ext/approval/test.php
@@ -33,11 +33,4 @@ class ApprovalTest extends ShimmiePHPUnitTestCase
         $this->log_in_as_user();
         $this->assert_search_results(["some_tag"], [$image_id]);
     }
-
-    public function tearDown(): void
-    {
-        global $config;
-        $config->set_bool(ApprovalConfig::IMAGES, false);
-        parent::tearDown();
-    }
 }

--- a/ext/comment/test.php
+++ b/ext/comment/test.php
@@ -14,13 +14,6 @@ class CommentListTest extends ShimmiePHPUnitTestCase
         $this->log_out();
     }
 
-    public function tearDown(): void
-    {
-        global $config;
-        $config->set_int(CommentConfig::LIMIT, 10);
-        parent::tearDown();
-    }
-
     public function testCommentsPage(): void
     {
         global $user;

--- a/ext/downtime/test.php
+++ b/ext/downtime/test.php
@@ -6,13 +6,6 @@ namespace Shimmie2;
 
 class DowntimeTest extends ShimmiePHPUnitTestCase
 {
-    public function tearDown(): void
-    {
-        global $config;
-        $config->set_bool("downtime", false);
-        parent::tearDown();
-    }
-
     public function testDowntime(): void
     {
         global $config;

--- a/ext/rating/test.php
+++ b/ext/rating/test.php
@@ -107,9 +107,7 @@ class RatingsTest extends ShimmiePHPUnitTestCase
     // that it doesn't mess with other unrelated tests
     public function tearDown(): void
     {
-        global $config, $user_config;
-        $config->set_array("ext_rating_user_privs", ["?", "s", "q", "e"]);
-        $config->set_array("ext_rating_anonymous_privs", ["?", "s", "q", "e"]);
+        global $user_config;
 
         $this->log_in_as_user();
         $user_config->set_array(RatingsConfig::USER_DEFAULTS, ["?", "s", "q", "e"]);

--- a/ext/ratings_blur/test.php
+++ b/ext/ratings_blur/test.php
@@ -122,8 +122,7 @@ class RatingsBlurTest extends ShimmiePHPUnitTestCase
     // that it doesn't mess with other unrelated tests
     public function tearDown(): void
     {
-        global $config, $user_config;
-        $config->set_array(RatingsBlurConfig::GLOBAL_DEFAULTS, RatingsBlurConfig::DEFAULT_OPTIONS);
+        global $user_config;
 
         $this->log_in_as_user();
         $user_config->set_array(RatingsBlurConfig::USER_DEFAULTS, RatingsBlurConfig::DEFAULT_OPTIONS);

--- a/ext/res_limit/test.php
+++ b/ext/res_limit/test.php
@@ -66,18 +66,4 @@ class ResolutionLimitTest extends ShimmiePHPUnitTestCase
         });
         $this->assertEquals("Post needs to be in one of these ratios: 16:9", $e->getMessage());
     }
-
-    # reset to defaults, otherwise this can interfere with
-    # other extensions' test suites
-    public function tearDown(): void
-    {
-        global $config;
-        $config->delete("upload_min_height");
-        $config->delete("upload_min_width");
-        $config->delete("upload_max_height");
-        $config->delete("upload_max_width");
-        $config->delete("upload_ratios");
-
-        parent::tearDown();
-    }
 }


### PR DESCRIPTION
Humans gonna human, and the human error of leaving a `$config` setting with a weird value at the end of a unit test is a nightmare to debug - let's make sure to clean them up every time