### PR TITLE
Use an enum for log levels

### DIFF
--- a/core/cli_app.php
+++ b/core/cli_app.php
@@ -41,16 +41,16 @@ class CliApp extends \Symfony\Component\Console\Application
             send_event(new UserLoginEvent($user));
         }
 
-        $log_level = SCORE_LOG_WARNING;
+        $log_level = LogLevel::WARNING->value;
         if (true === $input->hasParameterOption(['--quiet', '-q'], true)) {
-            $log_level = SCORE_LOG_ERROR;
+            $log_level = LogLevel::ERROR->value;
         } else {
             if ($input->hasParameterOption('-vvv', true) || $input->hasParameterOption('--verbose=3', true) || 3 === $input->getParameterOption('--verbose', false, true)) {
-                $log_level = SCORE_LOG_DEBUG;
+                $log_level = LogLevel::DEBUG->value;
             } elseif ($input->hasParameterOption('-vv', true) || $input->hasParameterOption('--verbose=2', true) || 2 === $input->getParameterOption('--verbose', false, true)) {
-                $log_level = SCORE_LOG_DEBUG;
+                $log_level = LogLevel::DEBUG->value;
             } elseif ($input->hasParameterOption('-v', true) || $input->hasParameterOption('--verbose=1', true) || $input->hasParameterOption('--verbose', true) || $input->getParameterOption('--verbose', false, true)) {
-                $log_level = SCORE_LOG_INFO;
+                $log_level = LogLevel::INFO->value;
             }
         }
         if (!defined("CLI_LOG_LEVEL")) {

--- a/core/logging.php
+++ b/core/logging.php
@@ -8,28 +8,27 @@ namespace Shimmie2;
 * Logging convenience                                                       *
 \* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-define("SCORE_LOG_CRITICAL", 50);
-define("SCORE_LOG_ERROR", 40);
-define("SCORE_LOG_WARNING", 30);
-define("SCORE_LOG_INFO", 20);
-define("SCORE_LOG_DEBUG", 10);
-define("SCORE_LOG_NOTSET", 0);
+enum LogLevel: int
+{
+    case NOT_SET = 0;
+    case DEBUG = 10;
+    case INFO = 20;
+    case WARNING = 30;
+    case ERROR = 40;
+    case CRITICAL = 50;
 
-const LOGGING_LEVEL_NAMES = [
-    SCORE_LOG_NOTSET => "Not Set",
-    SCORE_LOG_DEBUG => "Debug",
-    SCORE_LOG_INFO => "Info",
-    SCORE_LOG_WARNING => "Warning",
-    SCORE_LOG_ERROR => "Error",
-    SCORE_LOG_CRITICAL => "Critical",
-];
-const LOGGING_LEVEL_NAMES_TO_LEVELS = [
-    LOGGING_LEVEL_NAMES[SCORE_LOG_DEBUG] => SCORE_LOG_DEBUG,
-    LOGGING_LEVEL_NAMES[SCORE_LOG_INFO] => SCORE_LOG_INFO,
-    LOGGING_LEVEL_NAMES[SCORE_LOG_WARNING] => SCORE_LOG_WARNING,
-    LOGGING_LEVEL_NAMES[SCORE_LOG_ERROR] => SCORE_LOG_ERROR,
-    LOGGING_LEVEL_NAMES[SCORE_LOG_CRITICAL] => SCORE_LOG_CRITICAL,
-];
+    /**
+     * @return array<string, int>
+     */
+    public static function names_to_levels(): array
+    {
+        $ret = [];
+        foreach (LogLevel::cases() as $case) {
+            $ret[$case->name] = $case->value;
+        }
+        return $ret;
+    }
+}
 
 /**
  * A shorthand way to send a LogEvent
@@ -38,13 +37,13 @@ const LOGGING_LEVEL_NAMES_TO_LEVELS = [
  * When taking action, a log event should be stored by the server
  * Quite often, both of these happen at once, hence log_*() having $flash
  */
-function log_msg(string $section, int $priority, string $message, ?string $flash = null): void
+function log_msg(string $section, LogLevel $priority, string $message, ?string $flash = null): void
 {
     global $page;
-    send_event(new LogEvent($section, $priority, $message));
+    send_event(new LogEvent($section, $priority->value, $message));
     $threshold = defined("CLI_LOG_LEVEL") ? CLI_LOG_LEVEL : 0;
 
-    if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && ($priority >= $threshold)) {
+    if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && ($priority->value >= $threshold)) {
         print date("c")." $section: $message\n";
         ob_flush();
     }
@@ -56,23 +55,23 @@ function log_msg(string $section, int $priority, string $message, ?string $flash
 // More shorthand ways of logging
 function log_debug(string $section, string $message, ?string $flash = null): void
 {
-    log_msg($section, SCORE_LOG_DEBUG, $message, $flash);
+    log_msg($section, LogLevel::DEBUG, $message, $flash);
 }
 function log_info(string $section, string $message, ?string $flash = null): void
 {
-    log_msg($section, SCORE_LOG_INFO, $message, $flash);
+    log_msg($section, LogLevel::INFO, $message, $flash);
 }
 function log_warning(string $section, string $message, ?string $flash = null): void
 {
-    log_msg($section, SCORE_LOG_WARNING, $message, $flash);
+    log_msg($section, LogLevel::WARNING, $message, $flash);
 }
 function log_error(string $section, string $message, ?string $flash = null): void
 {
-    log_msg($section, SCORE_LOG_ERROR, $message, $flash);
+    log_msg($section, LogLevel::ERROR, $message, $flash);
 }
 function log_critical(string $section, string $message, ?string $flash = null): void
 {
-    log_msg($section, SCORE_LOG_CRITICAL, $message, $flash);
+    log_msg($section, LogLevel::CRITICAL, $message, $flash);
 }
 
 

--- a/ext/log_console/main.php
+++ b/ext/log_console/main.php
@@ -11,7 +11,7 @@ class LogConsole extends Extension
         global $config;
         $config->set_default_bool(LogConsoleConfig::LOG_ACCESS, true);
         $config->set_default_bool(LogConsoleConfig::COLOUR, true);
-        $config->set_default_int(LogConsoleConfig::LEVEL, SCORE_LOG_INFO);
+        $config->set_default_int(LogConsoleConfig::LEVEL, LogLevel::INFO->value);
     }
 
     public function onSetupBuilding(SetupBuildingEvent $event): void
@@ -19,7 +19,7 @@ class LogConsole extends Extension
         $sb = $event->panel->create_new_block("Logging (Console)");
         $sb->add_bool_option(LogConsoleConfig::LOG_ACCESS, "Log page requests: ");
         $sb->add_bool_option(LogConsoleConfig::COLOUR, "<br>Log with colour: ");
-        $sb->add_choice_option(LogConsoleConfig::LEVEL, LOGGING_LEVEL_NAMES_TO_LEVELS, "<br>Log Level: ");
+        $sb->add_choice_option(LogConsoleConfig::LEVEL, LogLevel::names_to_levels(), "<br>Log Level: ");
     }
 
     public function onPageRequest(PageRequestEvent $event): void
