### PR TITLE
[post_tags] option to force tags to lowercase

### DIFF
--- a/core/ImageBoard/Tag.php
+++ b/core/ImageBoard/Tag.php
@@ -33,6 +33,11 @@ final class Tag
         );
         if (empty($id)) {
             // a new tag
+            // lowercase extension ruins unit tests, so disable during testing
+            if (!defined("UNITTEST") && Ctx::$config->get(PostTagsConfig::FORCE_LOWERCASE)) {
+                $tag = mb_strtolower($tag);
+            }
+
             Ctx::$database->execute(
                 "INSERT INTO tags(tag) VALUES (:tag)",
                 ["tag" => $tag]

--- a/ext/post_tags/config.php
+++ b/ext/post_tags/config.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+final class PostTagsConfig extends ConfigGroup
+{
+    public const KEY = "post_tags";
+
+    #[ConfigMeta(
+        "Force tags to lowercase",
+        ConfigType::BOOL,
+        default: false,
+        advanced: true,
+        help: "This does not change existing tags. Use the Board Admin tool to set all existing tags to lowercase."
+    )]
+    public const FORCE_LOWERCASE = "post_tags_force_lowercase";
+}

--- a/ext/post_tags/main.php
+++ b/ext/post_tags/main.php
@@ -121,6 +121,9 @@ final class PostTags extends Extension
 
     public function onPageRequest(PageRequestEvent $event): void
     {
+        if (Ctx::$config->get(PostTagsConfig::FORCE_LOWERCASE)) {
+            Ctx::$page->add_html_header(\MicroHTML\STYLE(".autocomplete_tags {text-transform: lowercase;}"));
+        }
         if ($event->page_matches("tag_edit/replace", method: "POST", permission: PostTagsPermission::MASS_TAG_EDIT)) {
             $this->mass_tag_edit($event->POST->req('search'), $event->POST->req('replace'), true);
             Ctx::$page->set_redirect(make_link("admin"));
@@ -193,6 +196,7 @@ final class PostTags extends Extension
             send_event(new TagTermParseEvent($tag, $event->image->id));
         }
     }
+
     public function onImageDeletion(ImageDeletionEvent $event): void
     {
         $event->image->delete_tags_from_image();


### PR DESCRIPTION

Based on #1843 by discomrade, but being a part of the post_tags extension rather than being a separate thing
