### PR TITLE
[wiki] Hide revision stuff if disabled

### DIFF
--- a/ext/wiki/theme.php
+++ b/ext/wiki/theme.php
@@ -182,6 +182,7 @@ class WikiTheme extends Themelet
     {
         $u_title = url_escape($page->title);
         $owner = $page->get_owner();
+        $revisions_enabled = Ctx::$config->get(WikiConfig::ENABLE_REVISIONS);
 
         $formatted_body = self::format_wiki_page($page);
 
@@ -194,7 +195,7 @@ class WikiTheme extends Themelet
             )));
         }
         if (Ctx::$user->can(WikiPermission::ADMIN)) {
-            if (Ctx::$config->get(WikiConfig::ENABLE_REVISIONS)) {
+            if ($revisions_enabled) {
                 $edit->appendChild(
                     TD(SHM_SIMPLE_FORM(
                         make_link("wiki/$u_title/delete_revision"),
@@ -205,20 +206,9 @@ class WikiTheme extends Themelet
             }
             $edit->appendChild(TD(SHM_SIMPLE_FORM(
                 make_link("wiki/$u_title/delete_all"),
-                SHM_SUBMIT("Delete All")
+                SHM_SUBMIT($revisions_enabled ? "Delete All" : "Delete")
             )));
         }
-
-        $p = [];
-
-        if (Ctx::$config->get(WikiConfig::ENABLE_REVISIONS)) {
-            $p[] = A(["href" => make_link("wiki/$u_title/history")], "Revision {$page->revision}");
-            $p[] = " by ";
-        }
-
-        $p[] = A(["href" => make_link("user/{$owner->name}")], $owner->name);
-        $p[] = " at {$page->date}";
-        $p[] = TABLE($edit);
 
         return DIV(
             ["class" => "wiki-page"],
@@ -226,7 +216,15 @@ class WikiTheme extends Themelet
             HR(),
             P(
                 ["class" => "wiki-footer"],
-                ... $p
+                ... $revisions_enabled ? [
+                    A(["href" => make_link("wiki/$u_title/history")], "Revision {$page->revision}"),
+                    " by ",
+                ] : [],
+                ... [
+                    A(["href" => make_link("user/{$owner->name}")], $owner->name),
+                    " at {$page->date}",
+                    TABLE($edit),
+                ]
             )
         );
     }


### PR DESCRIPTION
I understand that toggling revisions on/off is not something admins do often, and it's rather a choice for keeping a history of changes (like tags and sources having their separate extensions for it), so I made a small change to hide revision number and the delete revision form when wiki revisions are disabled.