### PR TITLE
[core] don't even check for niceurls if we don't need them 

### DIFF
--- a/core/Util/Url.php
+++ b/core/Util/Url.php
@@ -191,7 +191,7 @@ final readonly class Url
         $path     = $this->getPath();
 
         $query = $this->query;
-        if (!Ctx::$config->get_bool(SetupConfig::NICE_URLS) && $this->page !== null) {
+        if ($this->page !== null && !Ctx::$config->get_bool(SetupConfig::NICE_URLS)) {
             //$query["q"] = $this->page;
             $query = array_merge(["q" => $this->page], $query);
         }


### PR DESCRIPTION
(means that the Url class can work in the Installer environment)
