### PR TITLE
Update main.php for ext bulk_add_csv

### DIFF
--- a/ext/bulk_add_csv/main.php
+++ b/ext/bulk_add_csv/main.php
@@ -102,7 +102,7 @@ final class BulkAddCSV extends Extension
             $list .= "<br>".html_escape("$shortpath (".implode(", ", $tags).")... ");
             if (file_exists($csvdata[0]) && is_file($csvdata[0])) {
                 try {
-                    $this->add_image($fullpath, $shortpath, $tags, $source, $rating, $thumbfile);
+                    $this->add_image(new Path($fullpath), $shortpath, $tags, $source, $rating, new Path($thumbfile));
                     $list .= "ok\n";
                 } catch (\Exception $ex) {
                     $list .= "failed:<br>". $ex->getMessage();


### PR DESCRIPTION
I honestly have no idea what I was doing with this one. Changes courtesy of ChatGPT. They appear to work whereas before I was receiving an error. ChatGPT thought it was cut-and-dry and that this still follows the goals of alpha.

This was the error I was receiving prior to this edit:

```Internal Error
Message: TypeError: Shimmie2\BulkAddCSV::add_image(): Argument #1 ($tmpname) must be of type Shimmie2\Path, string given, called in /mnt/booksimagesmusic/shimmie2/ext/bulk_add_csv/main.php on line 105

Version: 2.12.0-alpha-git (on 8.4.6)

Stack Trace:

#0 /mnt/booksimagesmusic/shimmie2/ext/bulk_add_csv/main.php(105): Shimmie2\BulkAddCSV->add_image()
#1 /mnt/booksimagesmusic/shimmie2/ext/bulk_add_csv/main.php(22): Shimmie2\BulkAddCSV->add_csv()
#2 /mnt/booksimagesmusic/shimmie2/core/Events/EventBus.php(160): Shimmie2\BulkAddCSV->onPageRequest()
#3 /mnt/booksimagesmusic/shimmie2/core/Events/EventBus.php(16): Shimmie2\EventBus->send_event()
#4 /mnt/booksimagesmusic/shimmie2/index.php(90): Shimmie2\send_event()
#5 /mnt/booksimagesmusic/shimmie2/index.php(141): Shimmie2\main()
#6 {main}```