### PR TITLE
[ext] Update auto_tagger functionality and rating stabilty

### DIFF
--- a/ext/auto_tagger/main.php
+++ b/ext/auto_tagger/main.php
@@ -196,8 +196,8 @@ final class AutoTagger extends Extension
             $additional_tags = Tag::explode($additional_tags);
             $existing_tags = Tag::explode($existing_tags);
             foreach ($additional_tags as $t) {
-                if (!in_array(strtolower($t), $existing_tags)) {
-                    $existing_tags[] = strtolower($t);
+                if (!\in_array($t, $existing_tags, true)) {
+                    $existing_tags[] = $t;
                 }
             }
 
@@ -241,14 +241,14 @@ final class AutoTagger extends Extension
         global $database;
 
         // Normalize all tags
-        $tags = array_map('strtolower', $tags_mixed);
+        $tags = $tags_mixed;
         $tag_set = array_flip($tags);
 
         // Load all rules once
         $rows = $database->get_all("SELECT tag, additional_tags FROM auto_tag");
         $rules = [];
         foreach ($rows as $row) {
-            $rules[strtolower($row['tag'])] = Tag::explode($row['additional_tags']);
+            $rules[$row['tag']] = Tag::explode($row['additional_tags']);
         }
 
         $changed = true;
@@ -282,7 +282,6 @@ final class AutoTagger extends Extension
 
                 if ($match) {
                     foreach ($additions as $tag) {
-                        $tag = strtolower($tag);
                         if (!isset($tag_set[$tag])) {
                             $tags[] = $tag;
                             $tag_set[$tag] = true;

--- a/ext/auto_tagger/main.php
+++ b/ext/auto_tagger/main.php
@@ -223,8 +223,6 @@ final class AutoTagger extends Extension
                 "Added auto-tag for {$tag} -> {".implode(" ", $additional_tags)."}"
             );
         }
-        // Now we apply it to existing items
-        $this->apply_new_auto_tag($tag);
     }
 
     private function remove_auto_tag(string $tag): void

--- a/ext/auto_tagger/theme.php
+++ b/ext/auto_tagger/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\{A, B, BR, CODE, INPUT, P, emptyHTML};
+use function MicroHTML\{A, B, INPUT, P, emptyHTML};
 
 use MicroHTML\HTMLElement;
 

--- a/ext/auto_tagger/theme.php
+++ b/ext/auto_tagger/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\{A, INPUT, P, emptyHTML};
+use function MicroHTML\{A, B, BR, CODE, INPUT, P, emptyHTML};
 
 use MicroHTML\HTMLElement;
 
@@ -22,6 +22,10 @@ class AutoTaggerTheme extends Themelet
         $this->display_navigation();
 
         $page->add_block(new Block("Auto-Tag", emptyHTML(
+            P("Use the following formats:"),
+            P(B("Basic: "), "tag → auto-tagged"),
+            P(B("AND: "), "tag1+tag2 → auto-tagged"),
+            P(B("AND NOT: "), "tag1+!tag2 → auto-tagged"),
             $table,
             $paginator,
             P(A(

--- a/ext/rating/main.php
+++ b/ext/rating/main.php
@@ -360,14 +360,19 @@ final class Ratings extends Extension
         if (!isset($ratings)) {
             $ratings = self::get_sorted_ratings();
         }
-        return array_combine(
-            array_map(function ($o) {
-                return $o->code;
-            }, $ratings),
-            array_map(function ($o) {
-                return $o->name;
-            }, $ratings)
-        );
+
+        $dict = [];
+        foreach ($ratings as $r) {
+            if (
+                isset($r->code, $r->name) &&
+                is_string($r->code) && is_string($r->name) &&
+                trim($r->code) !== "" && trim($r->name) !== ""
+            ) {
+                $dict[trim($r->code)] = trim($r->name);
+            }
+        }
+
+        return $dict;
     }
 
     /**

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -17,7 +17,12 @@ class RatingsTheme extends Themelet
      */
     public function get_selection_rater_html(string $name = "rating", array $ratings = [], array $selected_options = []): HTMLElement
     {
-        return SHM_SELECT($name, !empty($ratings) ? $ratings : Ratings::get_ratings_dict(), required: true, selected_options: $selected_options);
+        return SHM_SELECT(
+            $name,
+            !empty($ratings) ? Ratings::get_ratings_dict($ratings) : Ratings::get_ratings_dict(),
+            required: true,
+            selected_options: $selected_options
+        );
     }
 
     public function get_image_rater_html(int $image_id, string $rating, bool $can_rate): HTMLElement

--- a/ext/rating/theme.php
+++ b/ext/rating/theme.php
@@ -17,12 +17,7 @@ class RatingsTheme extends Themelet
      */
     public function get_selection_rater_html(string $name = "rating", array $ratings = [], array $selected_options = []): HTMLElement
     {
-        return SHM_SELECT(
-            $name,
-            !empty($ratings) ? Ratings::get_ratings_dict($ratings) : Ratings::get_ratings_dict(),
-            required: true,
-            selected_options: $selected_options
-        );
+        return SHM_SELECT($name, !empty($ratings) ? $ratings : Ratings::get_ratings_dict(), required: true, selected_options: $selected_options);
     }
 
     public function get_image_rater_html(int $image_id, string $rating, bool $can_rate): HTMLElement


### PR DESCRIPTION
I'm not sure if this type of drastic change is acceptable or not, but I added AND as well as ANDNOT functionality to the auto_tagger extension and rewrote small parts of the theme to handle it. The update to rating was necessary because somehow something was breaking somewhere and this seems to be much more stable if anything isn't perfect.