### PR TITLE
[wip] attempt at typing globals

### DIFF
--- a/core/Testing/GenericStringTypeNodeResolverExtension.php
+++ b/core/Testing/GenericStringTypeNodeResolverExtension.php
@@ -3,7 +3,6 @@
 namespace Shimmie2;
 
 use PHPStan\Analyser\NameScope;
-use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\PhpDoc\TypeNodeResolverAwareExtension;
 use PHPStan\PhpDoc\TypeNodeResolverExtension;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
@@ -14,15 +13,6 @@ use PHPStan\Type\Type;
 
 class GenericStringTypeNodeResolverExtension implements TypeNodeResolverExtension //, TypeNodeResolverAwareExtension
 {
-    /*
-    // @ phpstan-ignore-next-line
-    private TypeNodeResolver $typeNodeResolver;
-
-    public function setTypeNodeResolver(TypeNodeResolver $typeNodeResolver): void
-    {
-        $this->typeNodeResolver = $typeNodeResolver;
-    }
-*/
     public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
     {
         if ($typeNode instanceof IdentifierTypeNode) {

--- a/core/Testing/GlobalNodeRule.php
+++ b/core/Testing/GlobalNodeRule.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Shimmie2;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+
+/**
+ * @implements \PHPStan\Rules\Rule<Node\Stmt\Global_>
+ */
+class GlobalNodeRule implements \PHPStan\Rules\Rule
+{
+    public function getNodeType(): string
+    {
+        return \PhpParser\Node::class;
+        //return \PhpParser\Node\Expr\Variable::class;
+        //return \PhpParser\Node\Stmt\Global_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // todo
+        print("Processing node: " . $node::class . " " . $node->name . "\n");
+        //var_dump($node::class);
+        //var_dump($scope);
+        //var_dump($node->vars);
+        return [];
+    }
+
+}

--- a/core/Testing/GlobalNodeVisitor.php
+++ b/core/Testing/GlobalNodeVisitor.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+final class GlobalNodeVisitor extends NodeVisitorAbstract
+{
+    public const ATTRIBUTE_NAME = 'globalTypeHint';
+
+    public function leaveNode(Node $node): ?Node
+    {
+        if (!$node instanceof Node\Stmt\Global_) {
+            return null;
+        }
+
+        foreach ($node->vars as $var) {
+            // FIXME: get this mapping from config file
+            $type = match($var->name) {
+                'config' => '\Shimmie2\Config',
+                'database' => '\Shimmie2\Database',
+                'page' => '\Shimmie2\Page',
+                'user' => '\Shimmie2\User',
+                default => 'mixed',
+            };
+            $var->setAttribute(self::ATTRIBUTE_NAME, $type);
+        }
+
+        //file_put_contents("log.txt", print_r($node, true), FILE_APPEND);
+
+        return null;
+    }
+
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,11 +1,12 @@
 parameters:
   level: 8
   paths:
-    - index.php
-    - core
-    - ext
-    - tests
-    - themes
+#    - index.php
+#    - core
+#    - ext
+#    - tests
+#    - themes
+    - test.php
   typeAliases:
     tag-string: non-empty-string
     hash-string: non-empty-string&internal-hash-string
@@ -33,3 +34,9 @@ services:
     class: Shimmie2\GenericStringTypeNodeResolverExtension
     tags:
       - phpstan.phpDoc.typeNodeResolverExtension
+  -
+    class: Shimmie2\GlobalNodeVisitor
+    tags:
+      - phpstan.parser.richParserNodeVisitor
+rules:
+  - Shimmie2\GlobalNodeRule


### PR DESCRIPTION

phpstan doesn't (and doesn't want to) support checking global variables, which means whenever we do eg `$config->get_string()` the return type is "unknown" D:

This is a so-far-unsuccessful attempt to write a phpstan plugin which adds types for these _specific_ globals (I expect it's most likely that we'll refactor things to use static properties rather than globals, which are _nearly_ the same thing but type checking works)
