### PR TITLE
[core] use full event class name as event bus key

### DIFF
--- a/core/Events/EventListener.php
+++ b/core/Events/EventListener.php
@@ -8,7 +8,7 @@ namespace Shimmie2;
 class EventListener
 {
     /**
-     * @param class-string|null $event
+     * @param class-string<Event>|null $event
      */
     public function __construct(
         public readonly ?string $event = null,


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/shish/shimmie2/pull/2080).
* __->__ #2080
* #2079
* #2078
* #2077