### PR TITLE
[dev] If Config::get() can only be certain options, reflect that in the type system

### DIFF
--- a/ext/transcode/main.php
+++ b/ext/transcode/main.php
@@ -286,7 +286,6 @@ final class TranscodeImage extends Extension
         return match ($engine) {
             MediaEngine::GD => $this->transcode_image_gd($source_name, $source_mime, $target_mime),
             MediaEngine::IMAGICK => $this->transcode_image_convert($source_name, $source_mime, $target_mime),
-            default => throw new ImageTranscodeException("No engine specified"),
         };
     }
 


### PR DESCRIPTION

Before:
```
dumpType($config->get(TranscodeImageConfig::ENGINE))
string
```

After:
```
dumpType($config->get(TranscodeImageConfig::ENGINE))
"convert"|"gd"
```
