### PR TITLE
[core] stricter validation for make_link

### DIFF
--- a/core/tests/UrlsTest.php
+++ b/core/tests/UrlsTest.php
@@ -63,12 +63,6 @@ class UrlsTest extends TestCase
                 make_link("foo")
             );
 
-            // remove leading slash from path
-            $this->assertEquals(
-                $nice_urls ? "/test/foo" : "/test/index.php?q=foo",
-                make_link("/foo")
-            );
-
             // query
             $this->assertEquals(
                 $nice_urls ? "/test/foo?a=1&b=2" : "/test/index.php?q=foo&a=1&b=2",
@@ -87,6 +81,20 @@ class UrlsTest extends TestCase
                 make_link("foo", "a=1&b=2", "cake")
             );
         }
+    }
+
+    #[Depends("test_make_link")]
+    public function test_make_link_exception(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        make_link("/foo");
+    }
+
+    #[Depends("test_make_link")]
+    public function test_make_link_double_exception(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        make_link(make_link("foo"));
     }
 
     #[Depends("test_make_link")]

--- a/core/urls.php
+++ b/core/urls.php
@@ -49,9 +49,11 @@ function make_link(?string $page = null, ?string $query = null, ?string $fragmen
     global $config;
 
     if (is_null($page)) {
-        $page = $config->get_string(SetupConfig::MAIN_PAGE);
+        $page = trim($config->get_string(SetupConfig::MAIN_PAGE), "/");
     }
-    $page = trim($page, "/");
+    if (str_starts_with($page, "/")) {
+        throw new \InvalidArgumentException("make_link($page): page cannot start with a slash");
+    }
 
     $parts = [];
     $install_dir = get_base_href();

--- a/ext/et/main.php
+++ b/ext/et/main.php
@@ -84,7 +84,7 @@ class ET extends Extension
             "about" => [
                 'title' => $config->get_string(SetupConfig::TITLE),
                 'theme' => $config->get_string(SetupConfig::THEME),
-                'url'   => make_http(make_link("/")),
+                'url'   => make_http(make_link("")),
             ],
             "versions" => [
                 'shimmie' => $ver,

--- a/ext/reverse_search_links/theme.php
+++ b/ext/reverse_search_links/theme.php
@@ -26,7 +26,7 @@ class ReverseSearchLinksTheme extends Themelet
         $html = "";
         foreach ($links as $name => $link) {
             if (in_array($name, $enabled_services)) {
-                $icon_link = make_link("/ext/reverse_search_links/icons/" . strtolower($name) . ".ico");
+                $icon_link = get_base_href() . "/ext/reverse_search_links/icons/" . strtolower($name) . ".ico";
                 $html .= "<a href='$link' class='reverse_image_link' rel='nofollow'><img title='Search with $name' src='$icon_link' alt='$name icon'></a>";
             }
         }


### PR DESCRIPTION

This should stop `make_link(make_link("foo"))` from slipping through
