### PR TITLE
[pools] add javascript null check to avoid error

### DIFF
--- a/ext/pools/script.js
+++ b/ext/pools/script.js
@@ -1,9 +1,10 @@
 document.addEventListener("DOMContentLoaded", () => {
-    document
-        .getElementById("order_pool")
-        .addEventListener("change", function () {
+    const order_pool = document.getElementById("order_pool");
+    if (order_pool) {
+        order_pool.addEventListener("change", function () {
             let val = this.options[this.selectedIndex].value;
             shm_cookie_set("ui-order-pool", val);
             window.location.href = "";
         });
+    }
 });


### PR DESCRIPTION
If the Pools extension is enabled, getElementById() would return null on all pages except /pool/list, causing a console error.