### PR TITLE
couple small bugfixes, and bandaid subnav fix

### DIFF
--- a/core/Page/NavLink.php
+++ b/core/Page/NavLink.php
@@ -26,6 +26,7 @@ class NavLink
         $this->order = $order;
         if ($active == null) {
             $query = _get_query();
+            $link = trim($link," \n\r\t\v\x00/\\");
             if ($query === "") {
                 // This indicates the front page, so we check what's set as the front page
                 $front_page = trim($config->get_string(SetupConfig::FRONT_PAGE), "/");

--- a/core/Util/CommandBuilder.php
+++ b/core/Util/CommandBuilder.php
@@ -13,7 +13,7 @@ class CommandBuilder
     /** @var string[] */
     private array $args = [];
     /** @var string[] */
-    public array $output;
+    public array $output = [];
 
     public function __construct(string $executable)
     {

--- a/ext/post_tags/main.php
+++ b/ext/post_tags/main.php
@@ -216,7 +216,7 @@ class PostTags extends Extension
     public function onPageSubNavBuilding(PageSubNavBuildingEvent $event): void
     {
         if ($event->parent == "tags") {
-            $event->add_nav_link("tags_help", make_link('ext_doc/tag_edit'), "Help");
+            $event->add_nav_link("tags_help", make_link('ext_doc/post_tags'), "Help");
         }
     }
 


### PR DESCRIPTION
With the new usage of  `$link` being a string, it always has a / in front of it, so it never matches `$query`, which does not have a slash in front. So trimming the slash away fixes it, but i feel like is a bandaid fix.

Besides that, the tag help link was pointing to the incorrect page.
And `CommandBuilder->execute()` always failed for me with `Cannot access uninitialized non-nullable property CommandBuilder::$output by reference `