### PR TITLE
[core] rename Image to Post, Media, or Image as appropriate

### DIFF
--- a/core/ImageBoard/MediaReplaceEvent.php
+++ b/core/ImageBoard/MediaReplaceEvent.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Shimmie2;
 
 /**
- * An image is being replaced.
+ * An post's file is being replaced.
  */
-final class ImageReplaceEvent extends Event
+final class MediaReplaceEvent extends Event
 {
     /** @var non-empty-string */
     public readonly string $old_hash;
@@ -22,7 +22,7 @@ final class ImageReplaceEvent extends Event
      * the old image file and thumbnail from the disk.
      */
     public function __construct(
-        public Image $image,
+        public Post $image,
         public Path $tmp_filename,
     ) {
         parent::__construct();

--- a/core/ImageBoard/MediaReplaceException.php
+++ b/core/ImageBoard/MediaReplaceException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-class ImageReplaceException extends SCoreException
+class MediaReplaceException extends SCoreException
 {
 }

--- a/core/ImageBoard/ParseLinkTemplateEvent.php
+++ b/core/ImageBoard/ParseLinkTemplateEvent.php
@@ -14,9 +14,9 @@ final class ParseLinkTemplateEvent extends Event
 {
     public string $link;
     public string $text;
-    public readonly Image $image;
+    public readonly Post $image;
 
-    public function __construct(string $link, Image $image)
+    public function __construct(string $link, Post $image)
     {
         parent::__construct();
         $this->link = $link;

--- a/core/ImageBoard/PostAdditionEvent.php
+++ b/core/ImageBoard/PostAdditionEvent.php
@@ -7,15 +7,15 @@ namespace Shimmie2;
 /**
  * An image is being added to the database.
  */
-final class ImageAdditionEvent extends Event
+final class PostAdditionEvent extends Event
 {
     /**
      * A new image is being added to the database - just the image,
-     * metadata will come later with ImageInfoSetEvent (and if that
+     * metadata will come later with PostInfoSetEvent (and if that
      * fails, then the image addition transaction will be rolled back)
      */
     public function __construct(
-        public readonly Image $image,
+        public readonly Post $image,
     ) {
         parent::__construct();
     }

--- a/core/ImageBoard/PostDeletionEvent.php
+++ b/core/ImageBoard/PostDeletionEvent.php
@@ -7,7 +7,7 @@ namespace Shimmie2;
 /**
  * An image is being deleted.
  */
-final class ImageDeletionEvent extends Event
+final class PostDeletionEvent extends Event
 {
     /**
      * Deletes an image.
@@ -16,7 +16,7 @@ final class ImageDeletionEvent extends Event
      * clean out related rows in their tables.
      */
     public function __construct(
-        public readonly Image $image,
+        public readonly Post $image,
         public readonly bool $force = false,
     ) {
         parent::__construct();

--- a/core/ImageBoard/PostPropType.php
+++ b/core/ImageBoard/PostPropType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-enum ImagePropType
+enum PostPropType
 {
     case BOOL;
     case INT;

--- a/core/ImageBoard/PostTest.php
+++ b/core/ImageBoard/PostTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-final class ImageTest extends ShimmiePHPUnitTestCase
+final class PostTest extends ShimmiePHPUnitTestCase
 {
     public function testLoadData(): void
     {
         self::log_in_as_user();
         $image_id_1 = $this->post_image("tests/pbx_screenshot.jpg", "AC/DC");
-        $image = Image::by_id_ex($image_id_1);
+        $image = Post::by_id_ex($image_id_1);
         self::assertNull($image->source);
         self::assertEquals("pbx_screenshot.jpg", $image->filename);
 

--- a/core/ImageBoard/ThumbnailGenerationEvent.php
+++ b/core/ImageBoard/ThumbnailGenerationEvent.php
@@ -15,7 +15,7 @@ final class ThumbnailGenerationEvent extends Event
      * Request a thumbnail be made for an image object
      */
     public function __construct(
-        public readonly Image $image,
+        public readonly Post $image,
         public readonly bool $force = false
     ) {
         parent::__construct();

--- a/core/ImageBoard/ThumbnailUtil.php
+++ b/core/ImageBoard/ThumbnailUtil.php
@@ -100,7 +100,7 @@ final class ThumbnailUtil
         return [$max_width, $max_height];
     }
 
-    public static function create_image_thumb(Image $image, ?MediaEngine $engine = null): void
+    public static function create_image_thumb(Post $image, ?MediaEngine $engine = null): void
     {
         self::create_scaled_image(
             $image->get_image_filename(),

--- a/core/Media/MediaCheckPropertiesEvent.php
+++ b/core/Media/MediaCheckPropertiesEvent.php
@@ -7,7 +7,7 @@ namespace Shimmie2;
 final class MediaCheckPropertiesEvent extends Event
 {
     public function __construct(
-        public readonly Image $image
+        public readonly Post $image
     ) {
         parent::__construct();
     }

--- a/core/Page/CommonElementsTheme.php
+++ b/core/Page/CommonElementsTheme.php
@@ -75,7 +75,7 @@ class CommonElementsTheme extends Themelet
      * Generic thumbnail code; returns HTML rather than adding
      * a block since thumbs tend to go inside blocks...
      */
-    public function build_thumb(Image $image): HTMLElement
+    public function build_thumb(Post $image): HTMLElement
     {
         $id = $image->id;
         $view_link = make_link('post/view/'.$id);

--- a/core/Page/Themelet.php
+++ b/core/Page/Themelet.php
@@ -74,7 +74,7 @@ class Themelet
         return self::get_common()->build_tag($tag, $show_underscores, $show_category, $style);
     }
 
-    public function build_thumb(Image $image): HTMLElement
+    public function build_thumb(Post $image): HTMLElement
     {
         return self::get_common()->build_thumb($image);
     }

--- a/core/Search/MetadataCondition.php
+++ b/core/Search/MetadataCondition.php
@@ -9,7 +9,7 @@ namespace Shimmie2;
  * "id:123", "width:100", etc - an extension will spot those meta-tags and turn
  * them into a little chunk of SQL
  */
-final readonly class ImgCondition
+final readonly class MetadataCondition
 {
     public function __construct(
         public Querylet $qlet,

--- a/core/Search/Search.php
+++ b/core/Search/Search.php
@@ -23,7 +23,7 @@ final class Search
      *
      * @param search-term-array $terms
      */
-    private static function find_images_internal(int $start = 0, ?int $limit = null, array $terms = []): \FFSPHP\PDOStatement
+    private static function find_posts_internal(int $start = 0, ?int $limit = null, array $terms = []): \FFSPHP\PDOStatement
     {
         if ($start < 0) {
             $start = 0;
@@ -53,16 +53,16 @@ final class Search
      * Search for an array of images
      *
      * @param search-term-array $terms
-     * @return Image[]
+     * @return Post[]
      */
     #[Query(name: "posts", type: "[Post!]!", args: ["terms" => "[string!]"])]
-    public static function find_images(int $offset = 0, ?int $limit = null, array $terms = []): array
+    public static function find_posts(int $offset = 0, ?int $limit = null, array $terms = []): array
     {
-        $result = self::find_images_internal($offset, $limit, $terms);
+        $result = self::find_posts_internal($offset, $limit, $terms);
 
         $images = [];
         foreach ($result as $row) {
-            $images[] = new Image($row);
+            $images[] = new Post($row);
         }
         return $images;
     }
@@ -71,13 +71,13 @@ final class Search
      * Search for an array of images, returning a iterable object of Image
      *
      * @param search-term-array $terms
-     * @return \Generator<Image>
+     * @return \Generator<Post>
      */
-    public static function find_images_iterable(int $start = 0, ?int $limit = null, array $terms = []): \Generator
+    public static function find_posts_iterable(int $start = 0, ?int $limit = null, array $terms = []): \Generator
     {
-        $result = self::find_images_internal($start, $limit, $terms);
+        $result = self::find_posts_internal($start, $limit, $terms);
         foreach ($result as $row) {
-            yield new Image($row);
+            yield new Post($row);
         }
     }
 
@@ -86,12 +86,12 @@ final class Search
      * with all the search stuff (rating filters etc) taken into account
      *
      * @param int[] $ids
-     * @return Image[]
+     * @return Post[]
      */
-    public static function get_images(array $ids): array
+    public static function get_posts(array $ids): array
     {
         $visible_images = [];
-        foreach (Search::find_images(terms: ["id=" . implode(",", $ids)]) as $image) {
+        foreach (Search::find_posts(terms: ["id=" . implode(",", $ids)]) as $image) {
             $visible_images[$image->id] = $image;
         }
         $visible_ids = array_keys($visible_images);
@@ -116,7 +116,7 @@ final class Search
         );
     }
 
-    private static function count_total_images(): int
+    private static function count_total_posts(): int
     {
         return cache_get_or_set("image-count", fn () => (int)Ctx::$database->get_one("SELECT COUNT(*) FROM images"), 600);
     }
@@ -126,7 +126,7 @@ final class Search
      *
      * @param search-term-array $terms
      */
-    public static function count_images(array $terms = []): int
+    public static function count_posts(array $terms = []): int
     {
         $term_count = count($terms);
 
@@ -135,13 +135,13 @@ final class Search
         $limit_complex = (Ctx::$config->get(IndexConfig::LIMIT_COMPLEX));
         if ($limit_complex && $term_count === 0) {
             // total number of images in the DB
-            $total = self::count_total_images();
+            $total = self::count_total_posts();
         } elseif ($limit_complex && $term_count === 1 && !\Safe\preg_match("/[:=><\*\?]/", $terms[0])) {
             if (str_starts_with($terms[0], "-")) {
                 // one negative tag - subtract from the total
                 $tag = substr($terms[0], 1);
                 assert(strlen($tag) > 0);
-                $total = self::count_total_images() - self::count_tag($tag);
+                $total = self::count_total_posts() - self::count_tag($tag);
             } else {
                 // one positive tag - we can look that up directly
                 $total = self::count_tag($terms[0]);

--- a/core/Search/SearchParameters.php
+++ b/core/Search/SearchParameters.php
@@ -8,7 +8,7 @@ final class SearchParameters
 {
     /**
      * @param TagCondition[] $tag_conditions
-     * @param ImgCondition[] $img_conditions
+     * @param MetadataCondition[] $img_conditions
      */
     public function __construct(
         public readonly array $tag_conditions = [],

--- a/core/Search/SearchParametersTest.php
+++ b/core/Search/SearchParametersTest.php
@@ -11,7 +11,7 @@ final class SearchParametersTest extends ShimmiePHPUnitTestCase
     /**
      * @param string $tags
      * @param TagCondition[] $expected_tag_conditions
-     * @param ImgCondition[] $expected_img_conditions
+     * @param MetadataCondition[] $expected_img_conditions
      * @param string $expected_order
      */
     private function assert_TTC(
@@ -43,11 +43,11 @@ final class SearchParametersTest extends ShimmiePHPUnitTestCase
             [
             ],
             [
-                new ImgCondition(new Querylet("trash != TRUE")),
-                new ImgCondition(new Querylet("approved = TRUE")),
-                new ImgCondition(new Querylet("private != TRUE OR owner_id = :private_owner_id", [
+                new MetadataCondition(new Querylet("trash != TRUE")),
+                new MetadataCondition(new Querylet("approved = TRUE")),
+                new MetadataCondition(new Querylet("private != TRUE OR owner_id = :private_owner_id", [
                     "private_owner_id" => 1])),
-                new ImgCondition(new Querylet("rating IN ('?', 's', 'q', 'e')", [])),
+                new MetadataCondition(new Querylet("rating IN ('?', 's', 'q', 'e')", [])),
             ],
             "images.id DESC"
         );
@@ -60,12 +60,12 @@ final class SearchParametersTest extends ShimmiePHPUnitTestCase
             [
             ],
             [
-                new ImgCondition(new Querylet("trash != TRUE")),
-                new ImgCondition(new Querylet("approved = TRUE")),
-                new ImgCondition(new Querylet("private != TRUE OR owner_id = :private_owner_id", [
+                new MetadataCondition(new Querylet("trash != TRUE")),
+                new MetadataCondition(new Querylet("approved = TRUE")),
+                new MetadataCondition(new Querylet("private != TRUE OR owner_id = :private_owner_id", [
                     "private_owner_id" => 1])),
-                new ImgCondition(new Querylet("rating IN ('?', 's', 'q', 'e')", [])),
-                new ImgCondition(new Querylet("images.hash = :hash", ["hash" => "1234567890"])),
+                new MetadataCondition(new Querylet("rating IN ('?', 's', 'q', 'e')", [])),
+                new MetadataCondition(new Querylet("images.hash = :hash", ["hash" => "1234567890"])),
             ],
             "images.id DESC"
         );
@@ -78,12 +78,12 @@ final class SearchParametersTest extends ShimmiePHPUnitTestCase
             [
             ],
             [
-                new ImgCondition(new Querylet("trash != TRUE")),
-                new ImgCondition(new Querylet("approved = TRUE")),
-                new ImgCondition(new Querylet("private != TRUE OR owner_id = :private_owner_id", [
+                new MetadataCondition(new Querylet("trash != TRUE")),
+                new MetadataCondition(new Querylet("approved = TRUE")),
+                new MetadataCondition(new Querylet("private != TRUE OR owner_id = :private_owner_id", [
                     "private_owner_id" => 1])),
-                new ImgCondition(new Querylet("rating IN ('?', 's', 'q', 'e')", [])),
-                new ImgCondition(new Querylet("width / :width1 = height / :height1", ['width1' => 42,
+                new MetadataCondition(new Querylet("rating IN ('?', 's', 'q', 'e')", [])),
+                new MetadataCondition(new Querylet("width / :width1 = height / :height1", ['width1' => 42,
                 'height1' => 12345])),
             ],
             "images.id DESC"
@@ -97,11 +97,11 @@ final class SearchParametersTest extends ShimmiePHPUnitTestCase
             [
             ],
             [
-                new ImgCondition(new Querylet("trash != TRUE")),
-                new ImgCondition(new Querylet("approved = TRUE")),
-                new ImgCondition(new Querylet("private != TRUE OR owner_id = :private_owner_id", [
+                new MetadataCondition(new Querylet("trash != TRUE")),
+                new MetadataCondition(new Querylet("approved = TRUE")),
+                new MetadataCondition(new Querylet("private != TRUE OR owner_id = :private_owner_id", [
                     "private_owner_id" => 1])),
-                new ImgCondition(new Querylet("rating IN ('?', 's', 'q', 'e')", [])),
+                new MetadataCondition(new Querylet("rating IN ('?', 's', 'q', 'e')", [])),
             ],
             "images.numeric_score DESC"
         );

--- a/core/Search/SearchTest.php
+++ b/core/Search/SearchTest.php
@@ -30,15 +30,15 @@ final class SearchTest extends ShimmiePHPUnitTestCase
         $this->post_image("tests/bedroom_workshop.jpg", "question. colon_thing exclamation%");
         $this->post_image("tests/favicon.png", "another");
 
-        $is1 = Search::find_images(0, null, ["order=random_4123"]);
+        $is1 = Search::find_posts(0, null, ["order=random_4123"]);
         $ids1 = array_map(fn ($image) => $image->id, $is1);
         self::assertEquals(3, count($ids1));
 
-        $is2 = Search::find_images(0, null, ["order=random_4123"]);
+        $is2 = Search::find_posts(0, null, ["order=random_4123"]);
         $ids2 = array_map(fn ($image) => $image->id, $is2);
         self::assertEquals(3, count($ids1));
 
-        $is3 = Search::find_images(0, null, ["order=random_6543"]);
+        $is3 = Search::find_posts(0, null, ["order=random_6543"]);
         $ids3 = array_map(fn ($image) => $image->id, $is3);
         self::assertEquals(3, count($ids3));
 
@@ -348,7 +348,7 @@ final class SearchTest extends ShimmiePHPUnitTestCase
     * Meta Search        *
     * * * * * * * * * * */
     #[Depends('testUpload')]
-    public function testBSQ_ImgCond_NoResults(): void
+    public function testBSQ_MetaCond_NoResults(): void
     {
         $this->testUpload();
         self::assert_BSQ(
@@ -364,7 +364,7 @@ final class SearchTest extends ShimmiePHPUnitTestCase
     }
 
     #[Depends('testUpload')]
-    public function testBSQ_ImgCond_OneResult(): void
+    public function testBSQ_MetaCond_OneResult(): void
     {
         $image_ids = $this->testUpload();
         self::assert_BSQ(
@@ -385,7 +385,7 @@ final class SearchTest extends ShimmiePHPUnitTestCase
     }
 
     #[Depends('testUpload')]
-    public function testBSQ_ImgCond_ManyResults(): void
+    public function testBSQ_MetaCond_ManyResults(): void
     {
         $image_ids = $this->testUpload();
 
@@ -410,7 +410,7 @@ final class SearchTest extends ShimmiePHPUnitTestCase
     * Mixed              *
     * * * * * * * * * * */
     #[Depends('testUpload')]
-    public function testBSQ_TagCondWithImgCond(): void
+    public function testBSQ_TagCondWithMetaCond(): void
     {
         $image_ids = $this->testUpload();
         // multiple tags, many results
@@ -430,10 +430,10 @@ final class SearchTest extends ShimmiePHPUnitTestCase
     {
         $image_ids = $this->testUpload();
 
-        $res = Search::get_images($image_ids);
+        $res = Search::get_posts($image_ids);
         self::assertGreaterThan($res[0]->id, $res[1]->id);
 
-        $res = Search::get_images(array_reverse($image_ids));
+        $res = Search::get_posts(array_reverse($image_ids));
         self::assertLessThan($res[0]->id, $res[1]->id);
     }
 }

--- a/core/Testing/ShimmiePHPUnitTestCase.php
+++ b/core/Testing/ShimmiePHPUnitTestCase.php
@@ -63,7 +63,7 @@ abstract class ShimmiePHPUnitTestCase extends \PHPUnit\Framework\TestCase
         // Rolling back the transaction will remove any metadata,
         // but we also want to delete any uploaded files.
         foreach (Ctx::$database->get_col("SELECT id FROM images") as $image_id) {
-            send_event(new ImageDeletionEvent(Image::by_id_ex((int)$image_id), true));
+            send_event(new PostDeletionEvent(Post::by_id_ex((int)$image_id), true));
         }
 
         Ctx::$database->execute("ROLLBACK TO test_start");
@@ -212,7 +212,7 @@ abstract class ShimmiePHPUnitTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function assert_search_results(array $tags, array $results, string $message = ''): void
     {
-        $images = Search::find_images(0, null, $tags);
+        $images = Search::find_posts(0, null, $tags);
         $ids = [];
         foreach ($images as $image) {
             $ids[] = $image->id;
@@ -268,9 +268,9 @@ abstract class ShimmiePHPUnitTestCase extends \PHPUnit\Framework\TestCase
 
     protected function delete_image(int $image_id): void
     {
-        $img = Image::by_id($image_id);
+        $img = Post::by_id($image_id);
         if ($img) {
-            send_event(new ImageDeletionEvent($img, true));
+            send_event(new PostDeletionEvent($img, true));
         }
     }
 }

--- a/ext/approval/main.php
+++ b/ext/approval/main.php
@@ -12,12 +12,12 @@ final class Approval extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["approved"] = ImagePropType::BOOL;
-        Image::$prop_types["approved_by_id"] = ImagePropType::INT;
+        Post::$prop_types["approved"] = PostPropType::BOOL;
+        Post::$prop_types["approved_by_id"] = PostPropType::INT;
     }
 
     #[EventListener]
-    public function onImageAddition(ImageAdditionEvent $event): void
+    public function onPostAddition(PostAdditionEvent $event): void
     {
         if (defined("UNITTEST") || Ctx::$user->can(ApprovalPermission::BYPASS_IMAGE_APPROVAL)) {
             self::approve_image($event->image->id);
@@ -76,7 +76,7 @@ final class Approval extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         if (!$this->check_permissions($event->image)) {
             Ctx::$page->set_redirect(make_link());
@@ -175,7 +175,7 @@ final class Approval extends Extension
         );
     }
 
-    private function check_permissions(Image $image): bool
+    private function check_permissions(Post $image): bool
     {
         return (
             $image['approved']
@@ -196,7 +196,7 @@ final class Approval extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (Ctx::$user->can(ApprovalPermission::APPROVE_IMAGE)) {
             if ($event->image['approved'] === true) {

--- a/ext/artists/main.php
+++ b/ext/artists/main.php
@@ -10,7 +10,7 @@ final class AuthorSetEvent extends Event
      * @param non-empty-string $author
      */
     public function __construct(
-        public Image $image,
+        public Post $image,
         public User $user,
         public string $author
     ) {
@@ -35,11 +35,11 @@ final class Artists extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["author"] = ImagePropType::STRING;
+        Post::$prop_types["author"] = PostPropType::STRING;
     }
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         $author = $event->get_param("author");
         if (Ctx::$user->can(ArtistsPermission::EDIT_IMAGE_ARTIST) && $author) {
@@ -48,7 +48,7 @@ final class Artists extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         $artistName = $this->get_artistName_by_imageID($event->image->id);
         if (Ctx::$user->can(ArtistsPermission::EDIT_ARTIST_INFO)) {
@@ -199,7 +199,7 @@ final class Artists extends Extension
             $userIsLogged = $user->can(ArtistsPermission::EDIT_ARTIST_INFO);
             $userIsAdmin = $user->can(ArtistsPermission::ADMIN);
 
-            $images = Search::find_images(limit: 4, terms: SearchTerm::explode($artist['name']));
+            $images = Search::find_posts(limit: 4, terms: SearchTerm::explode($artist['name']));
 
             $this->theme->show_artist($artist, $aliases, $members, $urls, $images, $userIsLogged, $userIsAdmin);
 

--- a/ext/artists/test.php
+++ b/ext/artists/test.php
@@ -10,7 +10,7 @@ final class ArtistsTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx computer screenshot");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
         send_event(new AuthorSetEvent($image, Ctx::$user, "bob"));
 

--- a/ext/artists/theme.php
+++ b/ext/artists/theme.php
@@ -373,7 +373,7 @@ class ArtistsTheme extends Themelet
      * @param ArtistAlias[] $aliases
      * @param ArtistMember[] $members
      * @param ArtistUrl[] $urls
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function show_artist(array $artist, array $aliases, array $members, array $urls, array $images, bool $userIsLogged, bool $userIsAdmin): void
     {

--- a/ext/auto_tagger/main.php
+++ b/ext/auto_tagger/main.php
@@ -234,7 +234,7 @@ final class AutoTagger extends Extension
             $image_ids = $database->get_col_iterable("SELECT image_id FROM  image_tags WHERE tag_id = :tag_id", ["tag_id" => $tag_id]);
             foreach ($image_ids as $image_id) {
                 $image_id = (int) $image_id;
-                $image = Image::by_id_ex($image_id);
+                $image = Post::by_id_ex($image_id);
                 send_event(new TagSetEvent($image, $image->get_tag_array()));
             }
         }

--- a/ext/automatic1111_tagger/main.php
+++ b/ext/automatic1111_tagger/main.php
@@ -14,7 +14,7 @@ class Automatic1111Tagger extends Extension
         // Handle interrogation request
         if ($event->page_matches("automatic1111_tagger/interrogate/{post_id}")) {
             $post_id = $event->get_iarg('post_id');
-            $image_obj = Image::by_id_ex($post_id);
+            $image_obj = Post::by_id_ex($post_id);
             $image_contents = $image_obj->get_image_filename()->get_contents();
             $image_data = base64_encode($image_contents);
             $payload = [
@@ -54,7 +54,7 @@ class Automatic1111Tagger extends Extension
 
         if ($event->page_matches("automatic1111_tagger/get_rating/{post_id}")) {
             $post_id = $event->get_iarg('post_id');
-            $image_obj = Image::by_id_ex($post_id);
+            $image_obj = Post::by_id_ex($post_id);
             $image_contents = $image_obj->get_image_filename()->get_contents();
             $image_data = base64_encode($image_contents);
             $payload = [
@@ -76,7 +76,7 @@ class Automatic1111Tagger extends Extension
     /**
      * @param array<string, int> $rating_arr
      */
-    private function handle_rating(Image $image_obj, array $rating_arr): void
+    private function handle_rating(Post $image_obj, array $rating_arr): void
     {
         $max_rating = null;
         $max_value = -1;
@@ -101,7 +101,7 @@ class Automatic1111Tagger extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (Ctx::$user->can(Automatic1111TaggerPermission::INTERROGATE_IMAGE)) {
             $event->add_button("Interrogate", "automatic1111_tagger/interrogate/{$event->image->id}");

--- a/ext/avatar_post/main.php
+++ b/ext/avatar_post/main.php
@@ -40,7 +40,7 @@ final class AvatarPost extends AvatarExtension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (Ctx::$user->can(UserAccountsPermission::CHANGE_USER_SETTING)) {
             $event->add_button("Set Image As Avatar", "set_avatar/".$event->image->id);
@@ -67,7 +67,7 @@ final class AvatarPost extends AvatarExtension
         if ($id === null) {
             return null;
         }
-        $image = Image::by_id($id);
+        $image = Post::by_id($id);
         if (!$image) {
             $user_config->delete(AvatarPostUserConfig::AVATAR_ID);
             return null;

--- a/ext/avatar_post/theme.php
+++ b/ext/avatar_post/theme.php
@@ -15,7 +15,7 @@ class AvatarPostTheme extends Themelet
         $avatar_e = send_event(new BuildAvatarEvent(Ctx::$user));
         $current = $avatar_e->html;
 
-        $image = Image::by_id($image_id);
+        $image = Post::by_id($image_id);
         if (!$image) {
             throw new PostNotFound("Image $image_id not found");
         }
@@ -25,7 +25,7 @@ class AvatarPostTheme extends Themelet
         Ctx::$page->add_block(new Block("Avatar Editor", $this->avatar_editor_html($image)));
     }
 
-    public function avatar_editor_html(Image $image): HTMLElement
+    public function avatar_editor_html(Post $image): HTMLElement
     {
         $url = $image->get_thumb_link();
         return DIV(

--- a/ext/bone_quality/main.php
+++ b/ext/bone_quality/main.php
@@ -25,7 +25,7 @@ final class BoneQuality extends Extension
             if ($chore_searches) {
                 foreach ($chore_searches as $search) {
                     $search_boned = false;
-                    $search_count = Search::count_images(SearchTerm::explode($search));
+                    $search_count = Search::count_posts(SearchTerm::explode($search));
                     if ($search_count >= $chore_threshold) {
                         $boned = true;
                         $search_boned = true;

--- a/ext/bone_quality/test.php
+++ b/ext/bone_quality/test.php
@@ -23,7 +23,7 @@ final class BoneQualityTest extends ShimmiePHPUnitTestCase
         self::assert_text("Congratulations");
         self::assert_text("tagme</a> remaining: <span>1");
 
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         send_event(new TagSetEvent($image, ["new_tag"]));
 
         self::get_page("bone_quality");

--- a/ext/bulk_actions/main.php
+++ b/ext/bulk_actions/main.php
@@ -197,12 +197,12 @@ final class BulkActions extends Extension
 
     /**
      * @param int[] $data
-     * @return \Generator<Image>
+     * @return \Generator<Post>
      */
     private function yield_items(array $data): \Generator
     {
         foreach ($data as $id) {
-            $image = Image::by_id($id);
+            $image = Post::by_id($id);
             if ($image !== null) {
                 yield $image;
             }
@@ -210,12 +210,12 @@ final class BulkActions extends Extension
     }
 
     /**
-     * @return \Generator<Image>
+     * @return \Generator<Post>
      */
     private function yield_search_results(string $query): \Generator
     {
         $terms = SearchTerm::explode($query);
-        return Search::find_images_iterable(0, null, $terms);
+        return Search::find_posts_iterable(0, null, $terms);
     }
 
     /**
@@ -228,7 +228,7 @@ final class BulkActions extends Extension
     }
 
     /**
-     * @param iterable<Image> $posts
+     * @param iterable<Post> $posts
      * @return array{0: int, 1: int}
      */
     private function delete_posts(iterable $posts): array
@@ -243,7 +243,7 @@ final class BulkActions extends Extension
                         send_event(new AddImageHashBanEvent($post->hash, $reason));
                     }
                 }
-                send_event(new ImageDeletionEvent($post));
+                send_event(new PostDeletionEvent($post));
                 $total++;
                 $size += $post->filesize;
             } catch (\Exception $e) {
@@ -254,7 +254,7 @@ final class BulkActions extends Extension
     }
 
     /**
-     * @param iterable<Image> $items
+     * @param iterable<Post> $items
      */
     private function tag_items(iterable $items, string $tags, bool $replace): int
     {
@@ -299,7 +299,7 @@ final class BulkActions extends Extension
     }
 
     /**
-     * @param iterable<Image> $items
+     * @param iterable<Post> $items
      */
     private function set_source(iterable $items, string $source): int
     {

--- a/ext/bulk_add_csv/main.php
+++ b/ext/bulk_add_csv/main.php
@@ -69,7 +69,7 @@ final class BulkAddCSV extends Extension
                 throw new UploadException("File type not recognised");
             } else {
                 if ($thumbfile->exists()) {
-                    $thumbfile->copy(Filesystem::warehouse_path(Image::THUMBNAIL_DIR, $event->hash));
+                    $thumbfile->copy(Filesystem::warehouse_path(Post::THUMBNAIL_DIR, $event->hash));
                 }
             }
         });

--- a/ext/bulk_download/main.php
+++ b/ext/bulk_download/main.php
@@ -54,7 +54,7 @@ final class BulkDownload extends Extension
                 }
 
                 if ($include_metadata) {
-                    $image_info = send_event(new ImageInfoGetEvent($image))->params;
+                    $image_info = send_event(new PostInfoGetEvent($image))->params;
                     $image_info["hash"] = $image->hash;
                     $image_info["filename"] = $image->filename;
                     $image_info["_filename"] = $image->get_nice_image_name();

--- a/ext/bulk_download/test.php
+++ b/ext/bulk_download/test.php
@@ -15,8 +15,8 @@ final class BulkDownloadTest extends ShimmiePHPUnitTestCase
         $image_id_1 = self::post_image("tests/pbx_screenshot.jpg", "export test1");
         $image_id_2 = self::post_image("tests/favicon.png", "export test2");
 
-        $image1 = Image::by_id_ex($image_id_1);
-        $image2 = Image::by_id_ex($image_id_2);
+        $image1 = Post::by_id_ex($image_id_1);
+        $image2 = Post::by_id_ex($image_id_2);
 
         // Trigger bulk export
         send_event(new BulkActionEvent(

--- a/ext/comment/main.php
+++ b/ext/comment/main.php
@@ -132,7 +132,7 @@ final class Comment
      * @return Comment[]
      */
     #[Field(extends: "Post", name: "comments", type: "[Comment!]!")]
-    public static function get_comments(Image $post): array
+    public static function get_comments(Post $post): array
     {
         return self::get_all_from_image($post->id);
     }
@@ -155,7 +155,7 @@ final class CommentList extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["comments_locked"] = ImagePropType::BOOL;
+        Post::$prop_types["comments_locked"] = PostPropType::BOOL;
     }
 
     #[EventListener]
@@ -305,7 +305,7 @@ final class CommentList extends Extension
 
             $images = [];
             while ($row = $result->fetch()) {
-                $image = Image::by_id((int)$row["image_id"]);
+                $image = Post::by_id((int)$row["image_id"]);
                 if (
                     RatingsInfo::is_enabled() && !is_null($image) &&
                     !in_array($image['rating'], $user_ratings)
@@ -376,7 +376,7 @@ final class CommentList extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         $comments_locked = (bool)Ctx::$database->get_one(
             "SELECT comments_locked FROM images WHERE id = :id",
@@ -391,7 +391,7 @@ final class CommentList extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         if (Ctx::$user->can(CommentPermission::EDIT_COMMENT_LOCK)) {
             $comments_locked = $event->get_param('comments_locked') === "on";
@@ -411,7 +411,7 @@ final class CommentList extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         $comments_locked = (bool)Ctx::$database->get_one(
             "SELECT comments_locked FROM images WHERE id = :id",
@@ -555,7 +555,7 @@ final class CommentList extends Extension
             throw new CommentPostingException("You do not have permission to add comments");
         }
 
-        $image = Image::by_id($image_id);
+        $image = Post::by_id($image_id);
         if (is_null($image)) {
             throw new CommentPostingException("The image does not exist");
         }

--- a/ext/comment/theme.php
+++ b/ext/comment/theme.php
@@ -18,7 +18,7 @@ class CommentListTheme extends Themelet
     /**
      * Display a page with a list of images, and for each image, the image's comments.
      *
-     * @param array<array{0: Image, 1: Comment[]}> $images
+     * @param array<array{0: Post, 1: Comment[]}> $images
      */
     public function display_comment_list(array $images, int $page_number, int $total_pages, bool $can_post): void
     {
@@ -108,12 +108,12 @@ class CommentListTheme extends Themelet
     /**
      * Show comments for an image.
      *
-     * @param Image $image
+     * @param Post $image
      * @param Comment[] $comments
      * @param bool $postbox
      * @param bool $comments_locked
      */
-    public function display_image_comments(Image $image, array $comments, bool $postbox, bool $comments_locked): void
+    public function display_image_comments(Post $image, array $comments, bool $postbox, bool $comments_locked): void
     {
         $this->show_anon_id = true;
         $html = emptyHTML();

--- a/ext/danbooru_api/main.php
+++ b/ext/danbooru_api/main.php
@@ -179,13 +179,13 @@ final class DanbooruApi extends Extension
             $md5list = explode(",", $params['md5']);
             foreach ($md5list as $md5) {
                 assert($md5 !== '');
-                $results[] = Image::by_hash($md5);
+                $results[] = Post::by_hash($md5);
             }
             $count = count($results);
         } elseif (isset($params['id'])) {
             $idlist = explode(",", $params['id']);
             foreach ($idlist as $id) {
-                $results[] = Image::by_id(int_escape($id));
+                $results[] = Post::by_id(int_escape($id));
             }
             $count = count($results);
         } else {
@@ -206,8 +206,8 @@ final class DanbooruApi extends Extension
                 return $element !== "*";
             });
             $tags = array_values($tags); // reindex array because count_images() expects a 0-based array
-            $count = Search::count_images($tags);
-            $results = Search::find_images(max($start, 0), min($limit, 100), $tags);
+            $count = Search::count_posts($tags);
+            $results = Search::find_posts(max($start, 0), min($limit, 100), $tags);
         }
 
         // Now we have the array $results filled with Image objects
@@ -336,7 +336,7 @@ final class DanbooruApi extends Extension
         // It is also currently broken due to some confusion over file variable ($tmp_filename?)
 
         // Does it exist already?
-        $existing = Image::by_hash($hash);
+        $existing = Post::by_hash($hash);
         if (!is_null($existing)) {
             $page->set_code(409);
             $page->add_http_header("X-Danbooru-Errors: duplicate");

--- a/ext/download/events.php
+++ b/ext/download/events.php
@@ -9,7 +9,7 @@ class ImageDownloadingEvent extends Event
     public bool $file_modified = false;
 
     public function __construct(
-        public Image $image,
+        public Post $image,
         public Path $path,
         public MimeType $mime,
         public QueryArray $params

--- a/ext/eokm/main.php
+++ b/ext/eokm/main.php
@@ -9,7 +9,7 @@ final class Eokm extends Extension
     public const KEY = "eokm";
 
     #[EventListener(priority: 40)] // early, to veto ImageUploadEvent
-    public function onImageAddition(ImageAdditionEvent $event): void
+    public function onPostAddition(PostAdditionEvent $event): void
     {
         $username = Ctx::$config->get(EokmConfig::USERNAME);
         $password = Ctx::$config->get(EokmConfig::PASSWORD);

--- a/ext/favorites/main.php
+++ b/ext/favorites/main.php
@@ -25,11 +25,11 @@ final class Favorites extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["favorites"] = ImagePropType::INT;
+        Post::$prop_types["favorites"] = PostPropType::INT;
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (Ctx::$user->can(FavouritesPermission::EDIT_FAVOURITES)) {
             $user_id = Ctx::$user->id;
@@ -49,7 +49,7 @@ final class Favorites extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         $people = $this->list_persons_who_have_favorited($event->image);
         if (count($people) > 0) {
@@ -75,7 +75,7 @@ final class Favorites extends Extension
     #[EventListener]
     public function onUserPageBuilding(UserPageBuildingEvent $event): void
     {
-        $i_favorites_count = Search::count_images(["favorited_by={$event->display_user->name}"]);
+        $i_favorites_count = Search::count_posts(["favorited_by={$event->display_user->name}"]);
         $i_days_old = ((time() - \Safe\strtotime($event->display_user->join_date)) / 86400) + 1;
         $h_favorites_rate = sprintf("%.1f", ($i_favorites_count / $i_days_old));
         $favorites_link = search_link(["favorited_by={$event->display_user->name}"]);
@@ -86,7 +86,7 @@ final class Favorites extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         $action = $event->get_param("favorite_action");
         if (
@@ -107,7 +107,7 @@ final class Favorites extends Extension
     // FIXME: this should be handled by the foreign key. Check that it
     // is, and then remove this
     #[EventListener]
-    public function onImageDeletion(ImageDeletionEvent $event): void
+    public function onPostDeletion(PostDeletionEvent $event): void
     {
         Ctx::$database->execute("DELETE FROM user_favorites WHERE image_id=:image_id", ["image_id" => $event->image->id]);
     }
@@ -251,7 +251,7 @@ final class Favorites extends Extension
     /**
      * @return string[]
      */
-    private function list_persons_who_have_favorited(Image $image): array
+    private function list_persons_who_have_favorited(Post $image): array
     {
         global $database;
 

--- a/ext/featured/main.php
+++ b/ext/featured/main.php
@@ -21,7 +21,7 @@ final class Featured extends Extension
         if ($event->page_matches("featured_image/download")) {
             $fid = Ctx::$config->get(FeaturedConfig::ID);
             if (!is_null($fid)) {
-                $image = Image::by_id($fid);
+                $image = Post::by_id($fid);
                 if (!is_null($image)) {
                     Ctx::$page->set_data($image->get_mime(), $image->get_image_filename()->get_contents());
                 }
@@ -30,9 +30,9 @@ final class Featured extends Extension
         if ($event->page_matches("featured_image/view")) {
             $fid = Ctx::$config->get(FeaturedConfig::ID);
             if (!is_null($fid)) {
-                $image = Image::by_id($fid);
+                $image = Post::by_id($fid);
                 if (!is_null($image)) {
-                    send_event(new DisplayingImageEvent($image));
+                    send_event(new DisplayingPostEvent($image));
                 }
             }
         }
@@ -46,7 +46,7 @@ final class Featured extends Extension
             $image = cache_get_or_set(
                 "featured_image_object:$fid",
                 function () use ($fid) {
-                    $image = Image::by_id($fid);
+                    $image = Post::by_id($fid);
                     if ($image) { // make sure the object is fully populated before saving
                         $image->get_tag_array();
                     }
@@ -66,7 +66,7 @@ final class Featured extends Extension
     }
 
     #[EventListener]
-    public function onImageDeletion(ImageDeletionEvent $event): void
+    public function onPostDeletion(PostDeletionEvent $event): void
     {
         if ($event->image->id === Ctx::$config->get(FeaturedConfig::ID)) {
             Ctx::$config->delete(FeaturedConfig::ID);
@@ -74,7 +74,7 @@ final class Featured extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (Ctx::$user->can(FeaturedPermission::EDIT_FEATURE) && $event->context === "view") {
             $event->add_button("Feature This", "featured_image/set/{$event->image->id}");

--- a/ext/featured/theme.php
+++ b/ext/featured/theme.php
@@ -8,12 +8,12 @@ use function MicroHTML\{A, DIV, IMG};
 
 class FeaturedTheme extends Themelet
 {
-    public function display_featured(Image $image): void
+    public function display_featured(Post $image): void
     {
         Ctx::$page->add_block(new Block("Featured Post", $this->build_featured_html($image), "left", 3));
     }
 
-    public function build_featured_html(Image $image): \MicroHTML\HTMLElement
+    public function build_featured_html(Post $image): \MicroHTML\HTMLElement
     {
         $tsize = $image->get_thumb_size();
 

--- a/ext/forum/main.php
+++ b/ext/forum/main.php
@@ -83,7 +83,7 @@ final class ForumThread
     }
 }
 
-/** @phpstan-type Post array{id:int,thread_id:int,user_id:int,date:string,message:string,edited:bool|int} */
+/** @phpstan-type ForumPostArray array{id:int,thread_id:int,user_id:int,date:string,message:string,edited:bool|int} */
 final class ForumPost
 {
     public User $owner;
@@ -98,7 +98,7 @@ final class ForumPost
         $this->owner = User::by_id_dangerously_cached($owner_id);
     }
 
-    /** @param Post $row */
+    /** @param ForumPostArray $row */
     public static function from_row(array $row): ForumPost
     {
         return new ForumPost(
@@ -113,7 +113,7 @@ final class ForumPost
 
     public static function by_id(int $id, int $thread_id): ForumPost
     {
-        /** @var ?Post */
+        /** @var ?ForumPostArray */
         $row = Ctx::$database->get_row(
             'SELECT * FROM forum_posts
             WHERE id = :id
@@ -130,7 +130,7 @@ final class ForumPost
     /** @return ForumPost[] */
     public static function get_all_posts(int $thread_id, int $page_n = 0, int $posts_per_page = 15): array
     {
-        /** @var Post[] */
+        /** @var ForumPostArray[] */
         $posts = Ctx::$database->get_all(
             'SELECT * FROM forum_posts
             WHERE thread_id = :thread_id

--- a/ext/graphql/main.php
+++ b/ext/graphql/main.php
@@ -28,15 +28,15 @@ final class MetadataInput
      * @param array<MetadataInput> $metadata
      */
     #[\GQLA\Mutation(args: ["post_id" => "Int!", "metadata" => "[MetadataInput!]!"])]
-    public static function update_post_metadata(int $post_id, array $metadata): Image
+    public static function update_post_metadata(int $post_id, array $metadata): Post
     {
-        $image = Image::by_id_ex($post_id);
+        $image = Post::by_id_ex($post_id);
         $pairs = new QueryArray([]);
         foreach ($metadata as $m) {
             $pairs[$m->key] = $m->value;
         }
-        send_event(new ImageInfoSetEvent($image, 0, $pairs));
-        return Image::by_id_ex($post_id);
+        send_event(new PostInfoSetEvent($image, 0, $pairs));
+        return Post::by_id_ex($post_id);
     }
 }
 

--- a/ext/graphql/test.php
+++ b/ext/graphql/test.php
@@ -30,7 +30,7 @@ final class GraphQLTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "test");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
         $result = $this->graphql('{
             posts(limit: 3, offset: 0) {

--- a/ext/handle_audio/main.php
+++ b/ext/handle_audio/main.php
@@ -9,7 +9,7 @@ final class AudioFileHandler extends DataHandlerExtension
     public const KEY = "handle_audio";
     public const SUPPORTED_MIME = [MimeType::MP3, MimeType::OGG_AUDIO, MimeType::FLAC];
 
-    protected function media_check_properties(Image $image): MediaProperties
+    protected function media_check_properties(Post $image): MediaProperties
     {
         try {
             $command = new CommandBuilder(Ctx::$config->get(VideoFileHandlerConfig::FFPROBE_PATH));
@@ -38,7 +38,7 @@ final class AudioFileHandler extends DataHandlerExtension
         );
     }
 
-    protected function create_thumb(Image $image): bool
+    protected function create_thumb(Post $image): bool
     {
         (new Path("ext/handle_audio/thumb.jpg"))->copy($image->get_thumb_filename());
         return true;

--- a/ext/handle_audio/theme.php
+++ b/ext/handle_audio/theme.php
@@ -8,7 +8,7 @@ use function MicroHTML\{AUDIO, SOURCE, emptyHTML};
 
 class AudioFileHandlerTheme extends Themelet
 {
-    public function build_media(Image $image): \MicroHTML\HTMLElement
+    public function build_media(Post $image): \MicroHTML\HTMLElement
     {
         $ilink = $image->get_image_link();
 

--- a/ext/handle_cbz/main.php
+++ b/ext/handle_cbz/main.php
@@ -9,7 +9,7 @@ final class CBZFileHandler extends DataHandlerExtension
     public const KEY = "handle_cbz";
     public const SUPPORTED_MIME = [MimeType::COMIC_ZIP];
 
-    protected function media_check_properties(Image $image): MediaProperties
+    protected function media_check_properties(Post $image): MediaProperties
     {
         $tmp = $this->get_representative_image($image->get_image_filename());
         $info = getimagesize($tmp->str());
@@ -35,7 +35,7 @@ final class CBZFileHandler extends DataHandlerExtension
         );
     }
 
-    protected function create_thumb(Image $image): bool
+    protected function create_thumb(Post $image): bool
     {
         $cover = $this->get_representative_image($image->get_image_filename());
         ThumbnailUtil::create_scaled_image(

--- a/ext/handle_cbz/theme.php
+++ b/ext/handle_cbz/theme.php
@@ -8,7 +8,7 @@ use function MicroHTML\{A, DIV, IMG, SCRIPT, SELECT, SPAN, emptyHTML};
 
 class CBZFileHandlerTheme extends Themelet
 {
-    public function build_media(Image $image): \MicroHTML\HTMLElement
+    public function build_media(Post $image): \MicroHTML\HTMLElement
     {
         $data_href = Url::base();
         $ilink = $image->get_image_link();

--- a/ext/handle_ico/main.php
+++ b/ext/handle_ico/main.php
@@ -9,7 +9,7 @@ final class IcoFileHandler extends DataHandlerExtension
     public const KEY = "handle_ico";
     public const SUPPORTED_MIME = [MimeType::ICO];
 
-    protected function media_check_properties(Image $image): MediaProperties
+    protected function media_check_properties(Post $image): MediaProperties
     {
         $fp = \Safe\fopen($image->get_image_filename()->str(), "r");
         try {
@@ -35,7 +35,7 @@ final class IcoFileHandler extends DataHandlerExtension
         );
     }
 
-    protected function create_thumb(Image $image): bool
+    protected function create_thumb(Post $image): bool
     {
         try {
             $engine = defined("UNITTEST") ? MediaEngine::STATIC : MediaEngine::IMAGICK;

--- a/ext/handle_ico/test.php
+++ b/ext/handle_ico/test.php
@@ -20,7 +20,7 @@ final class IcoFileHandlerTest extends ShimmiePHPUnitTestCase
         $page = self::get_page("post/view/$image_id");
         self::assertEquals(200, $page->code);
 
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         self::assertEquals("ico", $image->get_ext());
 
         # FIXME: test that the thumb works

--- a/ext/handle_ico/theme.php
+++ b/ext/handle_ico/theme.php
@@ -8,7 +8,7 @@ use function MicroHTML\IMG;
 
 class IcoFileHandlerTheme extends Themelet
 {
-    public function build_media(Image $image): \MicroHTML\HTMLElement
+    public function build_media(Post $image): \MicroHTML\HTMLElement
     {
         return IMG([
             'src' => $image->get_image_link(),

--- a/ext/handle_image/main.php
+++ b/ext/handle_image/main.php
@@ -15,7 +15,7 @@ final class ImageFileHandler extends DataHandlerExtension
         MimeType::AVIF,
     ];
 
-    protected function media_check_properties(Image $image): MediaProperties
+    protected function media_check_properties(Post $image): MediaProperties
     {
         $filename = $image->get_image_filename();
         $mime = $image->get_mime();
@@ -57,7 +57,7 @@ final class ImageFileHandler extends DataHandlerExtension
         return $info && in_array($info[2], $valid);
     }
 
-    protected function create_thumb(Image $image): bool
+    protected function create_thumb(Post $image): bool
     {
         try {
             ThumbnailUtil::create_image_thumb($image);

--- a/ext/handle_image/theme.php
+++ b/ext/handle_image/theme.php
@@ -8,7 +8,7 @@ use function MicroHTML\{BR, IMG, joinHTML};
 
 class ImageFileHandlerTheme extends Themelet
 {
-    public function build_media(Image $image): \MicroHTML\HTMLElement
+    public function build_media(Post $image): \MicroHTML\HTMLElement
     {
         return IMG([
             'id' => 'main_image',
@@ -22,7 +22,7 @@ class ImageFileHandlerTheme extends Themelet
         ]);
     }
 
-    public function display_metadata(Image $image): void
+    public function display_metadata(Post $image): void
     {
         if (function_exists("exif_read_data")) {
             # FIXME: only read from jpegs?

--- a/ext/handle_image_extra/test.php
+++ b/ext/handle_image_extra/test.php
@@ -32,7 +32,7 @@ final class ExtraImageFileHandlerTest extends ShimmiePHPUnitTestCase
         self::assertEquals(200, $page->code);
 
         // check that it was converted to png
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         self::assertEquals("image/png", $image->get_mime());
     }
 }

--- a/ext/handle_svg/main.php
+++ b/ext/handle_svg/main.php
@@ -31,7 +31,7 @@ final class SVGFileHandler extends DataHandlerExtension
         }
     }
 
-    protected function media_check_properties(Image $image): MediaProperties
+    protected function media_check_properties(Post $image): MediaProperties
     {
         $msp = new MiniSVGParser($image->get_image_filename()->str());
         return new MediaProperties(
@@ -46,7 +46,7 @@ final class SVGFileHandler extends DataHandlerExtension
         );
     }
 
-    protected function create_thumb(Image $image): bool
+    protected function create_thumb(Post $image): bool
     {
         try {
             // Normally we require imagemagick, but for unit tests we can use a no-op engine

--- a/ext/handle_svg/test.php
+++ b/ext/handle_svg/test.php
@@ -13,7 +13,7 @@ final class SVGFileHandlerTest extends ShimmiePHPUnitTestCase
         self::get_page("post/view/$image_id"); // test for no crash
         self::get_page("image/$image_id/foo.svg"); // test for no crash
 
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         self::assertStringContainsString("www.w3.org", $image->get_image_filename()->get_contents());
 
         $page = self::get_page("thumb/$image_id/foo.jpg"); // check thumbnail was generated
@@ -30,7 +30,7 @@ final class SVGFileHandlerTest extends ShimmiePHPUnitTestCase
         self::get_page("post/view/$image_id");
         self::get_page("image/$image_id/foo.svg");
 
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         self::assertStringNotContainsString("script", $image->get_image_filename()->get_contents());
 
         $page = self::get_page("thumb/$image_id/foo.jpg"); // check thumbnail was generated

--- a/ext/handle_svg/theme.php
+++ b/ext/handle_svg/theme.php
@@ -8,7 +8,7 @@ use function MicroHTML\IMG;
 
 class SVGFileHandlerTheme extends Themelet
 {
-    public function build_media(Image $image): \MicroHTML\HTMLElement
+    public function build_media(Post $image): \MicroHTML\HTMLElement
     {
         return IMG([
             'id' => 'main_image',

--- a/ext/handle_video/main.php
+++ b/ext/handle_video/main.php
@@ -12,7 +12,7 @@ final class VideoFileHandler extends DataHandlerExtension
         MimeType::WEBM,
     ];
 
-    protected function media_check_properties(Image $image): MediaProperties
+    protected function media_check_properties(Post $image): MediaProperties
     {
         $video = false;
         $audio = false;
@@ -69,7 +69,7 @@ final class VideoFileHandler extends DataHandlerExtension
         );
     }
 
-    protected function create_thumb(Image $image): bool
+    protected function create_thumb(Post $image): bool
     {
         $inname = $image->get_image_filename();
         $outname = $image->get_thumb_filename();

--- a/ext/handle_video/theme.php
+++ b/ext/handle_video/theme.php
@@ -8,7 +8,7 @@ use function MicroHTML\{A, BR, SOURCE, VIDEO, emptyHTML};
 
 class VideoFileHandlerTheme extends Themelet
 {
-    public function build_media(Image $image): \MicroHTML\HTMLElement
+    public function build_media(Post $image): \MicroHTML\HTMLElement
     {
         $src = $image->get_image_link();
 

--- a/ext/handle_zip/main.php
+++ b/ext/handle_zip/main.php
@@ -63,7 +63,7 @@ final class ZipFileHandler extends DataHandlerExtension
                 }
 
                 // @phpstan-ignore-next-line - we know this is a string from the checks above
-                $image = Image::by_hash($metadata["hash"]);
+                $image = Post::by_hash($metadata["hash"]);
                 if ($image !== null) {
                     $skipped++;
                     Log::info(self::KEY, "$zip_filename already present, skipping");
@@ -108,7 +108,7 @@ final class ZipFileHandler extends DataHandlerExtension
         );
     }
 
-    protected function media_check_properties(Image $image): ?MediaProperties
+    protected function media_check_properties(Post $image): ?MediaProperties
     {
         return null;
     }
@@ -118,7 +118,7 @@ final class ZipFileHandler extends DataHandlerExtension
         return false;
     }
 
-    protected function create_thumb(Image $image): bool
+    protected function create_thumb(Post $image): bool
     {
         return false;
     }
@@ -138,7 +138,7 @@ final class ZipFileHandler extends DataHandlerExtension
      *   ...
      * ]
      *
-     * Output (ImageInfoSetEvent format):
+     * Output (PostInfoSetEvent format):
      * [
      *   "abc123" => QueryArray([
      *     "hash" => "abc123",

--- a/ext/handle_zip/test.php
+++ b/ext/handle_zip/test.php
@@ -33,12 +33,12 @@ final class ZipFileHandlerTest extends ShimmiePHPUnitTestCase
         self::assertCount(2, $dae->images);
 
         // Check first image - should have tags from filename
-        $image1 = Image::by_hash($test_image_1->md5());
+        $image1 = Post::by_hash($test_image_1->md5());
         self::assertNotNull($image1, "First image should be imported");
         self::assertEqualsCanonicalizing(["foo", "bar", "baz", "qux"], $image1->get_tag_array(), "First image should have tags from filename");
 
         // Check second image - should have tags from filename
-        $image2 = Image::by_hash($test_image_2->md5());
+        $image2 = Post::by_hash($test_image_2->md5());
         self::assertNotNull($image2, "Second image should be imported");
         self::assertEqualsCanonicalizing(["foo", "bar"], $image2->get_tag_array(), "Second image should have tags from filename");
 
@@ -99,7 +99,7 @@ final class ZipFileHandlerTest extends ShimmiePHPUnitTestCase
         self::assertCount(2, $dae->images);
 
         // Check first image - should have tags and metadata from export.json
-        $image1 = Image::by_hash($hash1);
+        $image1 = Post::by_hash($hash1);
         self::assertNotNull($image1, "First image should be imported");
         $tags1 = $image1->get_tag_array();
         self::assertContains("test", $tags1);
@@ -109,7 +109,7 @@ final class ZipFileHandlerTest extends ShimmiePHPUnitTestCase
         self::assertEquals("screenshot.jpg", $image1->filename);
 
         // Check second image - should have tags and metadata from export.json
-        $image2 = Image::by_hash($hash2);
+        $image2 = Post::by_hash($hash2);
         self::assertNotNull($image2, "Second image should be imported");
         $tags2 = $image2->get_tag_array();
         self::assertContains("test", $tags2);
@@ -131,7 +131,7 @@ final class ZipFileHandlerTest extends ShimmiePHPUnitTestCase
 
         // First, upload an image directly
         $image_id = self::post_image($test_image, "original");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         $original_hash = $image->hash;
 
         // Now create a zip with the same image
@@ -153,7 +153,7 @@ final class ZipFileHandlerTest extends ShimmiePHPUnitTestCase
         self::assertCount(0, $dae->images);
 
         // Original image should still exist with original tags
-        $image_check = Image::by_hash($original_hash);
+        $image_check = Post::by_hash($original_hash);
         self::assertNotNull($image_check);
         $tags = $image_check->get_tag_array();
         self::assertContains("original", $tags);

--- a/ext/home/main.php
+++ b/ext/home/main.php
@@ -43,7 +43,7 @@ final class Home extends Extension
             format_text($main_links),
             Ctx::$config->get(HomeConfig::TEXT),
             contact_link(),
-            Search::count_images(),
+            Search::count_posts(),
         );
     }
 }

--- a/ext/image_hash_ban/main.php
+++ b/ext/image_hash_ban/main.php
@@ -92,7 +92,7 @@ final class ImageBan extends Extension
             $c_reason = $event->POST->get("c_reason");
             $c_image_id = $event->POST->get("c_image_id");
 
-            $image = !empty($c_image_id) ? Image::by_id_ex(int_escape($c_image_id)) : null;
+            $image = !empty($c_image_id) ? Post::by_id_ex(int_escape($c_image_id)) : null;
             $hash = !empty($c_hash) ? $c_hash : $image?->hash;
             $reason = !empty($c_reason) ? $c_reason : "DNP";
 
@@ -101,7 +101,7 @@ final class ImageBan extends Extension
                 $page->flash("Post ban added");
 
                 if ($image) {
-                    send_event(new ImageDeletionEvent($image));
+                    send_event(new PostDeletionEvent($image));
                     $page->flash("Post deleted");
                 }
 
@@ -171,7 +171,7 @@ final class ImageBan extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (Ctx::$user->can(ImageHashBanPermission::BAN_IMAGE)) {
             $event->add_part(SHM_SIMPLE_FORM(

--- a/ext/image_hash_ban/test.php
+++ b/ext/image_hash_ban/test.php
@@ -26,7 +26,7 @@ final class ImageBanTest extends ShimmiePHPUnitTestCase
 
         // Ban & delete
         send_event(new AddImageHashBanEvent($this->hash, "test hash ban"));
-        send_event(new ImageDeletionEvent(Image::by_id_ex($image_id), true));
+        send_event(new PostDeletionEvent(Post::by_id_ex($image_id), true));
 
         // Check deleted
         self::assertException(PostNotFound::class, function () use ($image_id) {

--- a/ext/image_view_counter/main.php
+++ b/ext/image_view_counter/main.php
@@ -14,7 +14,7 @@ final class ImageViewCounter extends Extension
 
     # Adds view to database if needed
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         global $database;
 
@@ -55,7 +55,7 @@ final class ImageViewCounter extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         global $database;
 
@@ -104,7 +104,7 @@ final class ImageViewCounter extends Extension
                 ORDER BY total_views DESC
                 LIMIT 100
             ");
-            $images = Search::get_images($popular_ids);
+            $images = Search::get_posts($popular_ids);
             $this->theme->view_popular($images);
         }
     }

--- a/ext/image_view_counter/theme.php
+++ b/ext/image_view_counter/theme.php
@@ -11,7 +11,7 @@ use function MicroHTML\{P,joinHTML};
 class ImageViewCounterTheme extends Themelet
 {
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function view_popular(array $images): void
     {

--- a/ext/index/events.php
+++ b/ext/index/events.php
@@ -20,7 +20,7 @@ class SearchTermParseEvent extends Event
     public bool $negative = false;
     /** @var string[] */
     public array $context = [];
-    /** @var ImgCondition[] */
+    /** @var MetadataCondition[] */
     public array $img_conditions = [];
     /** @var TagCondition[] */
     public array $tag_conditions = [];
@@ -60,10 +60,10 @@ class SearchTermParseEvent extends Event
 
     public function add_querylet(Querylet $q): void
     {
-        $this->add_img_condition(new ImgCondition($q, !$this->negative));
+        $this->add_img_condition(new MetadataCondition($q, !$this->negative));
     }
 
-    public function add_img_condition(ImgCondition $c): void
+    public function add_img_condition(MetadataCondition $c): void
     {
         $this->img_conditions[] = $c;
     }

--- a/ext/index/main.php
+++ b/ext/index/main.php
@@ -55,7 +55,7 @@ final class Index extends Extension
                 );
             }
 
-            $total_pages = (int)ceil(Search::count_images($search_terms) / Ctx::$config->get(IndexConfig::IMAGES));
+            $total_pages = (int)ceil(Search::count_posts($search_terms) / Ctx::$config->get(IndexConfig::IMAGES));
             if ($search_results_limit && $total_pages > $search_results_limit / $page_size && !Ctx::$user->can(IndexPermission::BIG_SEARCH)) {
                 $total_pages = (int)ceil($search_results_limit / $page_size);
             }
@@ -66,13 +66,13 @@ final class Index extends Extension
                     // extra caching for the first few post/list pages
                     $images = cache_get_or_set(
                         "post-list:$page_number",
-                        fn () => Search::find_images(($page_number - 1) * $page_size, $page_size, $search_terms),
+                        fn () => Search::find_posts(($page_number - 1) * $page_size, $page_size, $search_terms),
                         60
                     );
                 }
             }
             if (is_null($images)) {
-                $images = Search::find_images(($page_number - 1) * $page_size, $page_size, $search_terms);
+                $images = Search::find_posts(($page_number - 1) * $page_size, $page_size, $search_terms);
             }
 
             $count_images = count($images);
@@ -121,7 +121,7 @@ final class Index extends Extension
             ->setDescription('Search the database and print results')
             ->setCode(function (InputInterface $input, OutputInterface $output): int {
                 $query = SearchTerm::explode($input->getArgument('query'));
-                $items = Search::find_images(limit: 1000, terms: $query);
+                $items = Search::find_posts(limit: 1000, terms: $query);
                 foreach ($items as $item) {
                     $output->writeln($item->hash);
                 }

--- a/ext/index/theme.php
+++ b/ext/index/theme.php
@@ -42,7 +42,7 @@ class IndexTheme extends Themelet
     }
 
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function display_page(array $images): void
     {
@@ -84,7 +84,7 @@ class IndexTheme extends Themelet
     }
 
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     protected function build_table(array $images, ?string $query): HTMLElement
     {
@@ -113,7 +113,7 @@ class IndexTheme extends Themelet
     }
 
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     protected function display_page_header(array $images): void
     {
@@ -135,7 +135,7 @@ class IndexTheme extends Themelet
     }
 
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     protected function display_page_images(array $images): void
     {

--- a/ext/link_image/main.php
+++ b/ext/link_image/main.php
@@ -10,7 +10,7 @@ final class LinkImage extends Extension
     public const KEY = "link_image";
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         $this->theme->links_block($this->data($event->image));
     }
@@ -18,7 +18,7 @@ final class LinkImage extends Extension
     /**
      * @return array{thumb_src: Url, image_src: Url, post_link: Url, text_link: string|null}
      */
-    private function data(Image $image): array
+    private function data(Post $image): array
     {
         $text_link = $image->parse_link_template(Ctx::$config->get(LinkImageConfig::TEXT_FORMAT));
         $text_link = trim($text_link) === "" ? null : $text_link; // null blank setting so the url gets filled in on the text links.

--- a/ext/link_scan/main.php
+++ b/ext/link_scan/main.php
@@ -31,14 +31,14 @@ final class LinkScan extends Extension
         $matches = [];
         \Safe\preg_match_all("/post\/view\/(\d+)/", $text, $matches);
         foreach ($matches[1] as $match) {
-            $img = Image::by_id((int)$match);
+            $img = Post::by_id((int)$match);
             if ($img) {
                 $ids[] = $img->id;
             }
         }
         \Safe\preg_match_all("/\b([0-9a-fA-F]{32})\b/", $text, $matches);
         foreach ($matches[1] as $match) {
-            $img = Image::by_hash($match);
+            $img = Post::by_hash($match);
             if ($img) {
                 $ids[] = $img->id;
             }

--- a/ext/livefeed/main.php
+++ b/ext/livefeed/main.php
@@ -15,7 +15,7 @@ final class LiveFeed extends Extension
     }
 
     #[EventListener(priority: 99)]
-    public function onImageAddition(ImageAdditionEvent $event): void
+    public function onPostAddition(PostAdditionEvent $event): void
     {
         $this->msg(
             make_link("post/view/".$event->image->id)->asAbsolute(). " - ".

--- a/ext/media/main.php
+++ b/ext/media/main.php
@@ -23,7 +23,7 @@ final class Media extends Extension
     public function onPageRequest(PageRequestEvent $event): void
     {
         if ($event->page_matches("media_rescan/{image_id}", method: "POST", permission: MediaPermission::RESCAN_MEDIA)) {
-            $image = Image::by_id_ex($event->get_iarg('image_id'));
+            $image = Post::by_id_ex($event->get_iarg('image_id'));
 
             send_event(new MediaCheckPropertiesEvent($image));
             $image->save_to_db();
@@ -33,7 +33,7 @@ final class Media extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (Ctx::$user->can(ImagePermission::DELETE_IMAGE)) {
             $event->add_button("Scan Media Properties", "media_rescan/{$event->image->id}");
@@ -78,7 +78,7 @@ final class Media extends Extension
             ->setDescription('Refresh metadata for a given post')
             ->setCode(function (InputInterface $input, OutputInterface $output): int {
                 $uid = $input->getArgument('id_or_hash');
-                $image = Image::by_id_or_hash($uid);
+                $image = Post::by_id_or_hash($uid);
                 if ($image) {
                     send_event(new MediaCheckPropertiesEvent($image));
                     $image->save_to_db();

--- a/ext/metrics_statsd/main.php
+++ b/ext/metrics_statsd/main.php
@@ -74,7 +74,7 @@ final class StatsDInterface extends Extension
     }
 
     #[EventListener(priority: 99)]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         $this->stats["shimmie_events.info-sets"] = "1|c";
     }

--- a/ext/not_a_tag/test.php
+++ b/ext/not_a_tag/test.php
@@ -14,7 +14,7 @@ final class NotATagTest extends ShimmiePHPUnitTestCase
 
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
         // Original
         self::get_page("post/view/$image_id");

--- a/ext/notes/main.php
+++ b/ext/notes/main.php
@@ -16,7 +16,7 @@ final class Notes extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["notes"] = ImagePropType::INT;
+        Post::$prop_types["notes"] = PostPropType::INT;
     }
 
     #[EventListener]
@@ -172,7 +172,7 @@ final class Notes extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         $this->theme->display_note_system(
             $event->image->id,
@@ -183,7 +183,7 @@ final class Notes extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (Ctx::$user->can(NotesPermission::CREATE)) {
             $event->add_part($this->theme->note_button($event->image->id));
@@ -358,7 +358,7 @@ final class Notes extends Extension
 
         $images = [];
         foreach ($image_ids as $id) {
-            $images[] = Image::by_id_ex($id);
+            $images[] = Post::by_id_ex($id);
         }
 
         $this->theme->display_note_list($images, $pageNumber + 1, $totalPages);
@@ -386,7 +386,7 @@ final class Notes extends Extension
 
         $images = [];
         while ($row = $result->fetch()) {
-            $images[] = Image::by_id_ex($row["image_id"]);
+            $images[] = Post::by_id_ex($row["image_id"]);
         }
 
         $this->theme->display_note_requests($images, $pageNumber + 1, $totalPages);

--- a/ext/notes/theme.php
+++ b/ext/notes/theme.php
@@ -73,7 +73,7 @@ class NotesTheme extends Themelet
     }
 
     /**
-     * @param array<Image> $images
+     * @param array<Post> $images
      */
     public function display_note_list(array $images, int $pageNumber, int $totalPages): void
     {
@@ -86,7 +86,7 @@ class NotesTheme extends Themelet
     }
 
     /**
-     * @param array<Image> $images
+     * @param array<Post> $images
      */
     public function display_note_requests(array $images, int $pageNumber, int $totalPages): void
     {

--- a/ext/numeric_score/theme.php
+++ b/ext/numeric_score/theme.php
@@ -10,7 +10,7 @@ use MicroHTML\HTMLElement;
 
 class NumericScoreTheme extends Themelet
 {
-    public function get_voter(Image $image): void
+    public function get_voter(Post $image): void
     {
         $vote_form = function (int $image_id, int $vote, string $text): HTMLElement {
             return SHM_SIMPLE_FORM(
@@ -63,7 +63,7 @@ class NumericScoreTheme extends Themelet
     }
 
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function view_popular(
         array $images,

--- a/ext/ouroboros_api/main.php
+++ b/ext/ouroboros_api/main.php
@@ -50,7 +50,7 @@ class _SafeOuroborosImage
     public string $sample_url = '';
     public ?int $sample_width = null;
 
-    public function __construct(Image $img)
+    public function __construct(Post $img)
     {
         // author
         $author = $img->get_owner();
@@ -294,7 +294,7 @@ final class OuroborosAPI extends Extension
     {
         $handler = Ctx::$config->get(UploadConfig::COLLISION_HANDLER);
         if (!empty($md5) && !($handler === 'merge')) {
-            $img = Image::by_hash($md5);
+            $img = Post::by_hash($md5);
             if (!is_null($img)) {
                 $this->sendResponse(420, self::ERROR_POST_CREATE_DUPE);
                 return;
@@ -330,7 +330,7 @@ final class OuroborosAPI extends Extension
             return;
         }
         // @phpstan-ignore-next-line
-        $img = Image::by_hash($meta->req('hash'));
+        $img = Post::by_hash($meta->req('hash'));
         if (!is_null($img)) {
             $handler = Ctx::$config->get(UploadConfig::COLLISION_HANDLER);
             if ($handler === 'merge') {
@@ -372,7 +372,7 @@ final class OuroborosAPI extends Extension
     protected function postShow(?int $id = null): void
     {
         if (!is_null($id)) {
-            $post = new _SafeOuroborosImage(Image::by_id_ex($id));
+            $post = new _SafeOuroborosImage(Post::by_id_ex($id));
             $this->sendData('post', [$post]);
         } else {
             $this->sendResponse(424, 'ID is mandatory');
@@ -386,7 +386,7 @@ final class OuroborosAPI extends Extension
     protected function postIndex(int $limit, int $page, array $terms): void
     {
         $start = ($page - 1) * $limit;
-        $results = Search::find_images(max($start, 0), min($limit, 100), $terms);
+        $results = Search::find_posts(max($start, 0), min($limit, 100), $terms);
         $posts = [];
         foreach ($results as $img) {
             $posts[] = new _SafeOuroborosImage($img);

--- a/ext/pools/main.php
+++ b/ext/pools/main.php
@@ -88,7 +88,7 @@ final class Pool
     }
 }
 
-function _image_to_id(Image $image): int
+function _image_to_id(Post $image): int
 {
     return $image->id;
 }
@@ -104,7 +104,7 @@ final class Pools extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["image_order"] = ImagePropType::INT;
+        Post::$prop_types["image_order"] = PostPropType::INT;
     }
 
     #[EventListener]
@@ -230,7 +230,7 @@ final class Pools extends Extension
             self::assert_permission($user, $pool);
 
             $image_ids = $database->get_col("SELECT image_id FROM pool_images WHERE pool_id=:pid ORDER BY image_order ASC", ["pid" => $pool_id]);
-            $images = array_filter(array_map(Image::by_id(...), $image_ids));
+            $images = array_filter(array_map(Post::by_id(...), $image_ids));
             $this->theme->edit_pool($pool, $images);
         }
         if ($event->page_matches("pool/order/{pool_id}")) {
@@ -246,7 +246,7 @@ final class Pools extends Extension
                 ORDER BY pool_images.image_order ASC",
                 ["pid" => $pool_id]
             );
-            $images = array_map(fn ($row) => new Image($row), $image_rows);
+            $images = array_map(fn ($row) => new Post($row), $image_rows);
             $this->theme->edit_order($pool, $images);
         }
         if ($event->page_matches("pool/save_order/{pool_id}", method: "POST")) {
@@ -298,7 +298,7 @@ final class Pools extends Extension
             $pool = $this->get_single_pool($pool_id);
             self::assert_permission($user, $pool);
 
-            $images = Search::find_images(
+            $images = Search::find_posts(
                 limit: Ctx::$config->get(PoolsConfig::MAX_IMPORT_RESULTS),
                 terms: SearchTerm::explode($event->POST->req("pool_tag"))
             );
@@ -381,7 +381,7 @@ final class Pools extends Extension
      * to the Next image in the pool.
      */
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         if (Ctx::$config->get(PoolsConfig::INFO_ON_VIEW_IMAGE)) {
             $imageID = $event->image->id;
@@ -403,7 +403,7 @@ final class Pools extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         global $database;
         if (Ctx::$config->get(PoolsConfig::ADDER_ON_VIEW_IMAGE) && Ctx::$user->can(PoolsPermission::UPDATE)) {
@@ -770,7 +770,7 @@ final class Pools extends Extension
 
         $images = [];
         foreach ($result as $singleResult) {
-            $images[] = Image::by_id_ex((int) $singleResult["image_id"]);
+            $images[] = Post::by_id_ex((int) $singleResult["image_id"]);
         }
 
         $this->theme->view_pool($pool, $images, $pageNumber + 1, $totalPages);

--- a/ext/pools/theme.php
+++ b/ext/pools/theme.php
@@ -142,7 +142,7 @@ class PoolsTheme extends Themelet
     }
 
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function view_pool(Pool $pool, array $images, int $pageNumber, int $totalPages): void
     {
@@ -203,7 +203,7 @@ class PoolsTheme extends Themelet
     }
 
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function pool_result(array $images, Pool $pool): void
     {
@@ -230,7 +230,7 @@ class PoolsTheme extends Themelet
      * HERE WE DISPLAY THE POOL ORDERER.
      * WE LIST ALL IMAGES ON POOL WITHOUT PAGINATION AND WITH A TEXT INPUT TO SET A NUMBER AND CHANGE THE ORDER
      *
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function edit_order(Pool $pool, array $images): void
     {
@@ -260,7 +260,7 @@ class PoolsTheme extends Themelet
      * WE LIST ALL IMAGES ON POOL WITHOUT PAGINATION AND WITH
      * A CHECKBOX TO SELECT WHICH IMAGE WE WANT TO REMOVE
      *
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function edit_pool(Pool $pool, array $images): void
     {

--- a/ext/post_description/main.php
+++ b/ext/post_description/main.php
@@ -36,7 +36,7 @@ final class PostDescription extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoGet(ImageInfoGetEvent $event): void
+    public function onPostInfoGet(PostInfoGetEvent $event): void
     {
         global $database;
         $description = (string) $database->get_one(
@@ -49,7 +49,7 @@ final class PostDescription extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         $description = $event->get_param("description");
         if (Ctx::$user->can(PostDescriptionPermission::EDIT_IMAGE_DESCRIPTIONS) && $description) {
@@ -75,7 +75,7 @@ final class PostDescription extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         global $database;
 

--- a/ext/post_lock/main.php
+++ b/ext/post_lock/main.php
@@ -7,7 +7,7 @@ namespace Shimmie2;
 final class LockSetEvent extends Event
 {
     public function __construct(
-        public Image $image,
+        public Post $image,
         public bool $locked
     ) {
         parent::__construct();
@@ -20,7 +20,7 @@ final class PostLock extends Extension
     public const KEY = "post_lock";
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         if ($event->image->is_locked() && !Ctx::$user->can(PostLockPermission::EDIT_IMAGE_LOCK)) {
             throw new PermissionDenied("Error: This image is locked and cannot be edited.");
@@ -40,7 +40,7 @@ final class PostLock extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         $event->add_part($this->theme->get_lock_editor_html($event->image), 42);
     }

--- a/ext/post_lock/test.php
+++ b/ext/post_lock/test.php
@@ -14,24 +14,24 @@ final class PostLockTest extends ShimmiePHPUnitTestCase
 
         // admin can lock
         self::log_in_as_admin();
-        send_event(new ImageInfoSetEvent(Image::by_id_ex($image_id), 0, new QueryArray(["locked" => "on"])));
+        send_event(new PostInfoSetEvent(Post::by_id_ex($image_id), 0, new QueryArray(["locked" => "on"])));
 
         // user can't edit locked post
         self::log_in_as_user();
         self::assertException(PermissionDenied::class, function () use ($image_id) {
-            send_event(new ImageInfoSetEvent(Image::by_id_ex($image_id), 0, new QueryArray(["source" => "http://example.com"])));
+            send_event(new PostInfoSetEvent(Post::by_id_ex($image_id), 0, new QueryArray(["source" => "http://example.com"])));
         });
 
         // admin can edit locked post
         self::log_in_as_admin();
-        send_event(new ImageInfoSetEvent(Image::by_id_ex($image_id), 0, new QueryArray(["source" => "http://example.com"])));
+        send_event(new PostInfoSetEvent(Post::by_id_ex($image_id), 0, new QueryArray(["source" => "http://example.com"])));
 
         // admin can unlock
         self::log_in_as_admin();
-        send_event(new ImageInfoSetEvent(Image::by_id_ex($image_id), 0, new QueryArray([]))); // "locked" is not set
+        send_event(new PostInfoSetEvent(Post::by_id_ex($image_id), 0, new QueryArray([]))); // "locked" is not set
 
         // user can edit un-locked post
         self::log_in_as_user();
-        send_event(new ImageInfoSetEvent(Image::by_id_ex($image_id), 0, new QueryArray(["source" => "http://example.com"])));
+        send_event(new PostInfoSetEvent(Post::by_id_ex($image_id), 0, new QueryArray(["source" => "http://example.com"])));
     }
 }

--- a/ext/post_lock/theme.php
+++ b/ext/post_lock/theme.php
@@ -10,7 +10,7 @@ use function MicroHTML\{INPUT};
 
 class PostLockTheme extends Themelet
 {
-    public function get_lock_editor_html(Image $image): HTMLElement
+    public function get_lock_editor_html(Post $image): HTMLElement
     {
         return SHM_POST_INFO(
             "Metadata Locked",

--- a/ext/post_owner/main.php
+++ b/ext/post_owner/main.php
@@ -7,7 +7,7 @@ namespace Shimmie2;
 final class OwnerSetEvent extends Event
 {
     public function __construct(
-        public Image $image,
+        public Post $image,
         public User $owner
     ) {
         parent::__construct();
@@ -20,7 +20,7 @@ final class PostOwner extends Extension
     public const KEY = "post_owner";
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         $owner = $event->get_param('owner');
         if (Ctx::$user->can(PostOwnerPermission::EDIT_IMAGE_OWNER) && !is_null($owner)) {
@@ -38,7 +38,7 @@ final class PostOwner extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         $event->add_part($this->theme->get_owner_editor_html($event->image), 39);
 

--- a/ext/post_owner/test.php
+++ b/ext/post_owner/test.php
@@ -10,10 +10,10 @@ final class PostOwnerTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
         self::log_in_as_admin();
-        send_event(new ImageInfoSetEvent($image, 0, new QueryArray(["owner" => self::ADMIN_NAME])));
+        send_event(new PostInfoSetEvent($image, 0, new QueryArray(["owner" => self::ADMIN_NAME])));
 
         self::log_in_as_user();
         self::get_page("post/view/$image_id");

--- a/ext/post_owner/theme.php
+++ b/ext/post_owner/theme.php
@@ -10,7 +10,7 @@ use MicroHTML\HTMLElement;
 
 class PostOwnerTheme extends Themelet
 {
-    public function get_owner_editor_html(Image $image): HTMLElement
+    public function get_owner_editor_html(Post $image): HTMLElement
     {
         $owner = $image->get_owner()->name;
         $date = SHM_DATE($image->posted);

--- a/ext/post_source/main.php
+++ b/ext/post_source/main.php
@@ -7,7 +7,7 @@ namespace Shimmie2;
 final class SourceSetEvent extends Event
 {
     public function __construct(
-        public Image $image,
+        public Post $image,
         public string $source
     ) {
         parent::__construct();
@@ -30,7 +30,7 @@ final class PostSource extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoGet(ImageInfoGetEvent $event): void
+    public function onPostInfoGet(PostInfoGetEvent $event): void
     {
         $source = $event->image->get_source();
         if ($source !== null) {
@@ -39,7 +39,7 @@ final class PostSource extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         $source = $event->get_param('source');
         if (is_null($source) && Ctx::$config->get(UploadConfig::TLSOURCE)) {
@@ -62,7 +62,7 @@ final class PostSource extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         $event->add_part($this->theme->get_source_editor_html($event->image), 41);
     }
@@ -97,7 +97,7 @@ final class PostSource extends Extension
         if ($matches = $event->matches("/^source[=:](.*)$/i")) {
             $source = ($matches[1] !== "none" ? $matches[1] : "");
             send_event(new CheckStringContentEvent($source, type: StringType::URL));
-            send_event(new SourceSetEvent(Image::by_id_ex($event->image_id), $source));
+            send_event(new SourceSetEvent(Post::by_id_ex($event->image_id), $source));
         }
     }
 
@@ -133,7 +133,7 @@ final class PostSource extends Extension
                 $search_forward[] = "id<$last_id";
             }
 
-            $images = Search::find_images(limit: 100, terms: $search_forward);
+            $images = Search::find_posts(limit: 100, terms: $search_forward);
             if (count($images) === 0) {
                 break;
             }

--- a/ext/post_source/test.php
+++ b/ext/post_source/test.php
@@ -10,10 +10,10 @@ final class PostSourceTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
-        send_event(new ImageInfoSetEvent($image, 0, new QueryArray(["source" => "example.com"])));
-        send_event(new ImageInfoSetEvent($image, 0, new QueryArray(["source" => "http://example.com"])));
+        send_event(new PostInfoSetEvent($image, 0, new QueryArray(["source" => "example.com"])));
+        send_event(new PostInfoSetEvent($image, 0, new QueryArray(["source" => "http://example.com"])));
 
         self::get_page("post/view/$image_id");
         self::assert_text("example.com");
@@ -23,16 +23,16 @@ final class PostSourceTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
-        send_event(new ImageInfoSetEvent($image, 0, new QueryArray(["source" => "http://example.com"])));
-        send_event(new ImageInfoSetEvent($image, 0, new QueryArray(["source" => "http://example.com/THING"])));
+        send_event(new PostInfoSetEvent($image, 0, new QueryArray(["source" => "http://example.com"])));
+        send_event(new PostInfoSetEvent($image, 0, new QueryArray(["source" => "http://example.com/THING"])));
 
         self::assert_search_results(["source:http://example.com"], [$image_id], "exact match");
         self::assert_search_results(["source:example.com"], [$image_id], "match without protocol");
         self::assert_search_results(["source:https://example.com"], [$image_id], "match with wrong protocol");
 
-        send_event(new ImageInfoSetEvent($image, 0, new QueryArray(["source" => "http://example.com/THING"])));
+        send_event(new PostInfoSetEvent($image, 0, new QueryArray(["source" => "http://example.com/THING"])));
 
         self::assert_search_results(["source:http://example.com"], [$image_id], "prefix match");
         self::assert_search_results(["source:http://example.com/THING"], [$image_id], "case match");

--- a/ext/post_source/theme.php
+++ b/ext/post_source/theme.php
@@ -20,7 +20,7 @@ class PostSourceTheme extends Themelet
         );
     }
 
-    public function get_source_editor_html(Image $image): HTMLElement
+    public function get_source_editor_html(Post $image): HTMLElement
     {
         return SHM_POST_INFO(
             "Source Link",

--- a/ext/post_tags/main.php
+++ b/ext/post_tags/main.php
@@ -21,7 +21,7 @@ final class TagSetException extends UserError
 
 final class TagSetEvent extends Event
 {
-    public Image $image;
+    public Post $image;
     /** @var list<tag-string> */
     public array $old_tags;
     /** @var list<tag-string> */
@@ -32,7 +32,7 @@ final class TagSetEvent extends Event
     /**
      * @param tag-string[] $tags
      */
-    public function __construct(Image $image, array $tags)
+    public function __construct(Post $image, array $tags)
     {
         parent::__construct();
         $this->image    = $image;
@@ -148,13 +148,13 @@ final class PostTags extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoGet(ImageInfoGetEvent $event): void
+    public function onPostInfoGet(PostInfoGetEvent $event): void
     {
         $event->params['tags'] = $event->image->get_tag_list();
     }
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         if (
             Ctx::$user->can(PostTagsPermission::EDIT_IMAGE_TAG) && (
@@ -210,7 +210,7 @@ final class PostTags extends Extension
     }
 
     #[EventListener]
-    public function onImageDeletion(ImageDeletionEvent $event): void
+    public function onPostDeletion(PostDeletionEvent $event): void
     {
         $event->image->delete_tags_from_image();
     }
@@ -239,7 +239,7 @@ final class PostTags extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         $event->add_part($this->theme->get_tag_editor_html($event->image), 40);
     }
@@ -286,7 +286,7 @@ final class PostTags extends Extension
         Log::info("tag_edit", "Mass editing tags: '$search' -> '$replace'");
 
         if (count($search_set) === 1 && count($replace_set) === 1) {
-            $images = Search::find_images(limit: 10, terms: $replace_set);
+            $images = Search::find_posts(limit: 10, terms: $replace_set);
             if (count($images) === 0) {
                 Log::info("tag_edit", "No images found with target tag, doing in-place rename");
                 $database->execute(
@@ -312,7 +312,7 @@ final class PostTags extends Extension
                 $search_forward[] = "id<$last_id";
             }
 
-            $images = Search::find_images(limit: 100, terms: $search_forward);
+            $images = Search::find_posts(limit: 100, terms: $search_forward);
             if (count($images) === 0) {
                 break;
             }

--- a/ext/post_tags/test.php
+++ b/ext/post_tags/test.php
@@ -10,7 +10,7 @@ final class PostTagsTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
         // Original
         self::get_page("post/view/$image_id");
@@ -26,7 +26,7 @@ final class PostTagsTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
         $e = self::assertException(TagSetException::class, function () use ($image) {
             send_event(new TagSetEvent($image, []));

--- a/ext/post_tags/theme.php
+++ b/ext/post_tags/theme.php
@@ -24,7 +24,7 @@ class PostTagsTheme extends Themelet
         Ctx::$page->add_block(new Block("Mass Tag Edit", $html));
     }
 
-    public function get_tag_editor_html(Image $image): HTMLElement
+    public function get_tag_editor_html(Post $image): HTMLElement
     {
         $tag_links = [];
         foreach ($image->get_tag_array() as $tag) {

--- a/ext/post_titles/main.php
+++ b/ext/post_titles/main.php
@@ -7,7 +7,7 @@ namespace Shimmie2;
 class PostTitleSetEvent extends Event
 {
     public function __construct(
-        public Image $image,
+        public Post $image,
         public string $title
     ) {
         parent::__construct();
@@ -22,7 +22,7 @@ final class PostTitles extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["title"] = ImagePropType::STRING;
+        Post::$prop_types["title"] = PostPropType::STRING;
     }
 
     #[EventListener]
@@ -37,7 +37,7 @@ final class PostTitles extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         if (Ctx::$config->get(PostTitlesConfig::SHOW_IN_WINDOW_TITLE)) {
             Ctx::$page->set_title(self::get_title($event->image));
@@ -45,7 +45,7 @@ final class PostTitles extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         $event->add_part(
             $this->theme->get_title_set_html(
@@ -57,7 +57,7 @@ final class PostTitles extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoGet(ImageInfoGetEvent $event): void
+    public function onPostInfoGet(PostInfoGetEvent $event): void
     {
         $title = $event->image['title'];
         if ($title !== null) {
@@ -66,7 +66,7 @@ final class PostTitles extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         $title = $event->get_param('title');
         if (Ctx::$user->can(PostTitlesPermission::EDIT_IMAGE_TITLE) && !is_null($title)) {
@@ -101,7 +101,7 @@ final class PostTitles extends Extension
         Log::info("post_titles", "Title for >>{$image_id} set to: ".$title);
     }
 
-    public static function get_title(Image $image): string
+    public static function get_title(Post $image): string
     {
         $title = $image['title'] ?? "";
         if (empty($title) && Ctx::$config->get(PostTitlesConfig::DEFAULT_TO_FILENAME)) {

--- a/ext/post_titles/test.php
+++ b/ext/post_titles/test.php
@@ -10,9 +10,9 @@ final class PostTitleTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
-        send_event(new ImageInfoSetEvent($image, 0, new QueryArray(["title" => "My Photo"])));
+        send_event(new PostInfoSetEvent($image, 0, new QueryArray(["title" => "My Photo"])));
 
         self::get_page("post/view/$image_id");
         self::assert_text("My Photo");
@@ -22,9 +22,9 @@ final class PostTitleTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
-        send_event(new ImageInfoSetEvent($image, 0, new QueryArray(["title" => "My Photo"])));
+        send_event(new PostInfoSetEvent($image, 0, new QueryArray(["title" => "My Photo"])));
 
         self::assert_search_results(["title:Photo"], [$image_id], "partial match");
     }

--- a/ext/private_image/main.php
+++ b/ext/private_image/main.php
@@ -12,7 +12,7 @@ final class PrivateImage extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["private"] = ImagePropType::BOOL;
+        Post::$prop_types["private"] = PostPropType::BOOL;
     }
 
     #[EventListener]
@@ -22,7 +22,7 @@ final class PrivateImage extends Extension
 
         if ($event->page_matches("privatize_image/{image_id}", method: "POST", permission: PrivateImagePermission::SET_PRIVATE_IMAGE)) {
             $image_id = $event->get_iarg('image_id');
-            $image = Image::by_id_ex($image_id);
+            $image = Post::by_id_ex($image_id);
             if ($image->owner_id !== $user->id && !$user->can(PrivateImagePermission::SET_OTHERS_PRIVATE_IMAGES)) {
                 throw new PermissionDenied("Cannot set another user's image to private.");
             }
@@ -33,7 +33,7 @@ final class PrivateImage extends Extension
 
         if ($event->page_matches("publicize_image/{image_id}", method: "POST")) {
             $image_id = $event->get_iarg('image_id');
-            $image = Image::by_id_ex($image_id);
+            $image = Post::by_id_ex($image_id);
             if ($image->owner_id !== $user->id && !$user->can(PrivateImagePermission::SET_OTHERS_PRIVATE_IMAGES)) {
                 throw new PermissionDenied("Cannot set another user's image to public.");
             }
@@ -56,7 +56,7 @@ final class PrivateImage extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         if (
             $event->image['private'] === true
@@ -157,7 +157,7 @@ final class PrivateImage extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if ((Ctx::$user->can(PrivateImagePermission::SET_PRIVATE_IMAGE) && Ctx::$user->id === $event->image->owner_id) || Ctx::$user->can(PrivateImagePermission::SET_OTHERS_PRIVATE_IMAGES)) {
             if ($event->image['private'] === false) {
@@ -169,7 +169,7 @@ final class PrivateImage extends Extension
     }
 
     #[EventListener]
-    public function onImageAddition(ImageAdditionEvent $event): void
+    public function onPostAddition(PostAdditionEvent $event): void
     {
         if (Ctx::$user->get_config()->get(PrivateImageUserConfig::SET_DEFAULT) && Ctx::$user->can(PrivateImagePermission::SET_PRIVATE_IMAGE)) {
             self::privatize_image($event->image->id);

--- a/ext/random_image/main.php
+++ b/ext/random_image/main.php
@@ -18,7 +18,7 @@ final class RandomImage extends Extension
         ) {
             $action = $event->get_arg('action');
             $search_terms = SearchTerm::explode($event->get_arg('search', ""));
-            $image = Image::by_random($search_terms);
+            $image = Post::by_random($search_terms);
             if (!$image) {
                 throw new PostNotFound("Couldn't find any posts randomly");
             }
@@ -26,7 +26,7 @@ final class RandomImage extends Extension
             if ($action === "download") {
                 send_event(new ImageDownloadingEvent($image, $image->get_image_filename(), $image->get_mime(), $event->GET));
             } elseif ($action === "view") {
-                send_event(new DisplayingImageEvent($image));
+                send_event(new DisplayingPostEvent($image));
             } elseif ($action === "widget") {
                 $page = Ctx::$page;
                 $page->set_data(MimeType::HTML, (string)$this->theme->build_thumb($image));
@@ -38,7 +38,7 @@ final class RandomImage extends Extension
     public function onPostListBuilding(PostListBuildingEvent $event): void
     {
         if (Ctx::$config->get(RandomImageConfig::SHOW_RANDOM_BLOCK)) {
-            $image = Image::by_random($event->search_terms);
+            $image = Post::by_random($event->search_terms);
             if (!is_null($image)) {
                 $this->theme->display_random($image);
             }

--- a/ext/random_image/theme.php
+++ b/ext/random_image/theme.php
@@ -10,12 +10,12 @@ use MicroHTML\HTMLElement;
 
 class RandomImageTheme extends Themelet
 {
-    public function display_random(Image $image): void
+    public function display_random(Post $image): void
     {
         Ctx::$page->add_block(new Block("Random Post", $this->build_random_html($image), "left", 8));
     }
 
-    public function build_random_html(Image $image): HTMLElement
+    public function build_random_html(Post $image): HTMLElement
     {
         $tsize = $image->get_thumb_size();
 

--- a/ext/random_list/main.php
+++ b/ext/random_list/main.php
@@ -32,7 +32,7 @@ final class RandomList extends Extension
             $images_per_page = Ctx::$config->get(RandomListConfig::LIST_COUNT);
             $random_images = [];
             for ($i = 0; $i < $images_per_page; $i++) {
-                $random_image = Image::by_random($search_terms);
+                $random_image = Post::by_random($search_terms);
                 if (!$random_image) {
                     continue;
                 }

--- a/ext/random_list/theme.php
+++ b/ext/random_list/theme.php
@@ -11,7 +11,7 @@ class RandomListTheme extends Themelet
 {
     /**
      * @param search-term-array $search_terms
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function display_page(array $search_terms, array $images): void
     {

--- a/ext/rating/test.php
+++ b/ext/rating/test.php
@@ -10,7 +10,7 @@ final class RatingsTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         send_event(new RatingSetEvent($image, "s"));
 
         # search for it in various ways
@@ -30,7 +30,7 @@ final class RatingsTest extends ShimmiePHPUnitTestCase
         Ctx::$config->set("ext_rating_anonymous_privs", ["s", "q"]);
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         send_event(new RatingSetEvent($image, "e"));
 
         # the explicit image shouldn't show up in anon's searches
@@ -43,10 +43,10 @@ final class RatingsTest extends ShimmiePHPUnitTestCase
         // post a safe image and an explicit image
         self::log_in_as_user();
         $image_id_e = $this->post_image("tests/bedroom_workshop.jpg", "pbx");
-        $image_e = Image::by_id_ex($image_id_e);
+        $image_e = Post::by_id_ex($image_id_e);
         send_event(new RatingSetEvent($image_e, "e"));
         $image_id_s = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image_s = Image::by_id_ex($image_id_s);
+        $image_s = Post::by_id_ex($image_id_s);
         send_event(new RatingSetEvent($image_s, "s"));
 
         // user is allowed to see all
@@ -81,20 +81,20 @@ final class RatingsTest extends ShimmiePHPUnitTestCase
         self::log_in_as_user();
 
         $image_id_s = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image_s = Image::by_id_ex($image_id_s);
+        $image_s = Post::by_id_ex($image_id_s);
         send_event(new RatingSetEvent($image_s, "s"));
         $image_id_q = $this->post_image("tests/favicon.png", "favicon");
-        $image_q = Image::by_id_ex($image_id_q);
+        $image_q = Post::by_id_ex($image_id_q);
         send_event(new RatingSetEvent($image_q, "q"));
         $image_id_e = $this->post_image("tests/bedroom_workshop.jpg", "bedroom");
-        $image_e = Image::by_id_ex($image_id_e);
+        $image_e = Post::by_id_ex($image_id_e);
         send_event(new RatingSetEvent($image_e, "e"));
 
         Ctx::$config->set("ext_rating_user_privs", ["s", "q"]);
         Ctx::$user->get_config()->set(RatingsUserConfig::DEFAULTS, ["s"]);
 
-        self::assertEquals(1, Search::count_images(["rating=s"]), "UserClass has access to safe, show safe");
-        self::assertEquals(2, Search::count_images(["rating=*"]), "UserClass has access to s/q - if user asks for everything, show those two but hide e");
-        self::assertEquals(1, Search::count_images(), "If search doesn't specify anything, check the user defaults");
+        self::assertEquals(1, Search::count_posts(["rating=s"]), "UserClass has access to safe, show safe");
+        self::assertEquals(2, Search::count_posts(["rating=*"]), "UserClass has access to s/q - if user asks for everything, show those two but hide e");
+        self::assertEquals(1, Search::count_posts(), "If search doesn't specify anything, check the user defaults");
     }
 }

--- a/ext/ratings_blur/test.php
+++ b/ext/ratings_blur/test.php
@@ -12,7 +12,7 @@ final class RatingsBlurTest extends ShimmiePHPUnitTestCase
     {
         self::log_in_as_user();
         $image_id_s = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image_s = Image::by_id_ex($image_id_s);
+        $image_s = Post::by_id_ex($image_id_s);
         send_event(new RatingSetEvent($image_s, "s"));
 
         // the safe image should not insert a blur class
@@ -20,7 +20,7 @@ final class RatingsBlurTest extends ShimmiePHPUnitTestCase
         self::assert_no_text("blur");
 
         $image_id_e = $this->post_image("tests/bedroom_workshop.jpg", "bedroom");
-        $image_e = Image::by_id_ex($image_id_e);
+        $image_e = Post::by_id_ex($image_id_e);
         send_event(new RatingSetEvent($image_e, "e"));
 
         // the explicit image should insert a blur class
@@ -36,7 +36,7 @@ final class RatingsBlurTest extends ShimmiePHPUnitTestCase
         $this->create_test_user($this->username);
 
         $image_id_e = $this->post_image("tests/bedroom_workshop.jpg", "bedroom");
-        $image_e = Image::by_id_ex($image_id_e);
+        $image_e = Post::by_id_ex($image_id_e);
         send_event(new RatingSetEvent($image_e, "e"));
 
         // the explicit image should not insert a blur class
@@ -44,7 +44,7 @@ final class RatingsBlurTest extends ShimmiePHPUnitTestCase
         self::assert_no_text("blur");
 
         $image_id_s = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image_s = Image::by_id_ex($image_id_s);
+        $image_s = Post::by_id_ex($image_id_s);
         send_event(new RatingSetEvent($image_s, "s"));
 
         // the safe image should insert a blur class
@@ -74,7 +74,7 @@ final class RatingsBlurTest extends ShimmiePHPUnitTestCase
         Ctx::$user->get_config()->set(RatingsBlurUserConfig::USER_DEFAULTS, ["s"]);
 
         $image_id_e = $this->post_image("tests/bedroom_workshop.jpg", "bedroom");
-        $image_e = Image::by_id_ex($image_id_e);
+        $image_e = Post::by_id_ex($image_id_e);
         send_event(new RatingSetEvent($image_e, "e"));
 
         // the explicit image should not insert a blur class
@@ -82,7 +82,7 @@ final class RatingsBlurTest extends ShimmiePHPUnitTestCase
         self::assert_no_text("blur");
 
         $image_id_s = $this->post_image("tests/pbx_screenshot.jpg", "pbx");
-        $image_s = Image::by_id_ex($image_id_s);
+        $image_s = Post::by_id_ex($image_id_s);
         send_event(new RatingSetEvent($image_s, "s"));
 
         // the safe image should insert a blur class

--- a/ext/regen_thumb/theme.php
+++ b/ext/regen_thumb/theme.php
@@ -14,7 +14,7 @@ class RegenThumbTheme extends Themelet
     /**
      * Show a link to the new thumbnail.
      */
-    public function display_results(Image $image): void
+    public function display_results(Post $image): void
     {
         Ctx::$page->set_title("Thumbnail Regenerated");
         Ctx::$page->add_html_header(META(['http-equiv' => 'cache-control', 'content' => 'no-cache']));

--- a/ext/relationships/main.php
+++ b/ext/relationships/main.php
@@ -25,8 +25,8 @@ final class Relationships extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["parent_id"] = ImagePropType::INT;
-        Image::$prop_types["has_children"] = ImagePropType::BOOL;
+        Post::$prop_types["parent_id"] = PostPropType::INT;
+        Post::$prop_types["has_children"] = PostPropType::BOOL;
     }
 
     #[EventListener]
@@ -52,7 +52,7 @@ final class Relationships extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         if (Ctx::$user->can(RelationshipsPermission::EDIT_IMAGE_RELATIONSHIPS)) {
             if ($event->params['tags'] ? !\Safe\preg_match('/parent[=:]/', $event->params->req("tags")) : true) { //Ignore parent if tags contain parent metatag
@@ -66,7 +66,7 @@ final class Relationships extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         $this->theme->relationship_info($event->image);
     }
@@ -122,13 +122,13 @@ final class Relationships extends Extension
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         $event->add_part($this->theme->get_parent_editor_html($event->image), 45);
     }
 
     #[EventListener]
-    public function onImageDeletion(ImageDeletionEvent $event): void
+    public function onPostDeletion(PostDeletionEvent $event): void
     {
         global $database;
 
@@ -154,7 +154,7 @@ final class Relationships extends Extension
         if ($old_parent === $event->parent_id) {
             return;  // no change
         }
-        if (!Image::by_id($event->parent_id) || !Image::by_id($event->child_id)) {
+        if (!Post::by_id($event->parent_id) || !Post::by_id($event->child_id)) {
             return;  // one of the images doesn't exist
         }
 
@@ -167,14 +167,14 @@ final class Relationships extends Extension
     }
 
     /**
-     * @return Image[]
+     * @return Post[]
      */
     public static function get_children(int $image_id): array
     {
         global $database;
         $child_ids = $database->get_col("SELECT id FROM images WHERE parent_id = :pid ", ["pid" => $image_id]);
 
-        return Search::get_images($child_ids);
+        return Search::get_posts($child_ids);
     }
 
     private function remove_parent(int $imageID): void
@@ -213,7 +213,7 @@ final class Relationships extends Extension
     {
         global $database;
 
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
         $count = $database->get_one(
             "SELECT COUNT(*) FROM images WHERE id!=:id AND parent_id=:pid",
@@ -224,19 +224,19 @@ final class Relationships extends Extension
     }
 
     /**
-     * @return Image[]
+     * @return Post[]
      */
     public static function get_siblings(int $image_id): array
     {
         global $database;
 
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
         $sibling_ids = $database->get_col(
             "SELECT id FROM images WHERE id!=:id AND parent_id=:pid",
             ["id" => $image_id, "pid" => $image['parent_id']]
         );
-        $siblings = Search::get_images($sibling_ids);
+        $siblings = Search::get_posts($sibling_ids);
 
         return $siblings;
     }

--- a/ext/relationships/test.php
+++ b/ext/relationships/test.php
@@ -13,7 +13,7 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
     //=================================================================
 
     /**
-     * @return array{0: Image, 1: Image, 2: Image}
+     * @return array{0:Post, 1:Post, 2:Post}
      */
     public function testNoParent(): array
     {
@@ -23,9 +23,9 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
         $image_id_2 = $this->post_image("tests/bedroom_workshop.jpg", "pbx");
         $image_id_3 = $this->post_image("tests/favicon.png", "pbx");
 
-        $image_1 = Image::by_id_ex($image_id_1);
-        $image_2 = Image::by_id_ex($image_id_2);
-        $image_3 = Image::by_id_ex($image_id_3);
+        $image_1 = Post::by_id_ex($image_id_1);
+        $image_2 = Post::by_id_ex($image_id_2);
+        $image_3 = Post::by_id_ex($image_id_3);
 
         self::assertNull($image_1['parent_id']);
         self::assertNull($image_2['parent_id']);
@@ -38,7 +38,7 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
     }
 
     /**
-     * @return array{0:Image, 1:Image, 2:Image}
+     * @return array{0:Post, 1:Post, 2:Post}
      */
     #[Depends('testNoParent')]
     public function testSetParent(): array
@@ -48,9 +48,9 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
         send_event(new ImageRelationshipSetEvent($image_2->id, $image_1->id));
 
         // refresh data from database
-        $image_1 = Image::by_id_ex($image_1->id);
-        $image_2 = Image::by_id_ex($image_2->id);
-        $image_3 = Image::by_id_ex($image_3->id);
+        $image_1 = Post::by_id_ex($image_1->id);
+        $image_2 = Post::by_id_ex($image_2->id);
+        $image_3 = Post::by_id_ex($image_3->id);
 
         self::assertNull($image_1['parent_id']);
         self::assertEquals($image_1->id, $image_2['parent_id']);
@@ -63,7 +63,7 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
     }
 
     /**
-     * @return array{0:Image, 1:Image, 2:Image}
+     * @return array{0:Post, 1:Post, 2:Post}
      */
     #[Depends('testSetParent')]
     public function testChangeParent(): array
@@ -72,9 +72,9 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
         send_event(new ImageRelationshipSetEvent($image_2->id, $image_3->id));
 
         // refresh data from database
-        $image_1 = Image::by_id_ex($image_1->id);
-        $image_2 = Image::by_id_ex($image_2->id);
-        $image_3 = Image::by_id_ex($image_3->id);
+        $image_1 = Post::by_id_ex($image_1->id);
+        $image_2 = Post::by_id_ex($image_2->id);
+        $image_3 = Post::by_id_ex($image_3->id);
 
         self::assertNull($image_1['parent_id']);
         self::assertEquals($image_3->id, $image_2['parent_id']);
@@ -111,9 +111,9 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
         // FIXME: send_event(new ImageRelationshipSetEvent($image_2->id, null));
 
         // refresh data from database
-        $image_1 = Image::by_id_ex($image_1->id);
-        $image_2 = Image::by_id_ex($image_2->id);
-        $image_3 = Image::by_id_ex($image_3->id);
+        $image_1 = Post::by_id_ex($image_1->id);
+        $image_2 = Post::by_id_ex($image_2->id);
+        $image_3 = Post::by_id_ex($image_3->id);
 
         self::assertNull($image_1['parent_id']);
         self::assertNull($image_2['parent_id']);
@@ -128,7 +128,7 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
     //=================================================================
 
     /**
-     * @return array{0:Image, 1:Image, 2:Image}
+     * @return array{0:Post, 1:Post, 2:Post}
      */
     public function testSetParentByTagBase(): array
     {
@@ -137,9 +137,9 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
         $image_id_2 = $this->post_image("tests/bedroom_workshop.jpg", "pbx");
         $image_id_3 = $this->post_image("tests/favicon.png", "pbx");
 
-        $image_1 = Image::by_id_ex($image_id_1);
-        $image_2 = Image::by_id_ex($image_id_2);
-        $image_3 = Image::by_id_ex($image_id_3);
+        $image_1 = Post::by_id_ex($image_id_1);
+        $image_2 = Post::by_id_ex($image_id_2);
+        $image_3 = Post::by_id_ex($image_id_3);
 
         self::assertNull($image_1['parent_id']);
         self::assertNull($image_2['parent_id']);
@@ -152,7 +152,7 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
     }
 
     /**
-     * @return array{0:Image, 1:Image, 2:Image}
+     * @return array{0:Post, 1:Post, 2:Post}
      */
     #[Depends('testSetParentByTagBase')]
     public function testSetParentByTag(): array
@@ -162,9 +162,9 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
         send_event(new TagSetEvent($image_2, ["pbx", "parent:{$image_1->id}"]));
 
         // refresh data from database
-        $image_1 = Image::by_id_ex($image_1->id);
-        $image_2 = Image::by_id_ex($image_2->id);
-        $image_3 = Image::by_id_ex($image_3->id);
+        $image_1 = Post::by_id_ex($image_1->id);
+        $image_2 = Post::by_id_ex($image_2->id);
+        $image_3 = Post::by_id_ex($image_3->id);
 
         self::assertEquals(["pbx"], $image_2->get_tag_array());
         self::assertNull($image_1['parent_id']);
@@ -178,7 +178,7 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
     }
 
     /**
-     * @return array{0:Image, 1:Image, 2:Image}
+     * @return array{0:Post, 1:Post, 2:Post}
      */
     #[Depends('testSetParentByTag')]
     public function testSetChildByTag(): array
@@ -188,9 +188,9 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
         send_event(new TagSetEvent($image_3, ["pbx", "child:{$image_1->id}"]));
 
         // refresh data from database
-        $image_1 = Image::by_id_ex($image_1->id);
-        $image_2 = Image::by_id_ex($image_2->id);
-        $image_3 = Image::by_id_ex($image_3->id);
+        $image_1 = Post::by_id_ex($image_1->id);
+        $image_2 = Post::by_id_ex($image_2->id);
+        $image_3 = Post::by_id_ex($image_3->id);
 
         self::assertEquals(["pbx"], $image_3->get_tag_array());
         self::assertEquals($image_3->id, $image_1['parent_id']);
@@ -215,7 +215,7 @@ final class RelationshipsTest extends ShimmiePHPUnitTestCase
         send_event(new TagSetEvent($image_2, ["pbx", "parent:none"]));
 
         // refresh data from database
-        $image_2 = Image::by_id_ex($image_2->id);
+        $image_2 = Post::by_id_ex($image_2->id);
 
         // check it was unset
         self::assertEquals(["pbx"], $image_2->get_tag_array());

--- a/ext/relationships/theme.php
+++ b/ext/relationships/theme.php
@@ -12,9 +12,9 @@ use function MicroHTML\{INPUT};
 
 class RelationshipsTheme extends Themelet
 {
-    public function relationship_info(Image $image): void
+    public function relationship_info(Post $image): void
     {
-        $parent = Search::get_images([$image['parent_id']]);
+        $parent = Search::get_posts([$image['parent_id']]);
         if (!empty($parent)) {
             $visible_siblings = Relationships::has_siblings($image->id)
                 ? Relationships::get_siblings($image->id)
@@ -27,7 +27,7 @@ class RelationshipsTheme extends Themelet
                 A(["href" => "#", "id" => "relationships-parent-toggle", "class" => "shm-relationships-parent-toggle"], "« hide"),
                 DIV(
                     ["class" => "shm-relationships-parent-thumbs"],
-                    DIV(["class" => "shm-parent-thumbs"], $this->build_thumb(Image::by_id_ex($image['parent_id']))),
+                    DIV(["class" => "shm-parent-thumbs"], $this->build_thumb(Post::by_id_ex($image['parent_id']))),
                     DIV(["class" => "shm-sibling-thumbs"], joinHTML("", array_map(fn ($s) => $this->build_thumb($s), $visible_siblings))),
                 )
             );
@@ -54,7 +54,7 @@ class RelationshipsTheme extends Themelet
         }
     }
 
-    public function get_parent_editor_html(Image $image): HTMLElement
+    public function get_parent_editor_html(Post $image): HTMLElement
     {
         return SHM_POST_INFO(
             "Parent",

--- a/ext/replace_file/test.php
+++ b/ext/replace_file/test.php
@@ -22,7 +22,7 @@ final class ReplaceFileTest extends ShimmiePHPUnitTestCase
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx computer screenshot");
 
         // check that the image is original
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         $old_hash = \Safe\md5_file("tests/pbx_screenshot.jpg");
         //self::assertEquals("pbx_screenshot.jpg", $image->filename);
         self::assertEquals("image/jpeg", $image->get_mime());
@@ -52,7 +52,7 @@ final class ReplaceFileTest extends ShimmiePHPUnitTestCase
         self::assertEquals(1, $database->get_one("SELECT COUNT(*) FROM images"));
 
         // check that the image was replaced
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         // self::assertEquals("favicon.png", $image->filename); // TODO should we update filename?
         self::assertEquals("image/png", $image->get_mime());
         self::assertEquals(246, $image->filesize);
@@ -60,9 +60,9 @@ final class ReplaceFileTest extends ShimmiePHPUnitTestCase
         self::assertEquals(md5_file("tests/favicon.png"), $image->hash);
 
         // check that new files exist and old files don't
-        self::assertFalse(Filesystem::warehouse_path(Image::IMAGE_DIR, $old_hash)->exists());
-        self::assertFalse(Filesystem::warehouse_path(Image::THUMBNAIL_DIR, $old_hash)->exists());
-        self::assertTrue(Filesystem::warehouse_path(Image::IMAGE_DIR, $new_hash)->exists());
-        self::assertTrue(Filesystem::warehouse_path(Image::THUMBNAIL_DIR, $new_hash)->exists());
+        self::assertFalse(Filesystem::warehouse_path(Post::IMAGE_DIR, $old_hash)->exists());
+        self::assertFalse(Filesystem::warehouse_path(Post::THUMBNAIL_DIR, $old_hash)->exists());
+        self::assertTrue(Filesystem::warehouse_path(Post::IMAGE_DIR, $new_hash)->exists());
+        self::assertTrue(Filesystem::warehouse_path(Post::THUMBNAIL_DIR, $new_hash)->exists());
     }
 }

--- a/ext/replace_file/theme.php
+++ b/ext/replace_file/theme.php
@@ -20,7 +20,7 @@ class ReplaceFileTheme extends Themelet
         $max_size = Ctx::$config->get(UploadConfig::SIZE);
         $max_kb = to_shorthand_int($max_size);
 
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         $thumbnail = $this->build_thumb($image);
 
         $form = SHM_FORM(make_link("replace/".$image_id), multipart: true);

--- a/ext/report_image/main.php
+++ b/ext/report_image/main.php
@@ -33,7 +33,7 @@ final class ImageReport
 }
 
 /**
- * @phpstan-type Report array{id: int, image: Image, reason: string, reporter_name: string}
+ * @phpstan-type Report array{id: int, image: Post, reason: string, reporter_name: string}
  * @extends Extension<ReportImageTheme>
  */
 final class ReportImage extends Extension
@@ -95,7 +95,7 @@ final class ReportImage extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         if (Ctx::$user->can(ReportImagePermission::CREATE_IMAGE_REPORT)) {
             $reps = $this->get_reports($event->image);
@@ -128,7 +128,7 @@ final class ReportImage extends Extension
     }
 
     #[EventListener]
-    public function onImageDeletion(ImageDeletionEvent $event): void
+    public function onPostDeletion(PostDeletionEvent $event): void
     {
         Ctx::$database->execute("DELETE FROM image_reports WHERE image_id = :image_id", ["image_id" => $event->image->id]);
         Ctx::$cache->delete("image-report-count");
@@ -167,7 +167,7 @@ final class ReportImage extends Extension
     /**
      * @return ImageReport[]
      */
-    public function get_reports(Image $image): array
+    public function get_reports(Post $image): array
     {
         $rows = Ctx::$database->get_all("
 			SELECT *
@@ -195,7 +195,7 @@ final class ReportImage extends Extension
         $reports = [];
         foreach ($all_reports as $report) {
             $image_id = (int)$report['image_id'];
-            $image = Image::by_id($image_id);
+            $image = Post::by_id($image_id);
             if (is_null($image)) {
                 send_event(new RemoveReportedImageEvent((int)$report['id']));
                 continue;

--- a/ext/report_image/theme.php
+++ b/ext/report_image/theme.php
@@ -8,7 +8,7 @@ use function MicroHTML\{A, B, BR, P, TABLE, TBODY, TD, THEAD, TR, emptyHTML, joi
 use function MicroHTML\{INPUT};
 
 /**
- * @phpstan-type Report array{id: int, image: Image, reason: string, reporter_name: string}
+ * @phpstan-type Report array{id: int, image: Post, reason: string, reporter_name: string}
  */
 class ReportImageTheme extends Themelet
 {
@@ -19,7 +19,7 @@ class ReportImageTheme extends Themelet
     {
         $tbody = TBODY();
         foreach ($reports as $report) {
-            $iabbe = send_event(new ImageAdminBlockBuildingEvent($report['image'], Ctx::$user, "report"));
+            $iabbe = send_event(new PostAdminBlockBuildingEvent($report['image'], Ctx::$user, "report"));
 
             $tbody->appendChild(TR(
                 TD($this->build_thumb($report['image'])),
@@ -62,7 +62,7 @@ class ReportImageTheme extends Themelet
     /**
      * @param ImageReport[] $reports
      */
-    public function display_image_banner(Image $image, array $reports): void
+    public function display_image_banner(Post $image, array $reports): void
     {
         $html = emptyHTML();
         $public = Ctx::$config->get(ReportImageConfig::SHOW_INFO);

--- a/ext/res_limit/main.php
+++ b/ext/res_limit/main.php
@@ -9,7 +9,7 @@ final class ResolutionLimit extends Extension
     public const KEY = "res_limit";
 
     #[EventListener(priority: 40)] // early, to veto ImageUploadEvent
-    public function onImageAddition(ImageAdditionEvent $event): void
+    public function onPostAddition(PostAdditionEvent $event): void
     {
         $min_w = Ctx::$config->get(ResolutionLimitConfig::MIN_WIDTH);
         $min_h = Ctx::$config->get(ResolutionLimitConfig::MIN_HEIGHT);

--- a/ext/res_limit/test.php
+++ b/ext/res_limit/test.php
@@ -18,7 +18,7 @@ final class ResolutionLimitTest extends ShimmiePHPUnitTestCase
         self::log_in_as_user();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "pbx computer screenshot");
         //self::assert_response(302);
-        self::assertNotNull(Image::by_id($image_id));
+        self::assertNotNull(Post::by_id($image_id));
     }
 
     public function testResLimitSmall(): void

--- a/ext/reverse_search_links/main.php
+++ b/ext/reverse_search_links/main.php
@@ -10,7 +10,7 @@ final class ReverseSearchLinks extends Extension
     public const KEY = "reverse_search_links";
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         // only support image types
         $supported_types = [MimeType::JPEG, MimeType::GIF, MimeType::PNG, MimeType::WEBP];

--- a/ext/reverse_search_links/theme.php
+++ b/ext/reverse_search_links/theme.php
@@ -8,7 +8,7 @@ use function MicroHTML\{A, IMG, joinHTML};
 
 class ReverseSearchLinksTheme extends Themelet
 {
-    public function reverse_search_block(Image $image): void
+    public function reverse_search_block(Post $image): void
     {
         $url = (string)$image->get_thumb_link()->asAbsolute();
         $links = [

--- a/ext/rss_images/main.php
+++ b/ext/rss_images/main.php
@@ -48,19 +48,19 @@ final class RSSImages extends Extension
             if (Ctx::$config->get(RSSImagesConfig::RSS_LIMIT) && $page_number > 9) {
                 return;
             }
-            $images = Search::find_images(($page_number - 1) * $page_size, $page_size, $search_terms);
+            $images = Search::find_posts(($page_number - 1) * $page_size, $page_size, $search_terms);
             $this->do_rss($images, $search_terms, $page_number);
         }
     }
 
     #[EventListener]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         Ctx::$cache->delete("rss-item-image:{$event->image->id}");
     }
 
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      * @param search-term-array $search_terms
      */
     private function do_rss(array $images, array $search_terms, int $page_number): void
@@ -104,7 +104,7 @@ final class RSSImages extends Extension
         Ctx::$page->set_data(MimeType::RSS, $xml);
     }
 
-    private function thumb(Image $image): HTMLElement
+    private function thumb(Post $image): HTMLElement
     {
         $link = make_link("post/view/{$image->id}")->asAbsolute();
         $tags = $image->get_tag_list();

--- a/ext/sitemap/main.php
+++ b/ext/sitemap/main.php
@@ -61,7 +61,7 @@ final class XMLSitemap extends Extension
         }
 
         /* --- Add latest images to sitemap with higher priority --- */
-        foreach (Search::find_images(limit: 50) as $image) {
+        foreach (Search::find_posts(limit: 50) as $image) {
             $urls[] = new XMLSitemapURL(
                 make_link("post/view/$image->id"),
                 "weekly",
@@ -81,7 +81,7 @@ final class XMLSitemap extends Extension
         }
 
         /* --- Add all other images to sitemap with lower priority --- */
-        foreach (Search::find_images(offset: 51, limit: 10000) as $image) {
+        foreach (Search::find_posts(offset: 51, limit: 10000) as $image) {
             $urls[] = new XMLSitemapURL(
                 make_link("post/view/$image->id"),
                 "monthly",

--- a/ext/source_history/main.php
+++ b/ext/source_history/main.php
@@ -40,7 +40,7 @@ final class SourceHistory extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         $event->add_button("View Source History", "source_history/{$event->image->id}", 20);
     }
@@ -129,7 +129,7 @@ final class SourceHistory extends Extension
 
         Log::debug("source_history", 'Reverting source of >>'.$stored_image_id.' to ['.$stored_source.']');
 
-        $image = Image::by_id_ex($stored_image_id);
+        $image = Post::by_id_ex($stored_image_id);
 
         // all should be ok so we can revert by firing the SetUserSources event.
         send_event(new SourceSetEvent($image, $stored_source));
@@ -299,7 +299,7 @@ final class SourceHistory extends Extension
 
                 Log::debug("source_history", 'Reverting source of >>'.$stored_image_id.' to ['.$stored_source.']');
 
-                $image = Image::by_id_ex($stored_image_id);
+                $image = Post::by_id_ex($stored_image_id);
 
                 // all should be ok so we can revert by firing the SetSources event.
                 send_event(new SourceSetEvent($image, $stored_source));
@@ -313,7 +313,7 @@ final class SourceHistory extends Extension
     /**
      * This function is called just before an images source is changed.
      */
-    private function add_source_history(Image $image, string $source): void
+    private function add_source_history(Post $image, string $source): void
     {
         global $database;
 

--- a/ext/tag_editcloud/main.php
+++ b/ext/tag_editcloud/main.php
@@ -10,7 +10,7 @@ final class TagEditCloud extends Extension
     public const KEY = "tag_editcloud";
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         if ($this->can_tag($event->image)) {
             $data = $this->get_cloud_data($event->image);
@@ -26,7 +26,7 @@ final class TagEditCloud extends Extension
     /**
      * @return array<array{tag: string, scaled: float, count: int}>|null
      */
-    private function get_cloud_data(Image $image): array|null
+    private function get_cloud_data(Post $image): array|null
     {
         global $database;
 
@@ -96,7 +96,7 @@ final class TagEditCloud extends Extension
         return $tag_data;
     }
 
-    private function can_tag(Image $image): bool
+    private function can_tag(Post $image): bool
     {
         return (
             Ctx::$user->can(PostTagsPermission::EDIT_IMAGE_TAG)

--- a/ext/tag_history/main.php
+++ b/ext/tag_history/main.php
@@ -40,7 +40,7 @@ final class TagHistory extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         $event->add_button("View Tag History", "tag_history/{$event->image->id}", 20);
     }
@@ -184,7 +184,7 @@ final class TagHistory extends Extension
         $stored_image_id = (int)$result['image_id'];
         $stored_tags = $result['tags'];
 
-        $image = Image::by_id_ex($stored_image_id);
+        $image = Post::by_id_ex($stored_image_id);
 
         Log::debug("tag_history", 'Reverting tags of >>'.$stored_image_id.' to ['.$stored_tags.']');
         // all should be ok so we can revert by firing the SetUserTags event.
@@ -369,7 +369,7 @@ final class TagHistory extends Extension
                 $stored_image_id = (int)$result['image_id'];
                 $stored_tags = $result['tags'];
 
-                $image = Image::by_id($stored_image_id);
+                $image = Post::by_id($stored_image_id);
                 if (is_null($image)) {
                     continue;
                 }

--- a/ext/tag_history/test.php
+++ b/ext/tag_history/test.php
@@ -13,7 +13,7 @@ final class TagHistoryTest extends ShimmiePHPUnitTestCase
         // Set original
         self::log_in_as_admin();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "old_tag");
-        Image::by_id_ex($image_id);
+        Post::by_id_ex($image_id);
 
         // Check post
         self::get_page("post/view/$image_id");
@@ -36,7 +36,7 @@ final class TagHistoryTest extends ShimmiePHPUnitTestCase
         // Set original
         self::log_in_as_admin();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "old_tag");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
 
         // Modify tags
         send_event(new TagSetEvent($image, ["new_tag"]));
@@ -64,7 +64,7 @@ final class TagHistoryTest extends ShimmiePHPUnitTestCase
         // Set original
         self::log_in_as_admin();
         $image_id = $this->post_image("tests/pbx_screenshot.jpg", "old_tag");
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         $revert_id = $database->get_one(
             "SELECT id FROM tag_histories WHERE image_id = :image_id ORDER BY id DESC LIMIT 1",
             ["image_id" => $image_id],

--- a/ext/tag_list/main.php
+++ b/ext/tag_list/main.php
@@ -22,7 +22,7 @@ final class TagList extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         if (Ctx::$config->get(TagListConfig::LENGTH) > 0) {
             $type = Ctx::$config->get(TagListConfig::IMAGE_TYPE);
@@ -66,7 +66,7 @@ final class TagList extends Extension
         );
     }
 
-    private function add_related_block(Image $image): void
+    private function add_related_block(Post $image): void
     {
         $omitted_tags = self::get_omitted_tags();
         $starting_tags = Ctx::$database->get_col("SELECT tag_id FROM image_tags WHERE image_id = :image_id", ["image_id" => $image->id]);
@@ -101,7 +101,7 @@ final class TagList extends Extension
         }
     }
 
-    private function add_tags_block(Image $image): void
+    private function add_tags_block(Post $image): void
     {
         /** @var array<array{tag: tag-string, count: int}> $tags */
         $tags = Ctx::$database->get_all("

--- a/ext/tombstones/main.php
+++ b/ext/tombstones/main.php
@@ -57,7 +57,7 @@ class Tombstones extends Extension
             $post_id = $event->get_iarg('post_id');
             $tombstone = $database->get_row("SELECT * FROM tombstones WHERE post_id=:post_id", ["post_id" => $post_id]);
             if (!is_null($tombstone)) {
-                if (!is_null(Image::by_id($post_id))) {
+                if (!is_null(Post::by_id($post_id))) {
                     // SQLite can re-use IDs of deleted rows, so if the
                     // post exists, ignore the tombstone
                     return;
@@ -83,7 +83,7 @@ class Tombstones extends Extension
     }
 
     #[EventListener]
-    public function onImageDeletion(ImageDeletionEvent $event): void
+    public function onPostDeletion(PostDeletionEvent $event): void
     {
         global $database;
 

--- a/ext/tombstones/test.php
+++ b/ext/tombstones/test.php
@@ -16,9 +16,9 @@ class TombstonesTest extends ShimmiePHPUnitTestCase
         self::assertEquals(200, $page->code);
 
         // Ban & delete
-        $image = Image::by_id_ex($image_id);
+        $image = Post::by_id_ex($image_id);
         send_event(new AddImageHashBanEvent($image->hash, "test hash ban"));
-        send_event(new ImageDeletionEvent($image, true));
+        send_event(new PostDeletionEvent($image, true));
 
         // Check deleted
         self::assertException(PostNotFound::class, function () use ($image_id) {

--- a/ext/transcode_image/main.php
+++ b/ext/transcode_image/main.php
@@ -39,7 +39,7 @@ final class TranscodeImage extends Extension
     ];
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (Ctx::$user->can(ImagePermission::EDIT_FILES) && $event->context !== "report") {
             $engine = MediaEngine::from(Ctx::$config->get(TranscodeImageConfig::ENGINE));
@@ -55,7 +55,7 @@ final class TranscodeImage extends Extension
     {
         if ($event->page_matches("transcode/{image_id}", method: "POST", permission: ImagePermission::EDIT_FILES)) {
             $image_id = $event->get_iarg('image_id');
-            $image_obj = Image::by_id_ex($image_id);
+            $image_obj = Post::by_id_ex($image_id);
             $this->transcode_and_replace_image($image_obj, new MimeType($event->POST->req('transcode_mime')));
             Ctx::$page->set_redirect(make_link("post/view/".$image_id));
         }
@@ -180,11 +180,11 @@ final class TranscodeImage extends Extension
         return $output;
     }
 
-    private function transcode_and_replace_image(Image $image, MimeType $target_mime): void
+    private function transcode_and_replace_image(Post $image, MimeType $target_mime): void
     {
-        $original_file = Filesystem::warehouse_path(Image::IMAGE_DIR, $image->hash);
+        $original_file = Filesystem::warehouse_path(Post::IMAGE_DIR, $image->hash);
         $tmp_filename = $this->transcode_image($original_file, $image->get_mime(), $target_mime);
-        send_event(new ImageReplaceEvent($image, $tmp_filename));
+        send_event(new MediaReplaceEvent($image, $tmp_filename));
     }
 
     private function transcode_image(Path $source_name, MimeType $source_mime, MimeType $target_mime): Path

--- a/ext/transcode_image/theme.php
+++ b/ext/transcode_image/theme.php
@@ -13,7 +13,7 @@ class TranscodeImageTheme extends Themelet
      *
      * @param array<string, ?MimeType> $options
      */
-    public function get_transcode_html(Image $image, array $options): \MicroHTML\HTMLElement
+    public function get_transcode_html(Post $image, array $options): \MicroHTML\HTMLElement
     {
         return SHM_FORM(
             action: make_link("transcode/{$image->id}"),

--- a/ext/transcode_video/theme.php
+++ b/ext/transcode_video/theme.php
@@ -13,7 +13,7 @@ class TranscodeVideoTheme extends Themelet
      *
      * @param array<string, ?VideoContainer> $options
      */
-    public function get_transcode_html(Image $image, array $options): \MicroHTML\HTMLElement
+    public function get_transcode_html(Post $image, array $options): \MicroHTML\HTMLElement
     {
         return SHM_SIMPLE_FORM(
             make_link("transcode_video/{$image->id}"),

--- a/ext/trash/main.php
+++ b/ext/trash/main.php
@@ -12,7 +12,7 @@ final class Trash extends Extension
     #[EventListener]
     public function onInitExt(InitExtEvent $event): void
     {
-        Image::$prop_types["trash"] = ImagePropType::BOOL;
+        Post::$prop_types["trash"] = PostPropType::BOOL;
     }
 
     #[EventListener]
@@ -25,7 +25,7 @@ final class Trash extends Extension
         }
     }
 
-    private function check_permissions(Image $image): bool
+    private function check_permissions(Post $image): bool
     {
         if ($image['trash'] === true && !Ctx::$user->can(TrashPermission::VIEW_TRASH)) {
             return false;
@@ -45,7 +45,7 @@ final class Trash extends Extension
     }
 
     #[EventListener(priority: 10)]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         if (!$this->check_permissions(($event->image))) {
             Ctx::$page->set_redirect(make_link());
@@ -53,7 +53,7 @@ final class Trash extends Extension
     }
 
     #[EventListener(priority: 10)] // Needs to be early to intercept delete events
-    public function onImageDeletion(ImageDeletionEvent $event): void
+    public function onPostDeletion(PostDeletionEvent $event): void
     {
         if ($event->force !== true && $event->image['trash'] !== true) {
             self::set_trash($event->image->id, true);
@@ -129,7 +129,7 @@ final class Trash extends Extension
     }
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if ($event->image['trash'] === true && Ctx::$user->can(TrashPermission::VIEW_TRASH)) {
             $event->add_button("Restore From Trash", "trash_restore/".$event->image->id);

--- a/ext/upload/main.php
+++ b/ext/upload/main.php
@@ -18,7 +18,7 @@ final class DataUploadEvent extends Event
     public MimeType $mime;
     public int $size;
 
-    /** @var Image[] */
+    /** @var Post[] */
     public array $images = [];
     public bool $handled = false;
     public bool $merged = false;

--- a/ext/user/main.php
+++ b/ext/user/main.php
@@ -733,9 +733,9 @@ final class UserPage extends Extension
             Log::warning("user", "Deleting user #{$uid} (@{$duser->name})'s uploads");
             $image_ids = $database->get_col("SELECT id FROM images WHERE owner_id = :owner_id", ["owner_id" => $uid]);
             foreach ($image_ids as $image_id) {
-                $image = Image::by_id((int) $image_id);
+                $image = Post::by_id((int) $image_id);
                 if ($image) {
-                    send_event(new ImageDeletionEvent($image));
+                    send_event(new PostDeletionEvent($image));
                 }
             }
         } else {

--- a/ext/varnish/main.php
+++ b/ext/varnish/main.php
@@ -39,13 +39,13 @@ final class VarnishPurger extends Extension
     }
 
     #[EventListener(priority: 99)]
-    public function onImageInfoSet(ImageInfoSetEvent $event): void
+    public function onPostInfoSet(PostInfoSetEvent $event): void
     {
         $this->curl_purge("post/view/{$event->image->id}");
     }
 
     #[EventListener(priority: 99)]
-    public function onImageDeletion(ImageDeletionEvent $event): void
+    public function onPostDeletion(PostDeletionEvent $event): void
     {
         $this->curl_purge("post/view/{$event->image->id}");
     }

--- a/ext/view/events.php
+++ b/ext/view/events.php
@@ -9,18 +9,14 @@ use MicroHTML\HTMLElement;
 use function MicroHTML\{INPUT};
 
 /*
- * DisplayingImageEvent:
- *   $image -- the image being displayed
- *   $page  -- the page to display on
- *
- * Sent when an image is ready to display. Extensions who
+ * Sent when a post is ready to display. Extensions who
  * wish to appear on the "view" page should listen for this,
- * which only appears when an image actually exists.
+ * which only appears when a post actually exists.
  */
-class DisplayingImageEvent extends Event
+class DisplayingPostEvent extends Event
 {
     public function __construct(
-        public Image $image
+        public Post $image
     ) {
         parent::__construct();
     }
@@ -29,10 +25,10 @@ class DisplayingImageEvent extends Event
 /**
  * @extends PartListBuildingEvent<HTMLElement>
  */
-class ImageAdminBlockBuildingEvent extends PartListBuildingEvent
+class PostAdminBlockBuildingEvent extends PartListBuildingEvent
 {
     public function __construct(
-        public Image $image,
+        public Post $image,
         public User $user,
         public string $context
     ) {
@@ -58,13 +54,13 @@ class ImageAdminBlockBuildingEvent extends PartListBuildingEvent
 /**
  * @extends PartListBuildingEvent<HTMLElement>
  */
-class ImageInfoBoxBuildingEvent extends PartListBuildingEvent
+class PostInfoBoxBuildingEvent extends PartListBuildingEvent
 {
     /** @var HTMLElement[] */
     private array $sidebar_parts = [];
 
     public function __construct(
-        public Image $image,
+        public Post $image,
         public User $user
     ) {
         parent::__construct();
@@ -93,12 +89,12 @@ class ImageInfoBoxBuildingEvent extends PartListBuildingEvent
 
 
 /**
- * Collect post metadata in a format usable by ImageInfoSetEvent
+ * Collect post metadata in a format usable by PostInfoSetEvent
  */
-class ImageInfoGetEvent extends Event
+class PostInfoGetEvent extends Event
 {
     public function __construct(
-        public Image $image,
+        public Post $image,
         public QueryArray $params = new QueryArray(),
     ) {
         parent::__construct();
@@ -106,10 +102,10 @@ class ImageInfoGetEvent extends Event
 }
 
 
-class ImageInfoSetEvent extends Event
+class PostInfoSetEvent extends Event
 {
     public function __construct(
-        public Image $image,
+        public Post $image,
         public int $slot,
         public QueryArray $params
     ) {

--- a/ext/view/main.php
+++ b/ext/view/main.php
@@ -24,7 +24,7 @@ final class ViewPost extends Extension
                 $fragment = null;
             }
 
-            $image = Image::by_id_ex($image_id);
+            $image = Post::by_id_ex($image_id);
 
             if ($event->page_matches("post/next/{image_id}")) {
                 $image = $image->get_next($search_terms);
@@ -47,13 +47,13 @@ final class ViewPost extends Extension
             }
 
             $image_id = $event->get_iarg('image_id');
-            $image = Image::by_id_ex($image_id);
-            send_event(new DisplayingImageEvent($image));
+            $image = Post::by_id_ex($image_id);
+            send_event(new DisplayingPostEvent($image));
         } elseif ($event->page_matches("post/set", method: "POST")) {
             $image_id = int_escape($event->POST->req('image_id'));
-            $image = Image::by_id_ex($image_id);
+            $image = Post::by_id_ex($image_id);
             if (!$image->is_locked() || Ctx::$user->can(PostLockPermission::EDIT_IMAGE_LOCK)) {
-                send_event(new ImageInfoSetEvent($image, 0, $event->POST));
+                send_event(new PostInfoSetEvent($image, 0, $event->POST));
 
                 if ($event->GET->get('search')) {
                     $fragment = "search=" . url_escape($event->GET->get('search'));
@@ -77,19 +77,19 @@ final class ViewPost extends Extension
     }
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         $this->theme->display_meta_headers($event->image);
 
-        $iibbe = send_event(new ImageInfoBoxBuildingEvent($event->image, Ctx::$user));
+        $iibbe = send_event(new PostInfoBoxBuildingEvent($event->image, Ctx::$user));
         $this->theme->display_page($event->image, $iibbe->get_parts(), $iibbe->get_sidebar_parts());
 
-        $iabbe = send_event(new ImageAdminBlockBuildingEvent($event->image, Ctx::$user, "view"));
+        $iabbe = send_event(new PostAdminBlockBuildingEvent($event->image, Ctx::$user, "view"));
         $this->theme->display_admin_block($iabbe->get_parts());
     }
 
     #[EventListener]
-    public function onImageInfoBoxBuilding(ImageInfoBoxBuildingEvent $event): void
+    public function onPostInfoBoxBuilding(PostInfoBoxBuildingEvent $event): void
     {
         $image_info = Ctx::$config->get(ImageConfig::INFO);
         if ($image_info) {

--- a/ext/view/theme.php
+++ b/ext/view/theme.php
@@ -11,7 +11,7 @@ use MicroHTML\HTMLElement;
 
 class ViewPostTheme extends Themelet
 {
-    public function display_meta_headers(Image $image): void
+    public function display_meta_headers(Post $image): void
     {
         $page = Ctx::$page;
         $h_metatags = str_replace(" ", ", ", $image->get_tag_list());
@@ -33,7 +33,7 @@ class ViewPostTheme extends Themelet
      * @param HTMLElement[] $editor_parts
      * @param HTMLElement[] $sidebar_parts
      */
-    public function display_page(Image $image, array $editor_parts, array $sidebar_parts): void
+    public function display_page(Post $image, array $editor_parts, array $sidebar_parts): void
     {
         $page = Ctx::$page;
         $page->set_title("Post {$image->id}: ".$image->get_tag_list());
@@ -86,7 +86,7 @@ class ViewPostTheme extends Themelet
         return false;
     }
 
-    protected function build_pin(Image $image): HTMLElement
+    protected function build_pin(Post $image): HTMLElement
     {
         if ($this->is_ordered_search()) {
             return A(["href" => make_link()], "Index");
@@ -100,7 +100,7 @@ class ViewPostTheme extends Themelet
         }
     }
 
-    protected function build_navigation(Image $image): HTMLElement
+    protected function build_navigation(Post $image): HTMLElement
     {
         $pin = $this->build_pin($image);
 
@@ -128,7 +128,7 @@ class ViewPostTheme extends Themelet
      * @param HTMLElement[] $editor_parts
      * @param HTMLElement[] $sidebar_parts
      */
-    protected function build_info(Image $image, array $editor_parts, array $sidebar_parts = []): HTMLElement
+    protected function build_info(Post $image, array $editor_parts, array $sidebar_parts = []): HTMLElement
     {
         if (count($editor_parts) === 0) {
             return emptyHTML($image->is_locked() ? "[Post Locked]" : "");
@@ -168,7 +168,7 @@ class ViewPostTheme extends Themelet
         );
     }
 
-    protected function build_stats(Image $image): HTMLElement
+    protected function build_stats(Post $image): HTMLElement
     {
         $owner = $image->get_owner()->name;
         $ip = Ctx::$user->can(IPBanPermission::VIEW_IP) ? " ({$image->owner_ip})" : "";

--- a/ext/zoom_lightbox/main.php
+++ b/ext/zoom_lightbox/main.php
@@ -11,7 +11,7 @@ final class ZoomLightbox extends Extension
     public const KEY = "zoom_lightbox";
 
     #[EventListener]
-    public function onDisplayingImage(DisplayingImageEvent $event): void
+    public function onDisplayingPost(DisplayingPostEvent $event): void
     {
         $data_href = Url::base();
         Ctx::$page->add_html_header(SCRIPT(["src" => "{$data_href}/ext/zoom_lightbox/glightbox.min.js", "defer" => true]), 10);

--- a/ext/zoom_to_fit/main.php
+++ b/ext/zoom_to_fit/main.php
@@ -11,7 +11,7 @@ final class ZoomToFit extends Extension
     public const KEY = "zoom_to_fit";
 
     #[EventListener]
-    public function onImageAdminBlockBuilding(ImageAdminBlockBuildingEvent $event): void
+    public function onPostAdminBlockBuilding(PostAdminBlockBuildingEvent $event): void
     {
         if (str_starts_with($event->image->get_mime()->base, "image/")) {
             if ($event->context === "view") {

--- a/themes/danbooru2/comment.theme.php
+++ b/themes/danbooru2/comment.theme.php
@@ -11,7 +11,7 @@ use MicroHTML\HTMLElement;
 class Danbooru2CommentListTheme extends CommentListTheme
 {
     /**
-     * @param array<array{0: Image, 1: Comment[]}> $images
+     * @param array<array{0: Post, 1: Comment[]}> $images
      */
     public function display_comment_list(array $images, int $page_number, int $total_pages, bool $can_post): void
     {

--- a/themes/danbooru2/index.theme.php
+++ b/themes/danbooru2/index.theme.php
@@ -13,7 +13,7 @@ use function MicroHTML\{INPUT,P};
 class Danbooru2IndexTheme extends IndexTheme
 {
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     public function display_page(array $images): void
     {
@@ -58,7 +58,7 @@ class Danbooru2IndexTheme extends IndexTheme
     }
 
     /**
-     * @param Image[] $images
+     * @param Post[] $images
      */
     protected function build_table(array $images, ?string $query): HTMLElement
     {

--- a/themes/danbooru2/view.theme.php
+++ b/themes/danbooru2/view.theme.php
@@ -14,7 +14,7 @@ class Danbooru2ViewPostTheme extends ViewPostTheme
      * @param HTMLElement[] $editor_parts
      * @param HTMLElement[] $sidebar_parts
      */
-    public function display_page(Image $image, array $editor_parts, array $sidebar_parts): void
+    public function display_page(Post $image, array $editor_parts, array $sidebar_parts): void
     {
         Ctx::$page->set_heading($image->get_tag_list());
         Ctx::$page->add_block(new Block("Search", $this->build_navigation($image), "left", 0));
@@ -22,7 +22,7 @@ class Danbooru2ViewPostTheme extends ViewPostTheme
         Ctx::$page->add_block(new Block(null, $this->build_info($image, $editor_parts), "main", 15));
     }
 
-    protected function build_navigation(Image $image): HTMLElement
+    protected function build_navigation(Post $image): HTMLElement
     {
         return SHM_FORM(
             action: search_link(),

--- a/themes/futaba/comment.theme.php
+++ b/themes/futaba/comment.theme.php
@@ -14,7 +14,7 @@ class FutabaCommentListTheme extends CommentListTheme
     public bool $post_page = true;
 
     /**
-     * @param array<array{0: Image, 1: Comment[]}> $images
+     * @param array<array{0: Post, 1: Comment[]}> $images
      */
     public function display_comment_list(array $images, int $page_number, int $total_pages, bool $can_post): void
     {

--- a/themes/futaba/view.theme.php
+++ b/themes/futaba/view.theme.php
@@ -12,7 +12,7 @@ class FutabaViewPostTheme extends ViewPostTheme
      * @param HTMLElement[] $editor_parts
      * @param HTMLElement[] $sidebar_parts
      */
-    public function display_page(Image $image, array $editor_parts, array $sidebar_parts): void
+    public function display_page(Post $image, array $editor_parts, array $sidebar_parts): void
     {
         Ctx::$page->set_heading($image->get_tag_list());
         Ctx::$page->add_block(new Block(null, $this->build_info($image, $editor_parts), "main", 10));

--- a/themes/lite/view.theme.php
+++ b/themes/lite/view.theme.php
@@ -12,7 +12,7 @@ class LiteViewPostTheme extends ViewPostTheme
      * @param HTMLElement[] $editor_parts
      * @param HTMLElement[] $sidebar_parts
      */
-    public function display_page(Image $image, array $editor_parts, array $sidebar_parts): void
+    public function display_page(Post $image, array $editor_parts, array $sidebar_parts): void
     {
         Ctx::$page->set_title("Post {$image->id}: ".$image->get_tag_list());
         Ctx::$page->set_heading($image->get_tag_list());


### PR DESCRIPTION
With apologies for all the third-party code being broken by `Image->Post` T_T

- Post: The top-level thing, a bit of media along with metadata
- Media: A file being uploaded
- Image: An actual image, eg png or jpeg
