### PR TITLE
[various] Avoid redundant usage of config defaults

### DIFF
--- a/core/Extension/Extension.php
+++ b/core/Extension/Extension.php
@@ -39,7 +39,7 @@ abstract class Extension extends Enablable
     protected function get_version(): int
     {
         $name = static::VERSION_KEY ?? "ext_" . static::KEY . "_version";
-        return Ctx::$config->get_int($name, 0);
+        return Ctx::$config->get_int($name) ?? 0;
     }
 
     protected function set_version(int $ver): void

--- a/core/ImageBoard/Image.php
+++ b/core/ImageBoard/Image.php
@@ -412,7 +412,7 @@ final class Image implements \ArrayAccess
                 $image_link = make_link($image_link);
             }
             $chosen = $image_link;
-        } elseif (Ctx::$config->get_bool(SetupConfig::NICE_URLS, false)) {
+        } elseif (Ctx::$config->get_bool(SetupConfig::NICE_URLS)) {
             $chosen = make_link($nice);
         } else {
             $chosen = make_link($plain);

--- a/core/Page/CommonElementsTheme.php
+++ b/core/Page/CommonElementsTheme.php
@@ -258,7 +258,7 @@ class CommonElementsTheme extends Themelet
                     $input = INPUT(["type" => "number", "id" => $key, "name" => "_config_$key", "value" => $val, "size" => 4, "step" => 1]);
                     break;
                 case "shorthand_int":
-                    $val = to_shorthand_int($config->get_int($key, 0));
+                    $val = to_shorthand_int($config->get_int($key) ?? 0);
                     $input = INPUT(["type" => "text", "id" => $key, "name" => "_config_$key", "value" => $val, "size" => 6]);
                     break;
                 case "text":
@@ -277,7 +277,7 @@ class CommonElementsTheme extends Themelet
                     }
                     break;
                 case "longtext":
-                    $val = $config->get_string($key, "");
+                    $val = $config->get_string($key) ?? "";
                     $rows = max(3, min(10, count(explode("\n", $val))));
                     $input = TEXTAREA(["rows" => $rows, "id" => $key, "name" => "_config_$key"], $val);
                     break;
@@ -286,7 +286,7 @@ class CommonElementsTheme extends Themelet
                     $input = INPUT(["type" => "color", "id" => $key, "name" => "_config_$key", "value" => $val]);
                     break;
                 case "multichoice":
