### PR TITLE
[image] show delete button if user can delete own image

### DIFF
--- a/ext/image/main.php
+++ b/ext/image/main.php
@@ -63,7 +63,8 @@ final class ImageIO extends Extension
 
     public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
     {
-        if (Ctx::$user->can(ImagePermission::DELETE_IMAGE)) {
+        $image = Image::by_id_ex($event->image->id);
+        if ($this->can_user_delete_image(Ctx::$user, $image)) {
             $event->add_part(SHM_FORM(
                 action: make_link("image/delete"),
                 id: "image_delete_form",


### PR DESCRIPTION
Fixes permission check to show the delete button to users only able to delete specific images. I didn't realize this line wasn't updated ^^