### PR TITLE
Thumbnail instead of image for AutoTagger

### DIFF
--- a/ext/automatic1111_tagger/main.php
+++ b/ext/automatic1111_tagger/main.php
@@ -55,7 +55,7 @@ class Automatic1111Tagger extends Extension
         if ($event->page_matches("automatic1111_tagger/get_rating/{post_id}")) {
             $post_id = $event->get_iarg('post_id');
             $image_obj = Post::by_id_ex($post_id);
-            $image_contents = $image_obj->get_media_filename()->get_contents();
+            $image_contents = $image_obj->get_thumb_filename()->get_contents();
             $image_data = base64_encode($image_contents);
             $payload = [
                 "image" => $image_data,


### PR DESCRIPTION
Instead of using the full res image, send over the thumb for interrogation. This adds support for bigger images and video, while speeding up the process.