### PR TITLE
Change to devcontainers + new data attr for thumbs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,8 @@
 		"target": "devcontainer"
 	},
 
+	"overrideCommand": false,
+
 	"workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
 	"workspaceFolder": "/app",
 
@@ -23,7 +25,6 @@
 	},
 
 	"updateContentCommand": "composer install && cp ./.devcontainer/bash_history /root/.bash_history",
-	"postStartCommand": "./.docker/entrypoint.sh php ./.docker/run.php",
 	"containerEnv": {
 		"UID": "2000",
 		"GID": "2000",

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,10 @@ ARG PHP_VERSION=8.4
 # Install base packages
 # Things which all stages (build, test, run) need
 FROM debian:trixie AS base
-COPY --from=mwader/static-ffmpeg:7.1 /ffmpeg /ffprobe /usr/local/bin/
+COPY --from=docker.io/mwader/static-ffmpeg:7.1 /ffmpeg /ffprobe /usr/local/bin/
 RUN apt update && \
     apt upgrade -y && \
-    apt install -y curl && \
-    apt update && apt install -y --no-install-recommends \
+    apt install -y --no-install-recommends \
     supervisor \
     nginx \
     php${PHP_VERSION}-cli php${PHP_VERSION}-fpm \
@@ -47,6 +46,8 @@ COPY . /app/
 # that's mounted from the host
 FROM dev-tools AS devcontainer
 EXPOSE 8000
+ENTRYPOINT ["/app/.docker/entrypoint.sh"]
+CMD ["php", "/app/.docker/run.php"]
 
 # Actually run shimmie
 FROM base AS run

--- a/core/Page/CommonElementsTheme.php
+++ b/core/Page/CommonElementsTheme.php
@@ -109,6 +109,9 @@ class CommonElementsTheme extends Themelet
             "data-mime" => $image->get_mime(),
             "data-post-id" => $id,
         ];
+        if ($image->video) {
+            $attrs["data-video"] = "1";
+        }
         if (RatingsInfo::is_enabled()) {
             $attrs["data-rating"] = $image['rating'];
         }


### PR DESCRIPTION
Bundled these 2 together since I don't see a reason to create a separate PR for the 2nd small commit.

The biggest one here is the change to the devcontainer. I'm looking for feedback on that. Basically:

- Specified docker.io source for podman compatibility.
- Moved the postStartCommand to the Dockerfile itself so that vscode doesn't get stuck on the "Configuring" stage.
- Removed duplicate apt update and install lines.

The other change is just adding a data attribute to thumbnails when the video flag is set. I use it to show a blue border around those in my theme.