### PR TITLE
Move base test case to core/tests/ rather than core/

### DIFF
--- a/core/tests/ShimmiePHPUnitTestCase.php
+++ b/core/tests/ShimmiePHPUnitTestCase.php
@@ -4,21 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-try {
-    abstract class TestBase extends \PHPUnit\Framework\TestCase
-    {
-    }
-}
-// @phpstan-ignore-next-line
-catch (\Throwable $e) {
-    abstract class TestBase
-    {
-        abstract public function name(): string;
-        abstract public static function assertEquals(mixed $expected, mixed $actual, string $message = ''): void;
-    }
-}
-
-abstract class ShimmiePHPUnitTestCase extends TestBase
+abstract class ShimmiePHPUnitTestCase extends \PHPUnit\Framework\TestCase
 {
     protected const ANON_NAME = "anonymous";
     protected const ADMIN_NAME = "demo";

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,7 @@ require_once "tests/defines.php";
 require_once "core/sys_config.php";
 require_once "core/polyfills.php";
 require_once "core/util.php";
+require_once "core/tests/ShimmiePHPUnitTestCase.php";
 
 $_SERVER['SCRIPT_FILENAME'] = '/var/www/html/test/index.php';
 $_SERVER['DOCUMENT_ROOT'] = '/var/www/html';


### PR DESCRIPTION

There was a lot of magic to ensure that this file didn't crash when loaded as part of `core/*.php`... but we could just _not_ load it as part of `core/*.php`
