### PR TITLE
[core] Make a specific function for Page::display_error() so that themes can override it

### DIFF
--- a/core/Page/Page.php
+++ b/core/Page/Page.php
@@ -104,6 +104,16 @@ class Page
 
     // ==============================================
 
+    public ?UserError $error = null;
+
+    public function set_error(UserError $error): void
+    {
+        $this->mode = PageMode::ERROR;
+        $this->error = $error;
+    }
+
+    // ==============================================
+
     public int $code = 200;
     public string $title = "";
     public string $heading = "";
@@ -265,6 +275,7 @@ class Page
         match($this->mode) {
             PageMode::MANUAL => null,
             PageMode::PAGE => $this->display_page(),
+            PageMode::ERROR => $this->display_error(),
             PageMode::DATA => $this->display_data(),
             PageMode::FILE => $this->display_file(),
             PageMode::REDIRECT => $this->display_redirect(),
@@ -272,7 +283,7 @@ class Page
         Ctx::$tracer->end();
     }
 
-    private function display_page(): void
+    protected function display_page(): void
     {
         $this->send_headers();
         usort($this->blocks, Block::cmp(...));
@@ -280,7 +291,18 @@ class Page
         $this->render();
     }
 
-    private function display_data(): void
+    protected function display_error(): void
+    {
+        $error = $this->error;
+        assert($error !== null);
+        $this->set_code($error->http_code);
+        $this->set_title("Error");
+        $this->blocks = [];
+        $this->add_block(new Block(null, \MicroHTML\SPAN($error->getMessage())));
+        $this->display_page();
+    }
+
+    protected function display_data(): void
     {
         $this->send_headers();
         header("Content-Length: " . strlen($this->data));
@@ -290,7 +312,7 @@ class Page
         print $this->data;
     }
 
-    private function display_file(): void
+    protected function display_file(): void
     {
         $this->send_headers();
         if (!is_null($this->filename)) {
@@ -345,7 +367,7 @@ class Page
         }
     }
 
-    private function display_redirect(): void
+    protected function display_redirect(): void
     {
         $this->send_headers();
         if ($this->flash) {

--- a/core/Page/PageMode.php
+++ b/core/Page/PageMode.php
@@ -11,4 +11,5 @@ enum PageMode
     case PAGE;
     case FILE;
     case MANUAL;
+    case ERROR;
 }

--- a/core/Testing/ShimmiePHPUnitTestCase.php
+++ b/core/Testing/ShimmiePHPUnitTestCase.php
@@ -163,7 +163,6 @@ abstract class ShimmiePHPUnitTestCase extends \PHPUnit\Framework\TestCase
             PageMode::DATA => $page->data,
             PageMode::REDIRECT => self::fail("Page mode is REDIRECT ({$page->redirect}) (only PAGE and DATA are supported)"),
             PageMode::FILE => self::fail("Page mode is FILE (only PAGE and DATA are supported)"),
-            // @phpstan-ignore-next-line
             PageMode::MANUAL => self::fail("Page mode is MANUAL (only PAGE and DATA are supported)"),
             default => self::fail("Unknown page mode {$page->mode->name}"),  // just for phpstan
         };

