### PR TITLE
[tag_list] avoid using null as an array offset

### DIFF
--- a/ext/tag_list/theme.php
+++ b/ext/tag_list/theme.php
@@ -70,7 +70,7 @@ class TagListTheme extends Themelet
 
         foreach ($tag_infos as $row) {
             $tag = $row['tag'];
-            $category = TagCategories::get_tag_category($tag);
+            $category = TagCategories::get_tag_category($tag) ?? "";
             if (!isset($tag_categories_html[$category])) {
                 $tag_categories_html[$category] = $this->get_tag_list_preamble();
             }


### PR DESCRIPTION
Fixes the PHP 8.5 error 'Using null as an array offset is deprecated, use an empty string instead'