-                    $val = $config->get_array($key, []);
+                    $val = $config->get_array($key) ?? [];
                     $input = SELECT(["id" => $key, "name" => "_config_{$key}[]", "multiple" => true, "size" => 5]);
                     $options = $meta->options;
                     if (is_callable($options)) {

--- a/core/Testing/ShimmiePHPUnitTestCase.php
+++ b/core/Testing/ShimmiePHPUnitTestCase.php
@@ -257,7 +257,7 @@ abstract class ShimmiePHPUnitTestCase extends \PHPUnit\Framework\TestCase
 
     protected static function log_out(): void
     {
-        send_event(new UserLoginEvent(User::by_id(Ctx::$config->get_int(UserAccountsConfig::ANON_ID, 0))));
+        send_event(new UserLoginEvent(User::by_id(Ctx::$config->req_int(UserAccountsConfig::ANON_ID))));
     }
 
     // post things

--- a/core/Util/Url.php
+++ b/core/Util/Url.php
@@ -158,7 +158,7 @@ final readonly class Url
              * "/v2/index.php?q=foo/bar" (uglyurls)
              */
             $install_dir = (string)Url::base();
-            if (Ctx::$config->get_bool(SetupConfig::NICE_URLS, false)) {
+            if (Ctx::$config->req_bool(SetupConfig::NICE_URLS)) {
                 $path = "$install_dir/{$this->page}";
             } else {
                 $path = "$install_dir/index.php";

--- a/core/Util/util.php
+++ b/core/Util/util.php
@@ -12,7 +12,7 @@ use MicroHTML\HTMLElement;
 
 function get_theme(): string
 {
-    $theme = Ctx::$config->get_string(SetupConfig::THEME, "default");
+    $theme = Ctx::$config->req_string(SetupConfig::THEME);
     if (!file_exists("themes/$theme")) {
         $theme = "default";
     }
@@ -363,7 +363,7 @@ function _get_user(): User
         $my_user = User::by_session(Ctx::$page->get_cookie("user"), Ctx::$page->get_cookie("session"));
     }
     if (is_null($my_user)) {
-        $my_user = User::by_id(Ctx::$config->get_int(UserAccountsConfig::ANON_ID, 0));
+        $my_user = User::by_id(Ctx::$config->req_int(UserAccountsConfig::ANON_ID));
     }
 
     return $my_user;

--- a/ext/biography/main.php
+++ b/ext/biography/main.php
@@ -14,7 +14,7 @@ final class Biography extends Extension
     {
         global $user;
         $duser = $event->display_user;
-        $bio = $duser->get_config()->get_string("biography", "");
+        $bio = $duser->get_config()->get_string("biography") ?? "";
 
         if ($user->id == $duser->id || $user->can(UserAccountsPermission::EDIT_USER_INFO)) {
             $this->theme->display_composer($duser, $bio);

--- a/ext/danbooru_api/main.php
+++ b/ext/danbooru_api/main.php
@@ -87,7 +87,7 @@ final class DanbooruApi extends Extension
                 $pass = $event->req_POST('password');
                 $user = User::by_name_and_pass($name, $pass);
             } catch (UserNotFound $e) {
-                $user = User::by_id($config->get_int(UserAccountsConfig::ANON_ID, 0));
+                $user = User::by_id($config->get_int(UserAccountsConfig::ANON_ID));
             }
             send_event(new UserLoginEvent($user));
         }

--- a/ext/featured/main.php
+++ b/ext/featured/main.php
@@ -21,17 +21,23 @@ final class Featured extends Extension
             $page->set_redirect(make_link("post/view/$id"));
         }
         if ($event->page_matches("featured_image/download")) {
-            $image = Image::by_id($config->get_int(FeaturedConfig::ID, 0));
-            if (!is_null($image)) {
-                $page->set_mode(PageMode::DATA);
-                $page->set_mime($image->get_mime());
-                $page->set_data($image->get_image_filename()->get_contents());
+            $fid = $config->get_int(FeaturedConfig::ID);
+            if (!is_null($fid)) {
+                $image = Image::by_id($fid);
+                if (!is_null($image)) {
+                    $page->set_mode(PageMode::DATA);
+                    $page->set_mime($image->get_mime());
+                    $page->set_data($image->get_image_filename()->get_contents());
+                }
             }
         }
         if ($event->page_matches("featured_image/view")) {
-            $image = Image::by_id($config->get_int(FeaturedConfig::ID, 0));
-            if (!is_null($image)) {
-                send_event(new DisplayingImageEvent($image));
+            $fid = $config->get_int(FeaturedConfig::ID);
+            if (!is_null($fid)) {
+                $image = Image::by_id($fid);
+                if (!is_null($image)) {
+                    send_event(new DisplayingImageEvent($image));
+                }
             }
         }
     }

--- a/ext/home/main.php
+++ b/ext/home/main.php
@@ -29,7 +29,7 @@ final class Home extends Extension
         global $config;
 
         // get the homelinks and process them
-        if (strlen($config->get_string(HomeConfig::LINKS, '')) > 0) {
+        if (!empty($config->get_string(HomeConfig::LINKS))) {
             $main_links = $config->get_string(HomeConfig::LINKS);
         } else {
             $main_links = '[url=site://post/list]Posts[/url][url=site://comment/list]Comments[/url][url=site://tags]Tags[/url]';
@@ -45,7 +45,7 @@ final class Home extends Extension
         return $this->theme->build_body(
             $config->get_string(SetupConfig::TITLE),
             format_text($main_links),
-            $config->get_string(HomeConfig::TEXT, null),
+            $config->get_string(HomeConfig::TEXT),
             contact_link(),
             Search::count_images(),
         );

--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -39,8 +39,8 @@ final class ImageIO extends Extension
     {
         global $config, $page, $user;
 
-        $thumb_width = $config->get_int(ThumbnailConfig::WIDTH, 192);
-        $thumb_height = $config->get_int(ThumbnailConfig::HEIGHT, 192);
+        $thumb_width = $config->get_int(ThumbnailConfig::WIDTH);
+        $thumb_height = $config->get_int(ThumbnailConfig::HEIGHT);
         $page->add_html_header(STYLE(":root {--thumb-width: {$thumb_width}px; --thumb-height: {$thumb_height}px;}"));
 
         if ($event->page_matches("image/delete", method: "POST")) {

--- a/ext/media/main.php
+++ b/ext/media/main.php
@@ -183,7 +183,7 @@ final class Media extends Extension
         }
 
         // TODO: Get output optimization tools working better
-        //        if ($config->get_bool("thumb_optim", false)) {
+        //        if ($config->get_bool("thumb_optim")) {
         //            exec("jpegoptim $outname", $output, $ret);
         //        }
     }

--- a/ext/ouroboros_api/main.php
+++ b/ext/ouroboros_api/main.php
@@ -580,7 +580,7 @@ final class OuroborosAPI extends Extension
             if (!is_null($duser)) {
                 $user = $duser;
             } else {
-                $user = User::by_id($config->get_int(UserAccountsConfig::ANON_ID, 0));
+                $user = User::by_id($config->get_int(UserAccountsConfig::ANON_ID));
             }
             send_event(new UserLoginEvent($user));
         } elseif (isset($_COOKIE[SysConfig::getCookiePrefix() . '_' . 'session']) &&
@@ -593,7 +593,7 @@ final class OuroborosAPI extends Extension
             if (!is_null($duser)) {
                 $user = $duser;
             } else {
-                $user = User::by_id($config->get_int(UserAccountsConfig::ANON_ID, 0));
+                $user = User::by_id($config->get_int(UserAccountsConfig::ANON_ID));
             }
             send_event(new UserLoginEvent($user));
         }

--- a/ext/setup/main.php
+++ b/ext/setup/main.php
@@ -92,7 +92,7 @@ final class Setup extends Extension
             $page->set_data(\Safe\json_encode([
                 "args" => $event->args,
                 "theme" => get_theme(),
-                "nice_urls" => $config->get_bool(SetupConfig::NICE_URLS, false),
+                "nice_urls" => $config->get_bool(SetupConfig::NICE_URLS),
                 "base" => (string)Url::base(),
                 "absolute_base" => (string)Url::base()->asAbsolute(),
                 "base_link" => (string)make_link(""),

--- a/ext/static_files/main.php
+++ b/ext/static_files/main.php
@@ -16,7 +16,7 @@ final class StaticFiles extends Extension
         if ($page->mode == PageMode::PAGE && $this->count_main($page->blocks) == 0) {
             $h_pagename = html_escape(implode('/', $event->args));
             $f_pagename = \Safe\preg_replace("/[^a-z_\-\.]+/", "_", $h_pagename);
-            $theme_name = $config->get_string(SetupConfig::THEME, "default");
+            $theme_name = $config->get_string(SetupConfig::THEME);
 
             $theme_file = "themes/$theme_name/static/$f_pagename";
             $static_file = "ext/static_files/static/$f_pagename";

--- a/ext/statsd/main.php
+++ b/ext/statsd/main.php
@@ -47,7 +47,7 @@ final class StatsDInterface extends Extension
             $this->_stats("other");
         }
 
-        $host = $config->get_string(StatsDInterfaceConfig::HOST, null);
+        $host = $config->get_string(StatsDInterfaceConfig::HOST);
         if (!is_null($host)) {
             $this->send($host, StatsDInterface::$stats, 1.0);
         }

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -99,7 +99,7 @@ final class LoginResult
             );
         } catch (UserNotFound $ex) {
             return new LoginResult(
-                User::by_id($config->get_int(UserAccountsConfig::ANON_ID, 0)),
+                User::by_id($config->req_int(UserAccountsConfig::ANON_ID)),
                 null,
                 "No user found"
             );
@@ -119,7 +119,7 @@ final class LoginResult
             );
         } catch (UserCreationException $ex) {
             return new LoginResult(
-                User::by_id($config->get_int(UserAccountsConfig::ANON_ID, 0)),
+                User::by_id($config->req_int(UserAccountsConfig::ANON_ID)),
                 null,
                 $ex->getMessage()
             );

--- a/ext/wiki/main.php
+++ b/ext/wiki/main.php
@@ -351,7 +351,7 @@ final class Wiki extends Extension
             // correct the default
             global $config;
             $row["title"] = $title;
-            $row["owner_id"] = $config->get_int(UserAccountsConfig::ANON_ID, 0);
+            $row["owner_id"] = $config->req_int(UserAccountsConfig::ANON_ID);
         }
 
         assert(!empty($row));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,7 +53,7 @@ $config->set_string(ThumbnailConfig::ENGINE, "static");
 $config->set_bool(SetupConfig::NICE_URLS, true);
 send_event(new DatabaseUpgradeEvent());
 send_event(new InitExtEvent());
-$user = Ctx::setUser(User::by_id($config->get_int(UserAccountsConfig::ANON_ID, 0)));
+$user = Ctx::setUser(User::by_id($config->req_int(UserAccountsConfig::ANON_ID)));
 $userPage = new UserPage();
 $userPage->onUserCreation(new UserCreationEvent("demo", "demo", "demo", "demo@demo.com", false));
 $userPage->onUserCreation(new UserCreationEvent("test", "test", "test", "test@test.com", false));

--- a/themes/lite/page.class.php
+++ b/themes/lite/page.class.php
@@ -22,7 +22,7 @@ class LitePage extends Page
     protected function body_html(): HTMLElement
     {
         list($nav_links, $sub_links) = $this->get_nav_links();
-        $theme_name = Ctx::$config->get_string(SetupConfig::THEME, 'lite');
+        $theme_name = Ctx::$config->get_string(SetupConfig::THEME);
         $site_name = Ctx::$config->get_string(SetupConfig::TITLE);
         $data_href = Url::base();
 


### PR DESCRIPTION

being able to set a default in `get()` made it possible for multiple callsites to request the same config and get different values
