### PR TITLE
Add HEVC codec support for MP4 video

### DIFF
--- a/ext/handle_video/main.php
+++ b/ext/handle_video/main.php
@@ -15,6 +15,7 @@ final class VideoFileHandler extends DataHandlerExtension
         MimeType::MP4_VIDEO => [
             VideoCodec::H264,
             VideoCodec::H265,
+            VideoCodec::HEVC,
         ],
         MimeType::WEBM => [
             VideoCodec::VP8,


### PR DESCRIPTION
Currently upload fails for videos if the mime type is identified as HEVC, as H.265 and HEVC are pretty much the same, this shouldn't break anything. Tested it on my install and it works as expected, even with file transforming extensions.