### PR TITLE
Forced specific model for ratings in AI Tagger

### DIFF
--- a/ext/automatic1111_tagger/info.php
+++ b/ext/automatic1111_tagger/info.php
@@ -12,6 +12,6 @@ final class Automatic1111TaggerInfo extends ExtensionInfo
     public array $authors = ["Saetron" => "https://github.com/Saetron/Shimmie2-AI-Tagger"];
     public string $license = self::LICENSE_MIT;
     public string $description = "Connects to the Automatic1111 API to interrogate images and suggest tags.";
-    public ?string $documentation = "Adds an 'Interrogate' button to the posts overview, sending images to the Automatic1111 API for tag suggestions.";
+    public ?string $documentation = "Adds an 'Interrogate' button to the posts overview, sending images to the Automatic1111 API for tag suggestions. Requires 'wd-v1-4-moat-tagger.v2' to function";
     public ExtensionCategory $category = ExtensionCategory::METADATA;
 }

--- a/ext/automatic1111_tagger/info.php
+++ b/ext/automatic1111_tagger/info.php
@@ -9,7 +9,7 @@ final class Automatic1111TaggerInfo extends ExtensionInfo
     public const KEY = "automatic1111_tagger";
 
     public string $name = "AI Tagger";
-    public array $authors = ["Saetron" => "https://github.com/Saetron/Shimmie2-AI-Tagger"];
+    public array $authors = ["Saetron" => "https://github.com/Saetron"];
     public string $license = self::LICENSE_MIT;
     public string $description = "Connects to the Automatic1111 API to interrogate images and suggest tags.";
     public ?string $documentation = "Adds an 'Interrogate' button to the posts overview, sending images to the Automatic1111 API for tag suggestions. Requires 'wd-v1-4-moat-tagger.v2' to function";

--- a/ext/automatic1111_tagger/main.php
+++ b/ext/automatic1111_tagger/main.php
@@ -41,6 +41,22 @@ class Automatic1111Tagger extends Extension
                 if (count($all_tags) > count($current_tags)) {
                     $all_tags = array_filter($all_tags, fn ($t) => strtolower($t) !== 'tagme');
                     send_event(new TagSetEvent($image_obj, $all_tags));
+                    if (Ctx::$config->get(Automatic1111TaggerConfig::MODEL) != "wd-v1-4-moat-tagger.v2") {
+                        $post_id = $event->get_iarg('post_id');
+                        $image_obj = Post::by_id_ex($post_id);
+                        $image_contents = $image_obj->get_thumb_filename()->get_contents();
+                        $image_data = base64_encode($image_contents);
+                        $payload = [
+                            "image" => $image_data,
+                            "model" => "wd-v1-4-moat-tagger.v2",
+                            "threshold" => (float)Ctx::$config->get(Automatic1111TaggerConfig::THRESHOLD)
+                        ];
+                        $endpoint = Ctx::$config->get(Automatic1111TaggerConfig::API_ENDPOINT);
+                        $result = $this->send_api_request($endpoint, $payload);
+                        if (isset($result['caption']['rating']) && is_array($result['caption']['rating'])) {
+                            $this->handle_rating($image_obj, $result['caption']['rating']);
+                        }
+                    }
                     Ctx::$page->flash("Tags added");
                     Ctx::$page->set_redirect(make_link("post/view/" . $post_id));
                 } else {
@@ -59,7 +75,7 @@ class Automatic1111Tagger extends Extension
             $image_data = base64_encode($image_contents);
             $payload = [
                 "image" => $image_data,
-                "model" => Ctx::$config->get(Automatic1111TaggerConfig::MODEL),
+                "model" => "wd-v1-4-moat-tagger.v2",
                 "threshold" => (float)Ctx::$config->get(Automatic1111TaggerConfig::THRESHOLD)
             ];
             $endpoint = Ctx::$config->get(Automatic1111TaggerConfig::API_ENDPOINT);

--- a/ext/automatic1111_tagger/main.php
+++ b/ext/automatic1111_tagger/main.php
@@ -55,7 +55,7 @@ class Automatic1111Tagger extends Extension
         if ($event->page_matches("automatic1111_tagger/get_rating/{post_id}")) {
             $post_id = $event->get_iarg('post_id');
             $image_obj = Post::by_id_ex($post_id);
-            $image_contents = $image_obj->get_media_filename()->get_contents();
+            $image_contents = $image_obj->get_thumb_filename()->get_contents();
             $image_data = base64_encode($image_contents);
             $payload = [
                 "image" => $image_data,

--- a/ext/automatic1111_tagger/main.php
+++ b/ext/automatic1111_tagger/main.php
@@ -41,7 +41,7 @@ class Automatic1111Tagger extends Extension
                 if (count($all_tags) > count($current_tags)) {
                     $all_tags = array_filter($all_tags, fn ($t) => strtolower($t) !== 'tagme');
                     send_event(new TagSetEvent($image_obj, $all_tags));
-                    if (Ctx::$config->get(Automatic1111TaggerConfig::MODEL) != "wd-v1-4-moat-tagger.v2") {
+                    if (Ctx::$config->get(Automatic1111TaggerConfig::MODEL) !== "wd-v1-4-moat-tagger.v2") {
                         $post_id = $event->get_iarg('post_id');
                         $image_obj = Post::by_id_ex($post_id);
                         $image_contents = $image_obj->get_thumb_filename()->get_contents();

--- a/ext/automatic1111_tagger/main.php
+++ b/ext/automatic1111_tagger/main.php
@@ -15,7 +15,7 @@ class Automatic1111Tagger extends Extension
         if ($event->page_matches("automatic1111_tagger/interrogate/{post_id}")) {
             $post_id = $event->get_iarg('post_id');
             $image_obj = Post::by_id_ex($post_id);
-            $image_contents = $image_obj->get_media_filename()->get_contents();
+            $image_contents = $image_obj->get_thumb_filename()->get_contents();
             $image_data = base64_encode($image_contents);
             $payload = [
                 "image" => $image_data,


### PR DESCRIPTION
Upon testing a new model for tagging, I found out that a few dont support ratings. This forces the tagger to use a model with rating support for ratings.