### PR TITLE
[perm-manager] Keep track of where classes came from

### DIFF
--- a/core/User/UserClass.php
+++ b/core/User/UserClass.php
@@ -12,6 +12,9 @@ final class UserClass
 {
     /** @var array<string, UserClass> */
     public static array $known_classes = [];
+    public static UserClassSource $loading = UserClassSource::UNKNOWN;
+    /** @var list<UserClassSource> */
+    public array $sources = [];
 
     /**
      * @param array<string, bool> $abilities
@@ -23,6 +26,10 @@ final class UserClass
         private array $abilities = [],
         public string $description = "",
     ) {
+        if (in_array($name, self::$known_classes)) {
+            $this->sources = self::$known_classes[$name]->sources;
+        }
+        $this->sources[] = self::$loading;
         self::$known_classes[$name] = $this;
     }
 

--- a/core/User/UserClassSource.php
+++ b/core/User/UserClassSource.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+enum UserClassSource
+{
+    case UNKNOWN;
+    case DEFAULT;
+    case FILE;
+}

--- a/ext/perm_manager/main.php
+++ b/ext/perm_manager/main.php
@@ -18,6 +18,7 @@ final class PermManager extends Extension
 
     private function add_default_classes(): void
     {
+        UserClass::$loading = UserClassSource::DEFAULT;
         $_all_false = [];
         $_all_true = [];
         foreach (PermissionGroup::get_subclasses(all: true) as $class) {
@@ -80,11 +81,14 @@ final class PermManager extends Extension
             ],
             description: "The default class for people who are logged in",
         );
+        UserClass::$loading = UserClassSource::UNKNOWN;
     }
 
     private function add_config_classes(): void
     {
+        UserClass::$loading = UserClassSource::FILE;
         @include_once "data/config/user-classes.conf.php";
+        UserClass::$loading = UserClassSource::UNKNOWN;
     }
 
     public function onPageRequest(PageRequestEvent $event): void


### PR DESCRIPTION

This is going to become useful with a class editor, where default / file / database classes need to be edited differently
