### PR TITLE
[lowercase] allow admin to force lowercase tags

### DIFF
--- a/core/ImageBoard/Tag.php
+++ b/core/ImageBoard/Tag.php
@@ -33,6 +33,11 @@ final class Tag
         );
         if (empty($id)) {
             // a new tag
+
+            // lowercase extension ruins unit tests, so disable during testing
+            if (!defined("UNITTEST") && ForceLowercaseInfo::is_enabled()) {
+                $tag = mb_strtolower($tag);
+            }
             Ctx::$database->execute(
                 "INSERT INTO tags(tag) VALUES (:tag)",
                 ["tag" => $tag]

--- a/ext/force_lowercase/info.php
+++ b/ext/force_lowercase/info.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+final class ForceLowercaseInfo extends ExtensionInfo
+{
+    public const KEY = "force_lowercase";
+
+    public string $key = self::KEY;
+    public string $name = "Force Lowercase";
+    public array $authors = ["Discomrade" => ""];
+    public string $license = self::LICENSE_WTFPL;
+    public ExtensionCategory $category = ExtensionCategory::GENERAL;
+    public string $description = "Forces tags to lowercase letters, similar to other booru softwares. Read the docs.";
+    public ?string $documentation = "This does not change existing tags. Use the <a href='/admin#Misc_Admin_Toolsmain'>board admin tool</a> to set all existing tags to lowercase.";
+}

--- a/ext/force_lowercase/main.php
+++ b/ext/force_lowercase/main.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+final class ForceLowercase extends Extension
+{
+    public const KEY = "force_lowercase";
+
+}

--- a/ext/force_lowercase/style.css
+++ b/ext/force_lowercase/style.css
@@ -1,0 +1,1 @@
+.autocomplete_tags{text-transform: lowercase;}


### PR DESCRIPTION
- Forces new tags into lowercase before adding to database
- Instructs admins how to change existing tags
- Styles tag fields to show input in lowercase, hinting to users that tags are treated as lowercase

Due to the simple function of the extension and how complicated it would be to handle it in existing unit testing, I believe it is reasonable to disable during unit testing.

The CSS reuses the `autocomplete_tags` class to find tag fields in the HTML. This is admittedly a hack, and therefore this is a draft pull request until this is either accepted or a better solution is decided on. My concerns are that I haven't checked if all tag fields are `autocomplete_tags` fields, and if so, should `autocomplete_tags` simply be replaced with `tags`?