### PR TITLE
[themes] Update danbooru2 style.css

### DIFF
--- a/themes/danbooru2/style.css
+++ b/themes/danbooru2/style.css
@@ -133,7 +133,7 @@ body {
 BODY.layout-grid {
 	display: grid;
 	grid-template-columns: 11.5rem auto;
-	grid-gap: 0 2rem;
+	grid-gap: 0 4rem;
 }
 BODY.layout-no-left NAV {
 	display: none;


### PR DESCRIPTION
Changes block at line 133:
BODY.layout-grid {
	display: grid;
	grid-template-columns: 11.5rem auto;
	grid-gap: 0 2rem;
}

to:
BODY.layout-grid {
	display: grid;
	grid-template-columns: 11.5rem auto;
	grid-gap: 0 4rem;
}

This fixes some overlap between the main body and the navigation sidebar. I considered reducing the padding on the navigation bar itself but that made it misalign with the top navigation bar text. I haven't yet seen any page issues with this change.
2 screenshots showing the difference are attached. I have tested this at 1440p, 4k and on mobile. 

![Screenshot_20250419_074408](https://github.com/user-attachments/assets/f6f4b87a-242c-4b64-84bc-d77bd89d909d)
![Screenshot_20250419_074435](https://github.com/user-attachments/assets/53b15bb3-e85f-4f54-b594-00023de60793)