--- a/index.php
+++ b/index.php
@@ -59,62 +59,66 @@ Ctx::$tracer->end();
 
 function main(): int
 {
+    // nested try-catch blocks so that we can try to handle user-errors
+    // in a pretty and theme-customisable way, but if that breaks, the
+    // breakage will be handled by the server-error handler
     try {
-        // Ctx::$tracer->mark($_SERVER["REQUEST_URI"] ?? "No Request");
-        Ctx::$tracer->begin(
-            $_SERVER["REQUEST_URI"] ?? "No Request",
-            [
-                "user" => $_COOKIE["shm_user"] ?? "No User",
-                "ip" => Network::get_real_ip(),
-                "user_agent" => $_SERVER['HTTP_USER_AGENT'] ?? "No UA",
-            ]
-        );
+        try {
+            // Ctx::$tracer->mark($_SERVER["REQUEST_URI"] ?? "No Request");
+            Ctx::$tracer->begin(
+                $_SERVER["REQUEST_URI"] ?? "No Request",
+                [
+                    "user" => $_COOKIE["shm_user"] ?? "No User",
+                    "ip" => Network::get_real_ip(),
+                    "user_agent" => $_SERVER['HTTP_USER_AGENT'] ?? "No UA",
+                ]
+            );
 
-        if (!Ctx::$config->get(SetupConfig::NO_AUTO_DB_UPGRADE)) {
-            send_event(new DatabaseUpgradeEvent());
-        }
-        send_event(new InitExtEvent());
-
-        // start the page generation waterfall
-        Ctx::setUser(_get_user());
-        send_event(new UserLoginEvent(Ctx::$user));
-        if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
-            ob_end_flush();
-            ob_implicit_flush(true);
-            $app = new CliApp();
-            send_event(new CliGenEvent($app));
-            if ($app->run() !== 0) {
-                throw new \Exception("CLI command failed");
+            if (!Ctx::$config->get(SetupConfig::NO_AUTO_DB_UPGRADE)) {
+                send_event(new DatabaseUpgradeEvent());
             }
-        } else {
-            send_event(new PageRequestEvent(
-                $_SERVER['REQUEST_METHOD'],
-                _get_query(),
-                new QueryArray($_GET),
-                new QueryArray($_POST)
-            ));
-            Ctx::$page->display();
-        }
+            send_event(new InitExtEvent());
 
-        if (Ctx::$database->is_transaction_open()) {
-            Ctx::$database->commit();
-        }
+            // start the page generation waterfall
+            Ctx::setUser(_get_user());
+            send_event(new UserLoginEvent(Ctx::$user));
+            if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
+                ob_end_flush();
+                ob_implicit_flush(true);
+                $app = new CliApp();
+                send_event(new CliGenEvent($app));
+                if ($app->run() !== 0) {
+                    throw new \Exception("CLI command failed");
+                }
+            } else {
+                send_event(new PageRequestEvent(
+                    $_SERVER['REQUEST_METHOD'],
+                    _get_query(),
+                    new QueryArray($_GET),
+                    new QueryArray($_POST)
+                ));
+                Ctx::$page->display();
+            }
 
-        // saving cache data and profiling data to disk can happen later
-        if (function_exists("fastcgi_finish_request")) {
-            fastcgi_finish_request();
-        }
-        $exit_code = 0;
-    } catch (\Throwable $e) {
-        if (Ctx::$database->is_transaction_open()) {
-            Ctx::$database->rollback();
-        }
-        if (is_a($e, \Shimmie2\UserError::class)) {
+            if (Ctx::$database->is_transaction_open()) {
+                Ctx::$database->commit();
+            }
+
+            // saving cache data and profiling data to disk can happen later
+            if (function_exists("fastcgi_finish_request")) {
+                fastcgi_finish_request();
+            }
+            $exit_code = 0;
+        } catch (UserError $e) {
+            if (Ctx::$database->is_transaction_open()) {
+                Ctx::$database->rollback();
+            }
             Ctx::$page->set_error($e);
             Ctx::$page->display();
-        } else {
-            _fatal_error($e);
+            $exit_code = 2;
         }
+    } catch (\Throwable $e) {
+        _fatal_error($e);
         $exit_code = 1;
     } finally {
         Ctx::$tracer->end();

--- a/index.php
+++ b/index.php
@@ -110,10 +110,7 @@ function main(): int
             Ctx::$database->rollback();
         }
         if (is_a($e, \Shimmie2\UserError::class)) {
-            Ctx::$page->set_mode(PageMode::PAGE);
-            Ctx::$page->set_code($e->http_code);
-            Ctx::$page->set_title("Error");
-            Ctx::$page->add_block(new Block(null, \MicroHTML\SPAN($e->getMessage())));
+            Ctx::$page->set_error($e);
             Ctx::$page->display();
         } else {
             _fatal_error($e);


### PR DESCRIPTION
The default implementation of `display_error()` being to remove any existing Blocks, add a new Block with an error message, and then do the same stuff that `display_page()` does

```
    protected function display_error(): void
    {
        $error = $this->error;
        assert($error !== null);
        $this->set_code($error->http_code);
        $this->set_title("Error");
        $this->blocks = [];
        $this->add_block(new Block(null, \MicroHTML\SPAN($error->getMessage())));
        $this->display_page();
    }
```