### PR TITLE
[report_image] require a report reason, reject excessively long reasons

### DIFF
--- a/ext/report_image/events.php
+++ b/ext/report_image/events.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+final class ReportPostingException extends InvalidInput
+{
+}

--- a/ext/report_image/main.php
+++ b/ext/report_image/main.php
@@ -44,8 +44,14 @@ final class ReportImage extends Extension
     public function onPageRequest(PageRequestEvent $event): void
     {
         if ($event->page_matches("image_report/add")) {
+            $reason = $event->POST->req('reason');
+            if (trim($reason) === "") {
+                throw new ReportPostingException("Reports need text...");
+            } elseif (strlen($reason) > 300) {
+                throw new ReportPostingException("Report too long~");
+            }
             $image_id = int_escape($event->POST->req('image_id'));
-            send_event(new AddReportedImageEvent(new ImageReport($image_id, Ctx::$user->id, $event->POST->req('reason'))));
+            send_event(new AddReportedImageEvent(new ImageReport($image_id, Ctx::$user->id, $reason)));
             Ctx::$page->set_redirect(make_link("post/view/$image_id"));
         }
         if ($event->page_matches("image_report/remove", method: "POST", permission: ReportImagePermission::VIEW_IMAGE_REPORT)) {

--- a/ext/report_image/theme.php
+++ b/ext/report_image/theme.php
@@ -84,7 +84,7 @@ class ReportImageTheme extends Themelet
         $html->appendChild(SHM_SIMPLE_FORM(
             make_link("image_report/add"),
             INPUT(["type" => 'hidden', "name" => 'image_id', "value" => $image->id]),
-            INPUT(["type" => 'text', "name" => 'reason', "placeholder" => 'Please enter a reason']),
+            INPUT(["type" => 'text', "name" => 'reason', "placeholder" => 'Please enter a reason', "required" => ""]),
             SHM_SUBMIT('Report')
         ));
         Ctx::$page->add_block(new Block("Report Post", $html, "left"));


### PR DESCRIPTION
Our booru has received a couple of empty reports on benign images which seem to be reported by accident. This commit adds some checks before accepting a report.