### PR TITLE
[various] Re-add the missing subnavs

### DIFF
--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -345,7 +345,7 @@ class UserPage extends Extension
         if ($user->is_anonymous()) {
             $event->add_nav_link(make_link('user_admin/login'), "Account", category: "user", order: 10);
         } else {
-            $event->add_nav_link(make_link('user'), "Account", category: "user", order: 10);
+            $event->add_nav_link(make_link('user'), "Account", ["user"], "user", 10);
         }
     }
 

--- a/ext/wiki/main.php
+++ b/ext/wiki/main.php
@@ -217,7 +217,7 @@ class Wiki extends Extension
 
     public function onPageNavBuilding(PageNavBuildingEvent $event): void
     {
-        $event->add_nav_link(make_link('wiki'), "Wiki", category: "wiki");
+        $event->add_nav_link(make_link('wiki'), "Wiki", ["wiki"], "wiki");
     }
 
     public function onPageSubNavBuilding(PageSubNavBuildingEvent $event): void


### PR DESCRIPTION
Both subnavs on wiki and the account page were missing, adding them back with the `$matches`  parameter