### PR TITLE
Update VideoCodec.php

### DIFF
--- a/core/Media/VideoCodec.php
+++ b/core/Media/VideoCodec.php
@@ -12,5 +12,7 @@ enum VideoCodec: string
     case THEORA = "theora";
     case MPEG4 = "mpeg4";
     case H264 = "h264";
+    case AVC = "avc";
     case H265 = "h265";
+    case HEVC = "hevc";
 }


### PR DESCRIPTION
Adds to VideoCodec.php ensuring that AVC and HEVC are correctly handled. Essentially fixes a regression since these worked fine with the extension in the last stable release. I do not know if it's necessary or useful to have the H264 and HEVC handlers so I have left those in as they shouldn't cause any problems by existing. 