### PR TITLE
[user] fix the redirect setting to work properly again

### DIFF
--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -554,7 +554,7 @@ class UserPage extends Extension
         $duser->set_login_cookie();
         $page->set_mode(PageMode::REDIRECT);
 
-        if ($config->get_string(UserAccountsConfig::LOGIN_REDIRECT, "previous")) {
+        if ($config->get_string(UserAccountsConfig::LOGIN_REDIRECT, "previous") === "previous") {
             $page->set_redirect(referer_or(make_link(), ["user/"]));
         } else {
             $page->set_redirect(make_link("user"));


### PR DESCRIPTION
Broken in commit a833f5fa5c7d390fef28968196e4a8ef435da15e
Where the setting before relied on `0` being interpreted as false in php, now the value is a string, and thus will always evaluate as true unless empty string which is not possible with the default given, nor the options given in `user/config.php`.
before:
`if ($config->get_int("user_loginshowprofile", 0))`