@@ -32,7 +32,7 @@ class LogConsole extends Extension
         ) {
             $this->log(new LogEvent(
                 "access",
-                SCORE_LOG_INFO,
+                LogLevel::INFO->value,
                 "{$_SERVER['REQUEST_METHOD']} {$_SERVER['REQUEST_URI']}"
             ));
         }
@@ -67,19 +67,19 @@ class LogConsole extends Extension
 
         $levelName = "[unknown]";
         $color = "\033[0;35m"; # purple for unknown levels
-        if ($event->priority >= SCORE_LOG_CRITICAL) {
+        if ($event->priority >= LogLevel::CRITICAL->value) {
             $levelName = "[critical]";
             $color = "\033[0;31m"; # red
-        } elseif ($event->priority >= SCORE_LOG_ERROR) {
+        } elseif ($event->priority >= LogLevel::ERROR->value) {
             $levelName = "[error]";
             $color = "\033[0;91m"; # high intensity red
-        } elseif ($event->priority >= SCORE_LOG_WARNING) {
+        } elseif ($event->priority >= LogLevel::WARNING->value) {
             $levelName = "[warning]";
             $color = "\033[0;33m"; # yellow
-        } elseif ($event->priority >= SCORE_LOG_INFO) {
+        } elseif ($event->priority >= LogLevel::INFO->value) {
             $levelName = "[info]";
             $color = ""; # none for info
-        } elseif ($event->priority >= SCORE_LOG_DEBUG) {
+        } elseif ($event->priority >= LogLevel::DEBUG->value) {
             $levelName = "[debug]";
             $color = "\033[0;94m"; # high intensity blue
         }

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -10,7 +10,6 @@ parameters:
     - TRUSTED_PROXIES
     - TIMEZONE
     - BASE_HREF
-    - STATSD_HOST
     - TRACE_FILE
     - UNITTEST
   ignoreErrors:


### PR DESCRIPTION

Avoiding a random handful of disconnected constants in the global namespace
