### PR TITLE
[perm manager] defer getting UserClass parent

### DIFF
--- a/core/User/UserClass.php
+++ b/core/User/UserClass.php
@@ -13,26 +13,21 @@ class UserClass
     /** @var array<string, UserClass> */
     public static array $known_classes = [];
 
-    #[Field]
-    public string $name;
-    public ?UserClass $parent = null;
-
-    /** @var array<string, bool> */
-    private array $abilities = [];
-
     /**
      * @param array<string, bool> $abilities
      */
-    public function __construct(string $name, ?string $parent = null, array $abilities = [])
-    {
-        $this->name = $name;
-        $this->abilities = $abilities;
-
-        if (!is_null($parent)) {
-            $this->parent = static::$known_classes[$parent];
-        }
-
+    public function __construct(
+        #[Field]
+        public string $name,
+        private ?string $parent_name = null,
+        private array $abilities = []
+    ) {
         static::$known_classes[$name] = $this;
+    }
+
+    public function get_parent(): ?UserClass
+    {
+        return static::$known_classes[$this->parent_name] ?? null;
     }
 
     // #[Field(type: "[Permission!]!")]
@@ -59,8 +54,8 @@ class UserClass
     {
         if (array_key_exists($ability, $this->abilities)) {
             return $this->abilities[$ability];
-        } elseif (!is_null($this->parent)) {
-            return $this->parent->can($ability);
+        } elseif (!is_null($this->get_parent())) {
+            return $this->get_parent()->can($ability);
         } else {
             $min_dist = 9999;
             $min_ability = null;

--- a/ext/perm_manager/theme.php
+++ b/ext/perm_manager/theme.php
@@ -24,8 +24,8 @@ class PermManagerTheme extends Themelet
         $row->appendChild(TH("Permission"));
         foreach ($classes as $class) {
             $n = $class->name;
-            if ($class->parent) {
-                $n .= " ({$class->parent->name})";
+            if ($class->get_parent()) {
+                $n .= " ({$class->get_parent()->name})";
             }
             $row->appendChild(TH($n));
         }

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -311,8 +311,8 @@ class UserPage extends Extension
         $duser = $event->display_user;
         $h_join_date = autodate($duser->join_date);
         $class = $duser->class;
-        if ($duser->can(UserAccountsPermission::HELLBANNED) && $class->parent) {
-            $h_class = $class->parent->name;
+        if ($duser->can(UserAccountsPermission::HELLBANNED) && $class->get_parent()) {
+            $h_class = $class->get_parent()->name;
         } else {
             $h_class = $class->name;
         }


### PR DESCRIPTION

This means that if we have a default "user" class, and later on we add a customised "user" class, any other classes who inherit from "user" will inherit from the custom one
