### PR TITLE
[wip][user] hellbanned as a flag rather than a permission

### DIFF
--- a/core/User/User.php
+++ b/core/User/User.php
@@ -27,6 +27,7 @@ class User
     public ?string $passhash;
     #[Field]
     public UserClass $class;
+    public bool $hellbanned;
     private ?Config $config = null;
     /** @var array<int, User> */
     private static array $by_id_cache = [];
@@ -54,6 +55,7 @@ class User
         $this->join_date = $row['joindate'];
         $this->passhash = $row['pass'];
         $this->class = UserClass::get_class($row['class']);
+        $this->hellbanned = $row['hellbanned'] ?? false;
     }
 
     public function get_config(): Config

--- a/ext/comment/theme.php
+++ b/ext/comment/theme.php
@@ -227,9 +227,10 @@ class CommentListTheme extends Themelet
         }
 
         $tfe = send_event(new TextFormattingEvent($comment->comment));
+        $hb = ($comment->get_owner()->hellbanned ? "hb" : "");
         if ($trim) {
             $html = DIV(
-                ["class" => "comment"],
+                ["class" => "comment $hb"],
                 $userlink,
                 ": ",
                 truncate($tfe->stripped, 50),
@@ -239,7 +240,7 @@ class CommentListTheme extends Themelet
             /** @var BuildAvatarEvent $bae */
             $bae = send_event(new BuildAvatarEvent($comment->get_owner()));
             $html = DIV(
-                ["class" => "comment", "id" => "c{$comment->comment_id}"],
+                ["class" => "comment $hb", "id" => "c{$comment->comment_id}"],
                 DIV(
                     ["class" => "info"],
                     emptyHTML(

--- a/ext/upgrade/main.php
+++ b/ext/upgrade/main.php
@@ -210,6 +210,23 @@ class Upgrade extends Extension
             $this->set_version("db_version", 21);
             $database->begin_transaction();
         }
+
+        if ($this->get_version("db_version") < 22) {
+            $database->execute(
+                "ALTER TABLE users ADD COLUMN hellbanned BOOLEAN NOT NULL DEFAULT :f",
+                ["f" => false]
+            );
+            $database->execute(
+                "UPDATE users SET hellbanned = :t WHERE class = :hellbanned",
+                ["t" => true, "hellbanned" => "hellbanned"]
+            );
+            $database->execute(
+                "UPDATE users SET class = :user WHERE class = :hellbanned",
+                ["user" => "user", "hellbanned" => "hellbanned"]
+            );
+
+            $this->set_version("db_version", 22);
+        }
     }
 
     public function get_priority(): int

--- a/ext/user/permissions.php
+++ b/ext/user/permissions.php
@@ -19,6 +19,7 @@ class UserAccountsPermission extends PermissionGroup
     /** modify own user-level settings */
     public const CHANGE_USER_SETTING = "change_user_setting";
     public const CHANGE_OTHER_USER_SETTING = "change_other_user_setting";
+    public const VIEW_HELLBANNED = "view_hellbanned";
     /** only admins can modify protected users (stops a moderator from changing an admin's password) */
     public const PROTECTED = "protected";
 }


### PR DESCRIPTION

having this as a permission was an ugly hack and it made other features harder

I'm still not quite happy with this design - I wonder if we should have a more generic "user ban" system mirroring IP bans, where there ban be different types of ban (total ban from interacting with the site at all, hellban, read-only mode, etc), and bans have a start and end date

But even then, hellbanning would still be a bit of a snowflake, because where most bans affect the banned user, hellbanning makes the user think everything is normal and _everybody else_ sees things differently
