### PR TITLE
Fix navlink bug in extensions

### DIFF
--- a/ext/approval/main.php
+++ b/ext/approval/main.php
@@ -93,7 +93,7 @@ class Approval extends Extension
         global $user;
         if ($event->parent == "posts") {
             if ($user->can(ApprovalPermission::APPROVE_IMAGE)) {
-                $event->add_nav_link("posts_unapproved", new Link('/post/list/approved%3Ano/1'), "Pending Approval", null, 60);
+                $event->add_nav_link("posts_unapproved", new Link('post/list/approved%3Ano/1'), "Pending Approval", null, 60);
             }
         }
     }

--- a/ext/trash/main.php
+++ b/ext/trash/main.php
@@ -75,7 +75,7 @@ class Trash extends Extension
         global $user;
         if ($event->parent == "posts") {
             if ($user->can(TrashPermission::VIEW_TRASH)) {
-                $event->add_nav_link("posts_trash", new Link('/post/list/in%3Atrash/1'), "Trash", null, 60);
+                $event->add_nav_link("posts_trash", new Link('post/list/in%3Atrash/1'), "Trash", null, 60);
             }
         }
     }


### PR DESCRIPTION
Using a leading slash in the navlinks causes the post list to fail to load with the following error:
```php
Internal Error
Message: make_link(/post/list/in%3Atrash/1): page cannot start with a slash

Version: 2.12.0-alpha (on 8.4.4)

Stack Trace:

#0 /app/core/urls.php(20): Shimmie2\make_link()
#1 /app/themes/danbooru2/page.class.php(142): Shimmie2\Link->make_link()
#2 /app/themes/danbooru2/page.class.php(108): Shimmie2\Danbooru2Page->navlinks()
#3 /app/core/page.php(565): Shimmie2\Danbooru2Page->body_html()
#4 /app/core/page.php(289): Shimmie2\Page->render()
#5 /app/index.php(106): Shimmie2\Page->display()
#6 /app/index.php(153): Shimmie2\main()
#7 {main}
```
Only affected extensions seems to be trash and approval.