### PR TITLE
Note extension fixes

### DIFF
--- a/ext/notes/script.js
+++ b/ext/notes/script.js
@@ -285,8 +285,8 @@ Notes.addNewNote = function () {
     window.notes.push({
         x1: Notes.noteImage.dataset.width * 0.2,
         y1: Notes.noteImage.dataset.height * 0.2,
-        width: 100,
-        height: 40,
+        width: Notes.noteImage.dataset.height * 0.2,
+        height: Notes.noteImage.dataset.height * 0.1,
         note: "new note",
         note_id: null,
         image_id: window.notes_image_id,


### PR DESCRIPTION
This should fix the notes from moving about randomly on the screen and the editor of the notes becoming larger when the mouse is touching the bottom-right corner. 