### PR TITLE
Fix Submit button for Edit Tag Category / Submit button for New Tag Category

### DIFF
--- a/ext/tag_categories/theme.php
+++ b/ext/tag_categories/theme.php
@@ -62,7 +62,7 @@ class TagCategoriesTheme extends Themelet
                     BUTTON([
                         "class" => "tc_edit",
                         "type" => "button",
-                        "onclick" => "$(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') tr + tr td span\').hide(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') td input\').show(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_edit\').hide(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_colorswatch\').hide(); $(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_submit\').show();"
+                        "onclick" => "$('.tagcategoryblock:nth-of-type($tc_block_index) tr + tr td span').hide(); $('.tagcategoryblock:nth-of-type($tc_block_index) td input').show(); $('.tagcategoryblock:nth-of-type($tc_block_index) .tc_edit').hide(); $('.tagcategoryblock:nth-of-type($tc_block_index) .tc_colorswatch').hide(); $('.tagcategoryblock:nth-of-type($tc_block_index) .tc_submit').show();"
                     ], "Edit"),
                     BUTTON([
                         "class" => "tc_submit",
@@ -75,7 +75,7 @@ class TagCategoriesTheme extends Themelet
                         "class" => "tc_submit",
                         "type" => "button",
                         "style" => "display:none;",
-                        "onclick" => "$(\'.tagcategoryblock:nth-of-type('.$tc_block_index.') .tc_delete\').show(); $(this).hide();",
+                        "onclick" => "$('.tagcategoryblock:nth-of-type($tc_block_index) .tc_delete').show(); $(this).hide();",
                     ], "Delete"),
                     BUTTON([
                         "class" => "tc_delete",
@@ -122,9 +122,10 @@ class TagCategoriesTheme extends Themelet
                             INPUT(["type" => "color", "name" => "tc_color", "value" => $tag_color])
                         )
                     ),
-                )
+                ),
+                BUTTON(["class" => "tc_submit", "type" => "submit", "name" => "tc_status", "value" => "new"], "Submit"),
             ),
-            BUTTON(["class" => "tc_submit", "type" => "submit", "name" => "tc_status", "value" => "new"], "Submit")
+            
         );
 
         // add html to stuffs

--- a/ext/tag_categories/theme.php
+++ b/ext/tag_categories/theme.php
@@ -125,7 +125,6 @@ class TagCategoriesTheme extends Themelet
                 ),
                 BUTTON(["class" => "tc_submit", "type" => "submit", "name" => "tc_status", "value" => "new"], "Submit"),
             ),
-            
         );
 
         // add html to stuffs


### PR DESCRIPTION
Found this bug on latest changes on main, so here's a PR that restores the functionality of editing/adding new tag categories!

Repro steps:
- Clone shimmie2 from main branch
- Run shimmie2
- Install Tag Categories extension
- Navigate to the "Tag Categories" page (tags/categories)
- Try to edit an existing tag from the defaults
- Button will be unresponsive due to a "SyntaxError" on the "Edit" button.
- Try to create a new Tag Category
- Button will be unresponsive as the "Submit" button is outside of the new Tag Category form