### PR TITLE
[system] fix referer link could be null

### DIFF
--- a/ext/system/main.php
+++ b/ext/system/main.php
@@ -13,7 +13,7 @@ final class System extends Extension
         if ($event->page_matches("system")) {
             $e = send_event(new PageSubNavBuildingEvent("system"));
             usort($e->links, fn (NavLink $a, NavLink $b) => $a->order - $b->order);
-            $link = $e->links[0]->link;
+            $link = $e->links[0]->link ?? Url::referer_or(Url::parse(Ctx::$config->get(SetupConfig::MAIN_PAGE)));
 
             Ctx::$page->set_redirect($link);
         }


### PR DESCRIPTION
If not enough extensions were enabled, or a user did not have enough permissions, the `/system` page would have the redirect be `null`, throwing an error 