### PR TITLE
Fix cbz files not loading due to SCRIPT function escaping the quotes

### DIFF
--- a/ext/handle_cbz/theme.php
+++ b/ext/handle_cbz/theme.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shimmie2;
 
-use function MicroHTML\{A, DIV, IMG, SCRIPT, SELECT, SPAN, emptyHTML};
+use function MicroHTML\{A, DIV, IMG, SCRIPT, SELECT, SPAN, emptyHTML, rawHTML};
 
 class CBZFileHandlerTheme extends Themelet
 {
@@ -29,7 +29,7 @@ class CBZFileHandlerTheme extends Themelet
             SCRIPT(["src" => "{$data_href}/ext/handle_cbz/jszip-utils.min.js"]),
             SCRIPT(["src" => "{$data_href}/ext/handle_cbz/jszip.min.js"]),
             SCRIPT(["src" => "{$data_href}/ext/handle_cbz/comic.js"]),
-            SCRIPT("window.comic = new Comic('comicMain', '$ilink');")
+            SCRIPT(rawHTML("window.comic = new Comic('comicMain', '$ilink');"))
         );
     }
 }


### PR DESCRIPTION
Fixes an issue where the comic reader would not load the file and just keep showing the loading icon, due to the MicroHTML SCRIPT function URL escaping the quotes inside the string.
<img width="1672" height="523" alt="image" src="https://github.com/user-attachments/assets/630da14f-97e4-4e0b-825b-3c3c66be9281" />
