### PR TITLE
[core] Remove default param from config->get_XXX()

### DIFF
--- a/core/Config/Config.php
+++ b/core/Config/Config.php
@@ -20,27 +20,18 @@ abstract class Config
      */
     abstract protected function save(string $name): void;
 
-    /**
-     * Set a configuration option to a new value, regardless of what the value is at the moment.
-     */
     public function set_int(string $name, int $value): void
     {
         $this->values[$name] = (string)$value;
         $this->save($name);
     }
 
-    /**
-     * Set a configuration option to a new value, regardless of what the value is at the moment.
-     */
     public function set_string(string $name, string $value): void
     {
         $this->values[$name] = $value;
         $this->save($name);
     }
 
-    /**
-     * Set a configuration option to a new value, regardless of what the value is at the moment.
-     */
     public function set_bool(string $name, bool $value): void
     {
         $this->values[$name] = $value ? 'Y' : 'N';
@@ -48,9 +39,7 @@ abstract class Config
     }
 
     /**
-     * Set a configuration option to a new value, regardless of what the value is at the moment.
-     *
-     * @param mixed[] $value
+     * @param string[] $value
      */
     public function set_array(string $name, array $value): void
     {
@@ -67,66 +56,32 @@ abstract class Config
         $this->save($name);
     }
 
-    /**
-     * Pick a value out of the table by name, cast to the appropriate data type.
-     *
-     * @template T of int|null
-     * @param T $default
-     * @return T|int
-     */
-    public function get_int(string $name, ?int $default = null): ?int
+    public function get_int(string $name): ?int
     {
         $val = $this->get($name);
-        if (is_null($val) || !is_numeric($val)) {
-            return $default;
-        }
-        return (int)$val;
+        return (is_null($val) || !is_numeric($val)) ? null : (int)$val;
+    }
+
+    public function get_string(string $name): ?string
+    {
+        $val = $this->get($name);
+        return is_null($val) ? null : $val;
+    }
+
+    public function get_bool(string $name): ?bool
+    {
+        $val = $this->get($name);
+        return (is_null($val)) ? null : bool_escape($val);
     }
 
     /**
-     * Pick a value out of the table by name, cast to the appropriate data type.
-     *
-     * @template T of string|null
-     * @param T $default
-     * @return T|string
+     * @return string[]
      */
-    public function get_string(string $name, ?string $default = null): ?string
+    public function get_array(string $name): ?array
     {
         $val = $this->get($name);
         if (is_null($val)) {
-            return $default;
-        }
-        return $val;
-    }
-
-    /**
-     * Pick a value out of the table by name, cast to the appropriate data type.
-     *
-     * @template T of bool|null
-     * @param T $default
-     * @return T|bool
-     */
-    public function get_bool(string $name, ?bool $default = null): ?bool
-    {
-        $val = $this->get($name);
-        if (is_null($val)) {
-            return $default;
-        }
-        return bool_escape($val);
-    }
-
-    /**
-     * Pick a value out of the table by name, cast to the appropriate data type.
-     *
-     * @template T of array<string>|null
-     * @param T $default
-     * @return T|array<string>
-     */
-    public function get_array(string $name, ?array $default = null): ?array
-    {
-        $val = $this->get($name);
-        if (is_null($val)) {
-            return $default;
+            return null;
         }
         if (empty($val)) {
             return [];
@@ -139,7 +94,7 @@ abstract class Config
         return $this->values[$name] ?? null;
     }
 
-    public function req_int(string $name, ?int $default = null): int
+    public function req_int(string $name): int
     {
         $val = $this->get_int($name);
         if (is_null($val)) {
@@ -148,7 +103,7 @@ abstract class Config
         return $val;
     }
 
-    public function req_string(string $name, ?string $default = null): string
+    public function req_string(string $name): string
     {
         $val = $this->get_string($name);
         if (is_null($val)) {
@@ -157,7 +112,7 @@ abstract class Config
         return $val;
     }
 
-    public function req_bool(string $name, ?bool $default = null): bool
+    public function req_bool(string $name): bool
     {
         $val = $this->get_bool($name);
         if (is_null($val)) {
@@ -167,10 +122,9 @@ abstract class Config
     }
 
     /**
-     * @param array<string>|null $default
      * @return array<string>
      */
-    public function req_array(string $name, ?array $default = null): array
+    public function req_array(string $name): array
     {
         $val = $this->get_array($name);
         if (is_null($val)) {

--- a/core/Config/ConfigTest.php
+++ b/core/Config/ConfigTest.php
@@ -14,21 +14,14 @@ final class ConfigTest extends ShimmiePHPUnitTestCase
             "get_int should return the value of a setting when it is set correctly"
         );
 
-        self::assertEquals(
-            (new TestConfig(["foo" => "waffo"]))->get_int("foo", 42),
-            42,
-            "get_int should return the default value when a setting is set incorrectly"
-        );
-
-        self::assertEquals(
-            (new TestConfig([]))->get_int("foo", 42),
-            42,
-            "get_int should return the default value when a setting is not set"
+        self::assertNull(
+            (new TestConfig(["foo" => "waffo"]))->get_int("foo"),
+            "get_int should return null when a setting is set incorrectly"
         );
 
         self::assertNull(
             (new TestConfig([]))->get_int("foo"),
-            "get_int should return null when a setting is not set and no default is specified"
+            "get_int should return null when a setting is not set"
         );
 
         self::assertException(ConfigException::class, function () {

--- a/ext/cron_uploader/main.php
+++ b/ext/cron_uploader/main.php
@@ -161,7 +161,7 @@ final class CronUploader extends Extension
     {
         global $user;
 
-        $user_api_key = $user->get_config()->get_string(UserConfigUserConfig::API_KEY, "API_KEY");
+        $user_api_key = $user->get_config()->get_string(UserConfigUserConfig::API_KEY) ?? "API_KEY";
 
         return (string)make_link("cron_upload/run", ["api_key" => $user_api_key])->asAbsolute();
     }

--- a/ext/filter/theme.php
+++ b/ext/filter/theme.php
@@ -19,9 +19,8 @@ class FilterTheme extends Themelet
         // If user is not able to set their own filters, use the default filters.
         if ($user->can(UserAccountsPermission::CHANGE_USER_SETTING)) {
             $tags = $user->get_config()->get_string(
-                FilterUserConfig::TAGS,
-                $config->get_string(FilterConfig::TAGS)
-            );
+                FilterUserConfig::TAGS
+            ) ?? $config->get_string(FilterConfig::TAGS);
         } else {
             $tags = $config->get_string(FilterConfig::TAGS);
         }


### PR DESCRIPTION

being able to set a default in `get()` made it possible for multiple callsites to request the same config and get different values
