### PR TITLE
s/global $user_config/$user->get_config()/

### DIFF
--- a/core/user.php
+++ b/core/user.php
@@ -27,6 +27,7 @@ class User
     public ?string $passhash;
     #[Field]
     public UserClass $class;
+    private ?Config $config = null;
 
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
     * Initialisation                                               *
@@ -56,6 +57,16 @@ class User
         } else {
             throw new ServerError("User '{$this->name}' has invalid class '{$row["class"]}'");
         }
+    }
+
+    public function get_config(): Config
+    {
+        global $database;
+        if (is_null($this->config)) {
+            $this->config = new DatabaseConfig($database, "user_config", "user_id", "{$this->id}");
+            send_event(new InitUserConfigEvent($this, $this->config));
+        }
+        return $this->config;
     }
 
     #[Query]

--- a/ext/avatar_post/main.php
+++ b/ext/avatar_post/main.php
@@ -25,7 +25,7 @@ class AvatarPost extends AvatarExtension
 
     public function onPageRequest(PageRequestEvent $event): void
     {
-        global $page, $user, $user_config;
+        global $page, $user;
         if ($event->page_matches("set_avatar/{image_id}", method: "POST", permission: Permissions::CHANGE_USER_SETTING)) {
             $image_id = int_escape($event->get_arg('image_id'));
             $page->set_mode(PageMode::REDIRECT);
@@ -35,7 +35,7 @@ class AvatarPost extends AvatarExtension
             $this->theme->display_avatar_edit_page($page, $image_id);
         } elseif ($event->page_matches("save_avatar", method: "POST", permission: Permissions::CHANGE_USER_SETTING)) {
             $settings = ConfigSaveEvent::postToSettings($event->POST);
-            send_event(new ConfigSaveEvent($user_config, $settings));
+            send_event(new ConfigSaveEvent($user->get_config(), $settings));
             $page->flash("Image set as avatar");
             $page->set_mode(PageMode::REDIRECT);
             if (key_exists(AvatarPostConfig::AVATAR_ID, $settings) && is_int($settings[AvatarPostConfig::AVATAR_ID])) {
@@ -48,10 +48,10 @@ class AvatarPost extends AvatarExtension
 
     public function onUserOptionsBuilding(UserOptionsBuildingEvent $event): void
     {
-        global $config, $user_config;
+        global $config, $user;
         $sb = $event->panel->create_new_block("Avatar");
         $sb->add_int_option(AvatarPostConfig::AVATAR_ID, 'Avatar post ID: ');
-        $image_id = $user_config->get_int(AvatarPostConfig::AVATAR_ID, null);
+        $image_id = $user->get_config()->get_int(AvatarPostConfig::AVATAR_ID, null);
         if (!is_null($image_id)) {
             $sb->add_label("<br><a href=".make_link("set_avatar/$image_id").">Change cropping</a>");
         }
@@ -85,7 +85,7 @@ class AvatarPost extends AvatarExtension
     public function get_avatar_html(User $user): HTMLElement|null
     {
         global $database, $config;
-        $user_config = UserConfig::get_for_user($user);
+        $user_config = $user->get_config();
         $id = $user_config->get_int(AvatarPostConfig::AVATAR_ID, 0);
         if ($id === 0) {
             return null;

--- a/ext/avatar_post/theme.php
+++ b/ext/avatar_post/theme.php
@@ -12,7 +12,7 @@ class AvatarPostTheme extends Themelet
 {
     public function display_avatar_edit_page(Page $page, int $image_id): void
     {
-        global $user, $user_config;
+        global $user;
         /** @var BuildAvatarEvent $avatar_e */
         $avatar_e = send_event(new BuildAvatarEvent($user));
         $current = $avatar_e->html;

--- a/ext/biography/main.php
+++ b/ext/biography/main.php
@@ -13,8 +13,7 @@ class Biography extends Extension
     {
         global $page, $user;
         $duser = $event->display_user;
-        $duser_config = UserConfig::get_for_user($event->display_user);
-        $bio = $duser_config->get_string("biography", "");
+        $bio = $duser->get_config()->get_string("biography", "");
 
         if ($user->id == $duser->id) {
             $this->theme->display_composer($page, $bio);
@@ -25,11 +24,11 @@ class Biography extends Extension
 
     public function onPageRequest(PageRequestEvent $event): void
     {
-        global $page, $user, $user_config;
+        global $page, $user;
         if ($event->page_matches("biography", method: "POST")) {
             $bio = $event->get_POST('biography');
             log_info("biography", "Set biography to $bio");
-            $user_config->set_string("biography", $bio);
+            $user->get_config()->set_string("biography", $bio);
             $page->flash("Bio Updated");
             $page->set_mode(PageMode::REDIRECT);
             $page->set_redirect(referer_or(make_link()));

--- a/ext/cron_uploader/main.php
+++ b/ext/cron_uploader/main.php
@@ -110,11 +110,11 @@ class CronUploader extends Extension
 
     public function onLog(LogEvent $event): void
     {
-        global $user_config;
+        global $user;
 
         if (self::$IMPORT_RUNNING) {
-            $all = $user_config->get_bool(CronUploaderConfig::INCLUDE_ALL_LOGS);
-            if ($event->priority >= $user_config->get_int(CronUploaderConfig::LOG_LEVEL) &&
+            $all = $user->get_config()->get_bool(CronUploaderConfig::INCLUDE_ALL_LOGS);
+            if ($event->priority >= $user->get_config()->get_int(CronUploaderConfig::LOG_LEVEL) &&
                 ($event->section == self::NAME || $all)) {
                 $output = "[" . date('Y-m-d H:i:s') . "] " . ($all ? '[' . $event->section . '] ' : '') . "[" . LOGGING_LEVEL_NAMES[$event->priority] . "] " . $event->message;
 
@@ -186,8 +186,8 @@ class CronUploader extends Extension
 
     private function clear_folder(string $folder): void
     {
-        global $page, $user_config;
-        $path = join_path($user_config->get_string(CronUploaderConfig::DIR), $folder);
+        global $page, $user;
+        $path = join_path($user->get_config()->get_string(CronUploaderConfig::DIR), $folder);
         deltree($path);
         $page->flash("Cleared $path");
     }
@@ -195,9 +195,9 @@ class CronUploader extends Extension
 
     private function get_cron_url(): string
     {
-        global $user_config;
+        global $user;
 
-        $user_api_key = $user_config->get_string(UserConfig::API_KEY, "API_KEY");
+        $user_api_key = $user->get_config()->get_string(UserConfig::API_KEY, "API_KEY");
 
         return make_http(make_link("/cron_upload/run", "api_key=".urlencode($user_api_key)));
     }
@@ -255,34 +255,34 @@ class CronUploader extends Extension
 
     public function get_queue_dir(): string
     {
-        global $user_config;
+        global $user;
 
-        $dir = $user_config->get_string(CronUploaderConfig::DIR);
+        $dir = $user->get_config()->get_string(CronUploaderConfig::DIR);
         return join_path($dir, self::QUEUE_DIR);
     }
 
     public function get_uploaded_dir(): string
     {
-        global $user_config;
+        global $user;
 
-        $dir = $user_config->get_string(CronUploaderConfig::DIR);
+        $dir = $user->get_config()->get_string(CronUploaderConfig::DIR);
         return join_path($dir, self::UPLOADED_DIR);
     }
 
     public function get_failed_dir(): string
     {
-        global $user_config;
+        global $user;
 
-        $dir = $user_config->get_string(CronUploaderConfig::DIR);
+        $dir = $user->get_config()->get_string(CronUploaderConfig::DIR);
         return join_path($dir, self::FAILED_DIR);
     }
 
     private function prep_root_dir(): string
     {
-        global $user_config;
+        global $user;
 
         // Determine directory (none = default)
-        $dir = $user_config->get_string(CronUploaderConfig::DIR);
+        $dir = $user->get_config()->get_string(CronUploaderConfig::DIR);
 
         // Make the directory if it doesn't exist yet
         if (!is_dir($this->get_queue_dir())) {
@@ -300,9 +300,9 @@ class CronUploader extends Extension
 
     private function get_lock_file(): string
     {
-        global $user_config;
+        global $user;
 
-        $root_dir = $user_config->get_string(CronUploaderConfig::DIR);
+        $root_dir = $user->get_config()->get_string(CronUploaderConfig::DIR);
         return join_path($root_dir, ".lock");
     }
 
@@ -311,7 +311,7 @@ class CronUploader extends Extension
      */
     public function process_upload(): bool
     {
-        global $database, $user, $user_config, $config, $_shm_load_start;
+        global $database, $user, $config, $_shm_load_start;
 
         $max_time = intval(ini_get('max_execution_time')) * .8;
 
@@ -375,7 +375,7 @@ class CronUploader extends Extension
                     $failed++;
                     $this->log_message(SCORE_LOG_ERROR, "(" . gettype($e) . ") " . $e->getMessage());
                     $this->log_message(SCORE_LOG_ERROR, $e->getTraceAsString());
-                    if ($user_config->get_bool(CronUploaderConfig::STOP_ON_ERROR)) {
+                    if ($user->get_config()->get_bool(CronUploaderConfig::STOP_ON_ERROR)) {
                         break;
                     } else {
                         $this->move_uploaded($img[0], $img[1], $output_subdir, true);
@@ -404,9 +404,9 @@ class CronUploader extends Extension
 
     private function move_uploaded(string $path, string $filename, string $output_subdir, bool $corrupt = false): void
     {
-        global $user_config;
+        global $user;
 
-        $rootDir = $user_config->get_string(CronUploaderConfig::DIR);
+        $rootDir = $user->get_config()->get_string(CronUploaderConfig::DIR);
         $rootLength = strlen($rootDir);
         if ($rootDir[$rootLength - 1] == "/" || $rootDir[$rootLength - 1] == "\\") {
             $rootLength--;
@@ -514,9 +514,9 @@ class CronUploader extends Extension
 
     private function get_log_file(): string
     {
-        global $user_config;
+        global $user;
 
-        $dir = $user_config->get_string(CronUploaderConfig::DIR);
+        $dir = $user->get_config()->get_string(CronUploaderConfig::DIR);
 
         return join_path($dir, "uploads.log");
     }

--- a/ext/cron_uploader/theme.php
+++ b/ext/cron_uploader/theme.php
@@ -34,7 +34,7 @@ class CronUploaderTheme extends Themelet
         string $cron_url,
         ?array $log_entries
     ): void {
-        global $page, $config, $user_config;
+        global $page, $config, $user;
 
         $info_html = "";
 
@@ -109,7 +109,7 @@ class CronUploaderTheme extends Themelet
                 <li>If an import is already running, another cannot start until it is done.</li>
                 <li>Each time it runs it will import for up to ".number_format($max_time)." seconds. This is controlled by the PHP max execution time.</li>
                 <li>Uploaded images will be moved to the 'uploaded' directory into a subfolder named after the time the import started. It's recommended that you remove everything out of this directory from time to time. If you have admin controls enabled, this can be done from <a href='".make_link("admin")."'>Board Admin</a>.</li>
-                <li>If you enable the db logging extension, you can view the log output on this screen. Otherwise the log will be written to a file at ".$user_config->get_string(CronUploaderConfig::DIR).DIRECTORY_SEPARATOR."uploads.log</li>
+                <li>If you enable the db logging extension, you can view the log output on this screen. Otherwise the log will be written to a file at ".$user->get_config()->get_string(CronUploaderConfig::DIR).DIRECTORY_SEPARATOR."uploads.log</li>
 			</ul>
         ";
 

--- a/ext/filter/theme.php
+++ b/ext/filter/theme.php
@@ -10,11 +10,11 @@ class FilterTheme extends Themelet
 {
     public function addFilterBox(): void
     {
-        global $config, $page, $user, $user_config;
+        global $config, $page, $user;
 
         // If user is not able to set their own filters, use the default filters.
         if ($user->can(Permissions::CHANGE_USER_SETTING)) {
-            $tags = $user_config->get_string("filter_tags");
+            $tags = $user->get_config()->get_string("filter_tags");
         } else {
             $tags = $config->get_string("filter_tags");
         }

--- a/ext/private_image/main.php
+++ b/ext/private_image/main.php
@@ -34,7 +34,7 @@ class PrivateImage extends Extension
 
     public function onPageRequest(PageRequestEvent $event): void
     {
-        global $page, $user, $user_config;
+        global $page, $user;
 
         if ($event->page_matches("privatize_image/{image_id}", method: "POST", permission: Permissions::SET_PRIVATE_IMAGE)) {
             $image_id = $event->get_iarg('image_id');
@@ -68,8 +68,8 @@ class PrivateImage extends Extension
             $set_default = array_key_exists("set_default", $event->POST);
             $view_default = array_key_exists("view_default", $event->POST);
 
-            $user_config->set_bool(PrivateImageConfig::USER_SET_DEFAULT, $set_default);
-            $user_config->set_bool(PrivateImageConfig::USER_VIEW_DEFAULT, $view_default);
+            $user->get_config()->set_bool(PrivateImageConfig::USER_SET_DEFAULT, $set_default);
+            $user->get_config()->set_bool(PrivateImageConfig::USER_VIEW_DEFAULT, $view_default);
 
             $page->set_mode(PageMode::REDIRECT);
             $page->set_redirect(make_link("user"));
@@ -89,8 +89,8 @@ class PrivateImage extends Extension
     public const SEARCH_REGEXP = "/^private:(yes|no|any)/i";
     public function onSearchTermParse(SearchTermParseEvent $event): void
     {
-        global $user, $user_config;
-        $show_private = $user_config->get_bool(PrivateImageConfig::USER_VIEW_DEFAULT);
+        global $user;
+        $show_private = $user->get_config()->get_bool(PrivateImageConfig::USER_VIEW_DEFAULT);
 
         if (is_null($event->term) && $this->no_private_query($event->context)) {
             if ($show_private) {
@@ -190,8 +190,8 @@ class PrivateImage extends Extension
 
     public function onImageAddition(ImageAdditionEvent $event): void
     {
-        global $user, $user_config;
-        if ($user_config->get_bool(PrivateImageConfig::USER_SET_DEFAULT) && $user->can(Permissions::SET_PRIVATE_IMAGE)) {
+        global $user;
+        if ($user->get_config()->get_bool(PrivateImageConfig::USER_SET_DEFAULT) && $user->can(Permissions::SET_PRIVATE_IMAGE)) {
             self::privatize_image($event->image->id);
         }
     }

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -464,10 +464,10 @@ class Ratings extends Extension
      */
     public static function get_user_default_ratings(): array
     {
-        global $user_config, $user;
+        global $user;
 
         $available = self::get_user_class_privs($user);
-        $selected = $user_config->get_array(RatingsConfig::USER_DEFAULTS);
+        $selected = $user->get_config()->get_array(RatingsConfig::USER_DEFAULTS);
 
         return array_intersect($available, $selected);
     }

--- a/ext/rating/test.php
+++ b/ext/rating/test.php
@@ -41,7 +41,7 @@ class RatingsTest extends ShimmiePHPUnitTestCase
 
     public function testUserConfig(): void
     {
-        global $config, $user_config;
+        global $config, $user;
 
         // post a safe image and an explicit image
         $this->log_in_as_user();
@@ -56,7 +56,7 @@ class RatingsTest extends ShimmiePHPUnitTestCase
         $config->set_array("ext_rating_user_privs", ["s", "q", "e"]);
 
         // user prefers safe-only by default
-        $user_config->set_array(RatingsConfig::USER_DEFAULTS, ["s"]);
+        $user->get_config()->set_array(RatingsConfig::USER_DEFAULTS, ["s"]);
 
         // search with no tags should return only safe image
         $this->assert_search_results([], [$image_id_s]);
@@ -67,7 +67,7 @@ class RatingsTest extends ShimmiePHPUnitTestCase
 
         // If user prefers to see all images, going to the safe image
         // and clicking next should show the explicit image
-        $user_config->set_array(RatingsConfig::USER_DEFAULTS, ["s", "q", "e"]);
+        $user->get_config()->set_array(RatingsConfig::USER_DEFAULTS, ["s", "q", "e"]);
         $next = $image_s->get_next();
         $this->assertNotNull($next);
         $this->assertEquals($next->id, $image_id_e);
@@ -75,13 +75,13 @@ class RatingsTest extends ShimmiePHPUnitTestCase
         // If the user prefers to see only safe images by default, then
         // going to the safe image and clicking next should not show
         // the explicit image (See bug #984)
-        $user_config->set_array(RatingsConfig::USER_DEFAULTS, ["s"]);
+        $user->get_config()->set_array(RatingsConfig::USER_DEFAULTS, ["s"]);
         $this->assertEquals($image_s->get_next(), null);
     }
 
     public function testCountImages(): void
     {
-        global $config, $user_config;
+        global $config, $user;
 
         $this->log_in_as_user();
 
@@ -96,7 +96,7 @@ class RatingsTest extends ShimmiePHPUnitTestCase
         send_event(new RatingSetEvent($image_e, "e"));
 
         $config->set_array("ext_rating_user_privs", ["s", "q"]);
-        $user_config->set_array(RatingsConfig::USER_DEFAULTS, ["s"]);
+        $user->get_config()->set_array(RatingsConfig::USER_DEFAULTS, ["s"]);
 
         $this->assertEquals(1, Search::count_images(["rating=s"]), "UserClass has access to safe, show safe");
         $this->assertEquals(2, Search::count_images(["rating=*"]), "UserClass has access to s/q - if user asks for everything, show those two but hide e");
@@ -107,10 +107,10 @@ class RatingsTest extends ShimmiePHPUnitTestCase
     // that it doesn't mess with other unrelated tests
     public function tearDown(): void
     {
-        global $user_config;
+        global $user;
 
         $this->log_in_as_user();
-        $user_config->set_array(RatingsConfig::USER_DEFAULTS, ["?", "s", "q", "e"]);
+        $user->get_config()->set_array(RatingsConfig::USER_DEFAULTS, ["?", "s", "q", "e"]);
 
         parent::tearDown();
     }

--- a/ext/ratings_blur/main.php
+++ b/ext/ratings_blur/main.php
@@ -59,9 +59,9 @@ class RatingsBlur extends Extension
 
     public function blur(string $rating): bool
     {
-        global $user_config;
+        global $user;
 
-        $blur_ratings = $user_config->get_array(RatingsBlurConfig::USER_DEFAULTS);
+        $blur_ratings = $user->get_config()->get_array(RatingsBlurConfig::USER_DEFAULTS);
         if (in_array(RatingsBlurConfig::NULL_OPTION, $blur_ratings)) {
             return false;
         }

--- a/ext/ratings_blur/test.php
+++ b/ext/ratings_blur/test.php
@@ -30,7 +30,7 @@ class RatingsBlurTest extends ShimmiePHPUnitTestCase
 
     public function testRatingBlurGlobalConfig(): void
     {
-        global $config, $user_config;
+        global $config;
 
         // change global setting: don't blur explict, only blur safe
         $config->set_array(RatingsBlurConfig::GLOBAL_DEFAULTS, ["s"]);
@@ -67,14 +67,14 @@ class RatingsBlurTest extends ShimmiePHPUnitTestCase
 
     public function testRatingBlurUserConfig(): void
     {
-        global $config, $user_config;
+        global $config, $user;
         // set global default to blur all, so we can test it is overriden
         $config->set_array(RatingsBlurConfig::GLOBAL_DEFAULTS, array_keys(ImageRating::$known_ratings));
 
         $this->log_in_as_user();
 
         // don't blur explict, blur safe
-        $user_config->set_array(RatingsBlurConfig::USER_DEFAULTS, ["s"]);
+        $user->get_config()->set_array(RatingsBlurConfig::USER_DEFAULTS, ["s"]);
 
         $image_id_e = $this->post_image("tests/bedroom_workshop.jpg", "bedroom");
         $image_e = Image::by_id_ex($image_id_e);
@@ -93,7 +93,7 @@ class RatingsBlurTest extends ShimmiePHPUnitTestCase
         $this->assert_text("blur");
 
         // don't blur any
-        $user_config->set_array(RatingsBlurConfig::USER_DEFAULTS, [RatingsBlurConfig::NULL_OPTION]);
+        $user->get_config()->set_array(RatingsBlurConfig::USER_DEFAULTS, [RatingsBlurConfig::NULL_OPTION]);
 
         $this->get_page("post/list");
         $this->assert_no_text("blur");
@@ -122,10 +122,10 @@ class RatingsBlurTest extends ShimmiePHPUnitTestCase
     // that it doesn't mess with other unrelated tests
     public function tearDown(): void
     {
-        global $user_config;
+        global $user;
 
         $this->log_in_as_user();
-        $user_config->set_array(RatingsBlurConfig::USER_DEFAULTS, RatingsBlurConfig::DEFAULT_OPTIONS);
+        $user->get_config()->set_array(RatingsBlurConfig::USER_DEFAULTS, RatingsBlurConfig::DEFAULT_OPTIONS);
 
         parent::tearDown();
     }

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -386,9 +386,7 @@ class UserPage extends Extension
 
         if (!$user->is_anonymous()) {
             if ($user->id == $event->display_user->id || $user->can("edit_user_info")) {
-                $user_config = UserConfig::get_for_user($event->display_user);
-
-                $uobe = send_event(new UserOperationsBuildingEvent($event->display_user, $user_config));
+                $uobe = send_event(new UserOperationsBuildingEvent($event->display_user, $event->display_user->get_config()));
                 $page->add_block(new Block("Operations", $this->theme->build_operations($event->display_user, $uobe), "main", 60));
             }
         }


### PR DESCRIPTION

Global variables are a pain, doubly so when you have two global variables which need to be kept in sync or things will go very very badly (`$user` and `$user_config`). Having a global `$user` feels like an acceptable tradeoff, but `$user_config` is redundant.
