### PR TITLE
[Pools] fix pools/list not showing anything

### DIFF
--- a/ext/pools/main.php
+++ b/ext/pools/main.php
@@ -577,7 +577,7 @@ final class Pools extends Extension
 		", [
             "l" => $poolsPerPage,
             "o" => $pageNumber * $poolsPerPage,
-            "search" => $search,
+            "search" => "%$search%",
         ]);
         $pools = array_map(fn ($row) => new Pool($row), $rows);
         $totalPages = (int) ceil((int) Ctx::$database->get_one(


### PR DESCRIPTION
The ilike pattern got the wildcards removed since bc28b4537c7169b5b171ce49a691c88a9f81e368 . So simply add them back, but now the :search and title are still not LOWER(), which probably would be nice to add back as well, but im not sure how that should be done together with the SCORE_ILIKE() function, especially since with sqlite it already adds the LOWER, but not for mysql and pgsql