### PR TITLE
Fix Danbooru Api: path can't be a str, it must be a Shimmie2/Path

### DIFF
--- a/ext/danbooru_api/main.php
+++ b/ext/danbooru_api/main.php
@@ -358,7 +358,7 @@ final class DanbooruApi extends Extension
         try {
             $newimg = $database->with_savepoint(function () use ($file, $filename, $posttags, $source) {
                 // Fire off an event which should process the new file and add it to the db
-                $dae = send_event(new DataUploadEvent($file, basename($filename), 0, [
+                $dae = send_event(new DataUploadEvent(new Path($file), basename($filename), 0, [
                     'tags' => $posttags,
                     'source' => $source,
                 ]));


### PR DESCRIPTION
issue: The danbooru API plugin hasn't been updated to reflect changes to the upload API



In the current state of shish/shimmie2:main, I receive the following error when attempting to upload via python:

```
Done. Status: 500
Response: 
<!doctype html>
<html lang="en">
	<head>
		<title>Internal error - SCore-2.12.0-alpha-20250316-f175f1d</title>
	</head>
	<body>
		<h1>Internal Error</h1>
		<p><b>Message:</b> Shimmie2\DataUploadEvent::__construct(): Argument #1 ($tmpname) must be of type Shimmie2\Path, string given, called in /app/ext/danbooru_api/main.php on line 361
		
		<p><b>Version:</b> 2.12.0-alpha-20250316-f175f1d (on 8.4.4)
        <p><b>Stack Trace:</b></p><pre><code>#0 /app/ext/danbooru_api/main.php(361): Shimmie2\DataUploadEvent->__construct()
#1 /app/core/Database/Database.php(119): Shimmie2\DanbooruApi->{closure:Shimmie2\DanbooruApi::api_add_post():359}()
#2 /app/ext/danbooru_api/main.php(359): Shimmie2\Database->with_savepoint()
#3 /app/ext/danbooru_api/main.php(51): Shimmie2\DanbooruApi->api_add_post()
#4 /app/core/Events/EventBus.php(170): Shimmie2\DanbooruApi->onPageRequest()
#5 /app/core/Events/EventBus.php(17): Shimmie2\EventBus->send_event()
#6 /app/index.php(98): Shimmie2\send_event()
#7 /app/index.php(146): Shimmie2\main()
#8 {main}</code></pre>
	</body>
</html>
```

Looks like the constructor of DataUploadEvent expects param1 to not be a string. 

I've patched it by converting $file to Path(). Let me know if this isn't the proper way to fix the issue.

A note about the unit test for this plugin: test.php doesn't seem to be calling the post image function from this plugin; it's using (I think) the post_image function in core/Testing/ShimmiePHPUnitTestCase.php. Unfortunately, this kind of test won't catch the bug I am trying to fix here.  