### PR TITLE
Add configurable OAuth2 login extension

### DIFF
--- a/ext/oauth2_login/README.md
+++ b/ext/oauth2_login/README.md
@@ -60,6 +60,11 @@ Set these Shimmie board config values:
 - Proxy email header: `X-Forwarded-Email`
 - Auto-create OAuth2 users: enabled
 
+Some proxies expose the authenticated username as `REMOTE_USER` instead of an
+HTTP header. For example, Authelia deployments can set Proxy username header to
+`REMOTE_USER`; Shimmie reads that exact server variable instead of converting it
+to `HTTP_REMOTE_USER`.
+
 The following files can be dropped into a checkout of
 `shish/shimmie2-examples` next to the existing `docker-compose.yaml`. The
 values are intentionally local-development only.

--- a/ext/oauth2_login/README.md
+++ b/ext/oauth2_login/README.md
@@ -1,0 +1,233 @@
+# OAuth2 Login extension
+
+This extension supports two deployment shapes:
+
+- direct OAuth2 login, where Shimmie talks to the provider itself
+- trusted reverse-proxy login, where a fronting service such as
+  oauth2-proxy authenticates the request and passes a username/email header to
+  Shimmie
+
+For both modes, enable the `oauth2_login` extension first.
+
+## Direct OAuth2 client test with Keycloak
+
+Create a local Keycloak realm and confidential client:
+
+- realm: `shimmie`
+- client id: `shimmie-local`
+- client authentication: enabled
+- client secret: `local-dev-secret`
+- valid redirect URI: `http://localhost:4010/oauth2_login/callback`
+- web origin: `http://localhost:4010`
+- test user: `shimmie-admin`
+- test user email: `shimmie-admin@example.test`
+- mark the test user's email as verified
+
+Then set these Shimmie board config values:
+
+- Provider name: `Keycloak`
+- Client ID: `shimmie-local`
+- Client secret: `local-dev-secret`
+- Authorization URL:
+  `http://keycloak.localhost:8080/realms/shimmie/protocol/openid-connect/auth`
+- Token URL:
+  `http://keycloak.localhost:8080/realms/shimmie/protocol/openid-connect/token`
+- Userinfo URL:
+  `http://keycloak.localhost:8080/realms/shimmie/protocol/openid-connect/userinfo`
+- Scopes: `openid profile email`
+- Username fields: `preferred_username,name,email`
+- Email field: `email`
+- Email verified field: `email_verified`
+- Require verified email: enabled
+- Auto-create OAuth2 users: enabled
+
+Visit `http://localhost:4010/`, click "Log in with Keycloak", and sign in as
+the Keycloak test user.
+
+## Trusted reverse-proxy testbed
+
+This mode is useful when oauth2-proxy or another fronting service owns all
+OAuth2 redirects. Shimmie only trusts the identity headers set by that proxy.
+
+Only enable trusted-header mode when clients cannot reach Shimmie directly.
+The reverse proxy must clear user-supplied identity headers before it sets the
+trusted values.
+
+Set these Shimmie board config values:
+
+- Trust reverse proxy headers: enabled
+- Proxy username header: `X-Forwarded-User`
+- Proxy email header: `X-Forwarded-Email`
+- Auto-create OAuth2 users: enabled
+
+The following files can be dropped into a checkout of
+`shish/shimmie2-examples` next to the existing `docker-compose.yaml`. The
+values are intentionally local-development only.
+
+### docker-compose override
+
+```yaml
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    command: start-dev --import-realm --hostname=keycloak.localhost --hostname-strict=false
+    ports:
+      - "8080:8080"
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+    volumes:
+      - ./oauth2-keycloak-realm.json:/opt/keycloak/data/import/shimmie-realm.json:ro
+    networks:
+      default:
+        aliases:
+          - keycloak.localhost
+
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
+    command:
+      - --provider=keycloak-oidc
+      - --oidc-issuer-url=http://keycloak.localhost:8080/realms/shimmie
+      - --client-id=shimmie-local
+      - --client-secret=local-dev-secret
+      - --redirect-url=http://localhost:4180/oauth2/callback
+      - --cookie-secret=0123456789abcdef0123456789abcdef
+      - --cookie-secure=false
+      - --email-domain=*
+      - --http-address=0.0.0.0:4180
+      - --reverse-proxy=true
+      - --set-xauthrequest=true
+      - --pass-user-headers=true
+      - --skip-provider-button=true
+    ports:
+      - "4180:4180"
+    depends_on:
+      - keycloak
+
+  oauth2-nginx:
+    image: nginx:alpine
+    ports:
+      - "4050:80"
+    volumes:
+      - ./oauth2-nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../shimmie2:/var/www/html
+    depends_on:
+      - php-fpm
+      - oauth2-proxy
+```
+
+### oauth2-nginx.conf
+
+```nginx
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+        root /var/www/html;
+        server_name _;
+
+        client_max_body_size 11M;
+
+        location /oauth2/ {
+            proxy_pass http://oauth2-proxy:4180;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Scheme $scheme;
+        }
+
+        location = /oauth2/auth {
+            proxy_pass http://oauth2-proxy:4180/oauth2/auth;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Original-URI $request_uri;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Scheme $scheme;
+        }
+
+        location / {
+            auth_request /oauth2/auth;
+            error_page 401 = /oauth2/sign_in;
+
+            auth_request_set $oauth_user $upstream_http_x_auth_request_user;
+            auth_request_set $oauth_email $upstream_http_x_auth_request_email;
+
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root/index.php;
+            fastcgi_param HTTP_X_FORWARDED_USER $oauth_user;
+            fastcgi_param HTTP_X_FORWARDED_EMAIL $oauth_email;
+            fastcgi_pass php-fpm:9000;
+        }
+    }
+}
+```
+
+### oauth2-keycloak-realm.json
+
+```json
+{
+  "realm": "shimmie",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "shimmie-local",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "local-dev-secret",
+      "redirectUris": [
+        "http://localhost:4180/oauth2/callback",
+        "http://localhost:4010/oauth2_login/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:4050",
+        "http://localhost:4010",
+        "http://localhost:4180"
+      ],
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true
+    }
+  ],
+  "users": [
+    {
+      "username": "shimmie-admin",
+      "enabled": true,
+      "email": "shimmie-admin@example.test",
+      "emailVerified": true,
+      "firstName": "Shimmie",
+      "lastName": "Admin",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}
+```
+
+Start the examples with:
+
+```sh
+docker compose up keycloak oauth2-proxy oauth2-nginx php-fpm
+```
+
+Then visit `http://localhost:4050/`. oauth2-proxy should redirect to
+Keycloak. Sign in with `shimmie-admin` / `password`. After the callback,
+Shimmie should receive:
+
+- `X-Forwarded-User: shimmie-admin`
+- `X-Forwarded-Email: shimmie-admin@example.test`
+
+The Shimmie extension should then create or load the matching local user.
+
+For production, replace all secrets and passwords, enable HTTPS, set secure
+cookies, and restrict direct access to Shimmie so that only the trusted reverse
+proxy can reach PHP-FPM.

--- a/ext/oauth2_login/README.md
+++ b/ext/oauth2_login/README.md
@@ -90,7 +90,7 @@ services:
       - --oidc-issuer-url=http://keycloak.localhost:8080/realms/shimmie
       - --client-id=shimmie-local
       - --client-secret=local-dev-secret
-      - --redirect-url=http://localhost:4180/oauth2/callback
+      - --redirect-url=http://localhost:4050/oauth2/callback
       - --cookie-secret=0123456789abcdef0123456789abcdef
       - --cookie-secure=false
       - --email-domain=*
@@ -99,8 +99,6 @@ services:
       - --set-xauthrequest=true
       - --pass-user-headers=true
       - --skip-provider-button=true
-    ports:
-      - "4180:4180"
     depends_on:
       - keycloak
 
@@ -138,6 +136,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Scheme $scheme;
+            proxy_set_header X-Auth-Request-Redirect $scheme://$http_host$request_uri;
         }
 
         location = /oauth2/auth {
@@ -181,13 +180,12 @@ http {
       "publicClient": false,
       "secret": "local-dev-secret",
       "redirectUris": [
-        "http://localhost:4180/oauth2/callback",
+        "http://localhost:4050/oauth2/callback",
         "http://localhost:4010/oauth2_login/callback"
       ],
       "webOrigins": [
         "http://localhost:4050",
-        "http://localhost:4010",
-        "http://localhost:4180"
+        "http://localhost:4010"
       ],
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": true

--- a/ext/oauth2_login/config.php
+++ b/ext/oauth2_login/config.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+final class OAuth2LoginConfig extends ConfigGroup
+{
+    public const KEY = "oauth2_login";
+
+    #[ConfigMeta("Provider name", ConfigType::STRING, default: "OAuth2")]
+    public const PROVIDER_NAME = "oauth2_login_provider_name";
+
+    #[ConfigMeta("Client ID", ConfigType::STRING)]
+    public const CLIENT_ID = "oauth2_login_client_id";
+
+    #[ConfigMeta("Client secret", ConfigType::STRING, advanced: true)]
+    public const CLIENT_SECRET = "oauth2_login_client_secret";
+
+    #[ConfigMeta("Authorization URL", ConfigType::STRING)]
+    public const AUTHORIZATION_URL = "oauth2_login_authorization_url";
+
+    #[ConfigMeta("Token URL", ConfigType::STRING)]
+    public const TOKEN_URL = "oauth2_login_token_url";
+
+    #[ConfigMeta("Userinfo URL", ConfigType::STRING)]
+    public const USERINFO_URL = "oauth2_login_userinfo_url";
+
+    #[ConfigMeta("Scopes", ConfigType::STRING, default: "openid profile email")]
+    public const SCOPES = "oauth2_login_scopes";
+
+    #[ConfigMeta("Username fields", ConfigType::STRING, default: "preferred_username,name,nickname,fqn,email,sub")]
+    public const USERNAME_FIELDS = "oauth2_login_username_fields";
+
+    #[ConfigMeta("Email field", ConfigType::STRING, default: "email")]
+    public const EMAIL_FIELD = "oauth2_login_email_field";
+
+    #[ConfigMeta("Email verified field", ConfigType::STRING, default: "email_verified", advanced: true)]
+    public const EMAIL_VERIFIED_FIELD = "oauth2_login_email_verified_field";
+
+    #[ConfigMeta("Require verified email", ConfigType::BOOL, default: true, advanced: true)]
+    public const REQUIRE_VERIFIED_EMAIL = "oauth2_login_require_verified_email";
+
+    #[ConfigMeta("Create users automatically", ConfigType::BOOL, default: true)]
+    public const AUTO_CREATE_USERS = "oauth2_login_auto_create_users";
+}

--- a/ext/oauth2_login/config.php
+++ b/ext/oauth2_login/config.php
@@ -43,4 +43,13 @@ final class OAuth2LoginConfig extends ConfigGroup
 
     #[ConfigMeta("Create users automatically", ConfigType::BOOL, default: true)]
     public const AUTO_CREATE_USERS = "oauth2_login_auto_create_users";
+
+    #[ConfigMeta("Trust reverse proxy headers", ConfigType::BOOL, default: false)]
+    public const TRUST_PROXY_HEADERS = "oauth2_login_trust_proxy_headers";
+
+    #[ConfigMeta("Proxy username header", ConfigType::STRING, default: "X-Forwarded-User", advanced: true)]
+    public const PROXY_USERNAME_HEADER = "oauth2_login_proxy_username_header";
+
+    #[ConfigMeta("Proxy email header", ConfigType::STRING, default: "X-Forwarded-Email", advanced: true)]
+    public const PROXY_EMAIL_HEADER = "oauth2_login_proxy_email_header";
 }

--- a/ext/oauth2_login/info.php
+++ b/ext/oauth2_login/info.php
@@ -31,5 +31,8 @@ auth_request /oauth2/auth;
 auth_request_set \$user \$upstream_http_x_auth_request_user;
 auth_request_set \$email \$upstream_http_x_auth_request_email;
 proxy_set_header X-Forwarded-User \$user;
-proxy_set_header X-Forwarded-Email \$email;</code></pre>";
+proxy_set_header X-Forwarded-Email \$email;</code></pre>
+
+See <code>ext/oauth2_login/README.md</code> for a local Keycloak and
+oauth2-proxy testbed that can be adapted into shimmie2-examples.";
 }

--- a/ext/oauth2_login/info.php
+++ b/ext/oauth2_login/info.php
@@ -11,9 +11,15 @@ final class OAuth2LoginInfo extends ExtensionInfo
     public string $name = "OAuth2 Login";
     public array $authors = self::SHISH_AUTHOR;
     public ExtensionCategory $category = ExtensionCategory::ADMIN;
-    public string $description = "Authenticate users through a configurable OAuth2 provider";
+    public string $description = "Authenticate users through OAuth2 or trusted reverse proxy headers";
     public ?string $documentation =
         "Adds a generic OAuth2 login button using administrator-configured authorization,
 token, and userinfo endpoints. The callback URL to register with the provider is
-<code>/oauth2_login/callback</code> on this Shimmie instance.";
+<code>/oauth2_login/callback</code> on this Shimmie instance.
+
+Alternatively, administrators can enable trusted reverse proxy headers for
+setups where oauth2-proxy, nginx, or another fronting service has already
+authenticated the request. Only enable that mode when Shimmie is not reachable
+directly by clients, because Shimmie will trust the configured username and
+email headers.";
 }

--- a/ext/oauth2_login/info.php
+++ b/ext/oauth2_login/info.php
@@ -21,5 +21,15 @@ Alternatively, administrators can enable trusted reverse proxy headers for
 setups where oauth2-proxy, nginx, or another fronting service has already
 authenticated the request. Only enable that mode when Shimmie is not reachable
 directly by clients, because Shimmie will trust the configured username and
-email headers.";
+email headers. A typical oauth2-proxy and nginx setup would protect Shimmie
+with <code>auth_request</code>, clear any inbound identity headers, then set the
+configured Shimmie headers from oauth2-proxy's authenticated response:
+
+<pre><code>proxy_set_header X-Forwarded-User \"\";
+proxy_set_header X-Forwarded-Email \"\";
+auth_request /oauth2/auth;
+auth_request_set \$user \$upstream_http_x_auth_request_user;
+auth_request_set \$email \$upstream_http_x_auth_request_email;
+proxy_set_header X-Forwarded-User \$user;
+proxy_set_header X-Forwarded-Email \$email;</code></pre>";
 }

--- a/ext/oauth2_login/info.php
+++ b/ext/oauth2_login/info.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+final class OAuth2LoginInfo extends ExtensionInfo
+{
+    public const KEY = "oauth2_login";
+
+    public string $name = "OAuth2 Login";
+    public array $authors = self::SHISH_AUTHOR;
+    public ExtensionCategory $category = ExtensionCategory::ADMIN;
+    public string $description = "Authenticate users through a configurable OAuth2 provider";
+    public ?string $documentation =
+        "Adds a generic OAuth2 login button using administrator-configured authorization,
+token, and userinfo endpoints. The callback URL to register with the provider is
+<code>/oauth2_login/callback</code> on this Shimmie instance.";
+}

--- a/ext/oauth2_login/main.php
+++ b/ext/oauth2_login/main.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+/** @extends Extension<OAuth2LoginTheme> */
+final class OAuth2Login extends Extension
+{
+    public const KEY = "oauth2_login";
+    private const STATE_COOKIE = "oauth2_login_state";
+
+    #[EventListener]
+    public function onPageRequest(PageRequestEvent $event): void
+    {
+        if ($event->page_matches("oauth2_login/start", method: "GET")) {
+            $this->page_start();
+            return;
+        }
+
+        if ($event->page_matches("oauth2_login/callback", method: "GET")) {
+            $this->page_callback($event->GET->toArray());
+            return;
+        }
+
+        if (
+            Ctx::$user->is_anonymous()
+            && $this->is_configured()
+            && !$event->page_starts_with("oauth2_login")
+        ) {
+            $this->theme->display_login_block($this->provider_name());
+        }
+    }
+
+    private function provider_name(): string
+    {
+        $name = trim($this->config_string(OAuth2LoginConfig::PROVIDER_NAME));
+        return $name === "" ? "OAuth2" : $name;
+    }
+
+    private function is_configured(): bool
+    {
+        return
+            trim($this->config_string(OAuth2LoginConfig::CLIENT_ID)) !== "" &&
+            trim($this->config_string(OAuth2LoginConfig::CLIENT_SECRET)) !== "" &&
+            trim($this->config_string(OAuth2LoginConfig::AUTHORIZATION_URL)) !== "" &&
+            trim($this->config_string(OAuth2LoginConfig::TOKEN_URL)) !== "" &&
+            trim($this->config_string(OAuth2LoginConfig::USERINFO_URL)) !== "";
+    }
+
+    private function config_string(string $key): string
+    {
+        $value = Ctx::$config->get($key);
+        return is_string($value) ? $value : "";
+    }
+
+    private function config_bool(string $key): bool
+    {
+        return Ctx::$config->get($key) === true;
+    }
+
+    private function page_start(): void
+    {
+        if (!$this->is_configured()) {
+            $this->theme->display_not_configured();
+            return;
+        }
+
+        $state = bin2hex(random_bytes(24));
+        Ctx::$page->add_cookie(self::STATE_COOKIE, $state, time() + 600);
+        Ctx::$page->set_redirect(Url::parse($this->with_query(
+            $this->config_string(OAuth2LoginConfig::AUTHORIZATION_URL),
+            [
+                "response_type" => "code",
+                "client_id" => $this->config_string(OAuth2LoginConfig::CLIENT_ID),
+                "redirect_uri" => $this->callback_url(),
+                "scope" => $this->config_string(OAuth2LoginConfig::SCOPES),
+                "state" => $state,
+            ]
+        )));
+    }
+
+    /**
+     * @param array<string, string|string[]> $query
+     */
+    private function page_callback(array $query): void
+    {
+        if (!$this->is_configured()) {
+            $this->theme->display_not_configured();
+            return;
+        }
+
+        if (isset($query["error"])) {
+            $description = $query["error_description"] ?? $query["error"];
+            if (is_array($description)) {
+                $description = implode(", ", $description);
+            }
+            throw new InvalidInput("OAuth2 login failed: $description");
+        }
+
+        $state = $this->single_query_value($query, "state");
+        $code = $this->single_query_value($query, "code");
+        $cookie_state = Ctx::$page->get_cookie(self::STATE_COOKIE);
+        Ctx::$page->add_cookie(self::STATE_COOKIE, "", time() - 3600);
+
+        if ($state === null || $cookie_state === null || !hash_equals($cookie_state, $state)) {
+            throw new InvalidInput("OAuth2 login failed state validation");
+        }
+        if ($code === null || $code === "") {
+            throw new InvalidInput("OAuth2 login callback did not include a code");
+        }
+
+        $token = $this->request_json(
+            $this->config_string(OAuth2LoginConfig::TOKEN_URL),
+            [
+                "grant_type" => "authorization_code",
+                "code" => $code,
+                "redirect_uri" => $this->callback_url(),
+                "client_id" => $this->config_string(OAuth2LoginConfig::CLIENT_ID),
+                "client_secret" => $this->config_string(OAuth2LoginConfig::CLIENT_SECRET),
+            ]
+        );
+        $access_token = $token["access_token"] ?? null;
+        if (!is_string($access_token) || $access_token === "") {
+            throw new InvalidInput("OAuth2 token endpoint did not return an access token");
+        }
+
+        $profile = $this->request_json(
+            $this->config_string(OAuth2LoginConfig::USERINFO_URL),
+            null,
+            ["Authorization: Bearer $access_token"]
+        );
+        $user = $this->find_or_create_user($profile);
+
+        send_event(new UserLoginEvent($user));
+        $user->set_login_cookie();
+        Ctx::$page->flash("Logged in with " . $this->provider_name());
+        Ctx::$page->set_redirect(make_link("user"));
+    }
+
+    /**
+     * @param array<string, string|string[]> $query
+     */
+    private function single_query_value(array $query, string $key): ?string
+    {
+        $value = $query[$key] ?? null;
+        if (is_array($value)) {
+            return $value[0] ?? null;
+        }
+        return $value;
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    private function with_query(string $url, array $query): string
+    {
+        return $url . (str_contains($url, "?") ? "&" : "?") . http_build_query($query);
+    }
+
+    private function callback_url(): string
+    {
+        return (string)make_link("oauth2_login/callback")->asAbsolute();
+    }
+
+    /**
+     * @param array<string, string>|null $post_fields
+     * @param string[] $headers
+     * @return array<string, mixed>
+     */
+    private function request_json(string $url, ?array $post_fields = null, array $headers = []): array
+    {
+        $ch = curl_init($url);
+        if ($ch === false) {
+            throw new ServerError("Could not initialize OAuth2 HTTP request");
+        }
+
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge(["Accept: application/json"], $headers));
+        if ($post_fields !== null) {
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($post_fields));
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge(
+                ["Accept: application/json", "Content-Type: application/x-www-form-urlencoded"],
+                $headers
+            ));
+        }
+
+        $response = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        if (!is_string($response)) {
+            throw new InvalidInput("OAuth2 request failed: $error");
+        }
+        if ($status < 200 || $status >= 300) {
+            throw new InvalidInput("OAuth2 endpoint returned HTTP $status");
+        }
+
+        $data = \Safe\json_decode($response, true);
+        if (!is_array($data)) {
+            throw new InvalidInput("OAuth2 endpoint did not return a JSON object");
+        }
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     */
+    private function find_or_create_user(array $profile): User
+    {
+        $email = $this->extract_email($profile);
+        if ($email !== "" && $this->email_is_trusted($profile)) {
+            $user = $this->find_user_by_email($email);
+            if ($user !== null) {
+                return $user;
+            }
+        }
+
+        if (!$this->config_bool(OAuth2LoginConfig::AUTO_CREATE_USERS)) {
+            throw new InvalidInput("OAuth2 user does not match an existing account");
+        }
+
+        return $this->create_user($this->unique_username($this->extract_username($profile)), $email);
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     */
+    private function extract_email(array $profile): string
+    {
+        $field = trim($this->config_string(OAuth2LoginConfig::EMAIL_FIELD));
+        if ($field === "") {
+            return "";
+        }
+
+        $email = $this->profile_value($profile, $field);
+        if ($email === null || $email === "") {
+            return "";
+        }
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new InvalidInput("OAuth2 provider returned an invalid email address");
+        }
+        return $email;
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     */
+    private function email_is_trusted(array $profile): bool
+    {
+        if (!$this->config_bool(OAuth2LoginConfig::REQUIRE_VERIFIED_EMAIL)) {
+            return true;
+        }
+
+        $field = trim($this->config_string(OAuth2LoginConfig::EMAIL_VERIFIED_FIELD));
+        if ($field === "") {
+            throw new InvalidInput("OAuth2 provider did not prove that the email address is verified");
+        }
+
+        $verified = strtolower($this->profile_value($profile, $field) ?? "");
+        if (\in_array($verified, ["1", "true", "yes"], true)) {
+            return true;
+        }
+        throw new InvalidInput("OAuth2 provider did not verify the email address");
+    }
+
+    private function find_user_by_email(string $email): ?User
+    {
+        $id = Ctx::$database->get_one(
+            "SELECT id FROM users WHERE LOWER(email) = LOWER(:email)",
+            ["email" => $email]
+        );
+        if ($id === null) {
+            return null;
+        }
+        return User::by_id((int)$id);
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     */
+    private function extract_username(array $profile): string
+    {
+        foreach ($this->configured_fields(OAuth2LoginConfig::USERNAME_FIELDS) as $field) {
+            $value = $this->profile_value($profile, $field);
+            if ($value !== null && $value !== "") {
+                return $this->normalise_username($value);
+            }
+        }
+
+        return "oauth2_" . substr(hash("sha256", \Safe\json_encode($profile)), 0, 12);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function configured_fields(string $config_key): array
+    {
+        $fields = array_map("trim", explode(",", $this->config_string($config_key)));
+        return array_values(array_filter($fields, fn (string $field): bool => $field !== ""));
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     */
+    private function profile_value(array $profile, string $field): ?string
+    {
+        $value = $profile;
+        foreach (explode(".", $field) as $part) {
+            if (!is_array($value) || !array_key_exists($part, $value)) {
+                return null;
+            }
+            $value = $value[$part];
+        }
+        if (is_scalar($value)) {
+            return trim((string)$value);
+        }
+        return null;
+    }
+
+    private function normalise_username(string $name): string
+    {
+        if (str_contains($name, "@")) {
+            $name = explode("@", $name, 2)[0];
+        }
+        $name = \Safe\preg_replace("/[^a-zA-Z0-9-_]+/", "_", $name);
+        $name = trim(\Safe\preg_replace("/_+/", "_", $name), "_-");
+        if ($name === "") {
+            $name = "oauth2_user";
+        }
+        return substr($name, 0, 64);
+    }
+
+    private function unique_username(string $base): string
+    {
+        $base = $base === "" ? "oauth2_user" : $base;
+        $candidate = $base;
+        for ($i = 0; $i < 100; $i++) {
+            try {
+                User::by_name($candidate);
+            } catch (UserNotFound) {
+                return $candidate;
+            }
+            $suffix = $i === 0 ? substr(bin2hex(random_bytes(4)), 0, 8) : (string)$i;
+            $candidate = substr($base, 0, 55) . "_" . $suffix;
+        }
+        throw new InvalidInput("Could not create a unique OAuth2 username");
+    }
+
+    private function create_user(string $username, string $email): User
+    {
+        $need_admin = (Ctx::$database->get_one("SELECT COUNT(*) FROM users WHERE class='admin'") === 0);
+        $class = $need_admin ? "admin" : "user";
+
+        Ctx::$database->execute(
+            "INSERT INTO users (name, pass, joindate, email, class) VALUES (:username, :hash, now(), :email, :class)",
+            ["username" => $username, "hash" => "", "email" => ($email === "" ? null : $email), "class" => $class]
+        );
+
+        $user = User::by_name($username);
+        $user->set_password(bin2hex(random_bytes(32)));
+        Log::info("oauth2-login", "Created OAuth2 user @$username");
+        return $user;
+    }
+}

--- a/ext/oauth2_login/main.php
+++ b/ext/oauth2_login/main.php
@@ -13,6 +13,10 @@ final class OAuth2Login extends Extension
     #[EventListener]
     public function onPageRequest(PageRequestEvent $event): void
     {
+        if (Ctx::$user->is_anonymous() && !$event->page_starts_with("oauth2_login")) {
+            $this->login_from_proxy_headers();
+        }
+
         if ($event->page_matches("oauth2_login/start", method: "GET")) {
             $this->page_start();
             return;
@@ -25,7 +29,7 @@ final class OAuth2Login extends Extension
 
         if (
             Ctx::$user->is_anonymous()
-            && $this->is_configured()
+            && $this->is_oauth2_client_configured()
             && !$event->page_starts_with("oauth2_login")
         ) {
             $this->theme->display_login_block($this->provider_name());
@@ -38,7 +42,7 @@ final class OAuth2Login extends Extension
         return $name === "" ? "OAuth2" : $name;
     }
 
-    private function is_configured(): bool
+    private function is_oauth2_client_configured(): bool
     {
         return
             trim($this->config_string(OAuth2LoginConfig::CLIENT_ID)) !== "" &&
@@ -59,9 +63,59 @@ final class OAuth2Login extends Extension
         return Ctx::$config->get($key) === true;
     }
 
+    private function login_from_proxy_headers(): void
+    {
+        if (!$this->config_bool(OAuth2LoginConfig::TRUST_PROXY_HEADERS)) {
+            return;
+        }
+
+        $username = $this->configured_header_value(OAuth2LoginConfig::PROXY_USERNAME_HEADER);
+        if ($username === null) {
+            return;
+        }
+
+        $email = $this->configured_header_value(OAuth2LoginConfig::PROXY_EMAIL_HEADER) ?? "";
+        if ($email !== "" && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new InvalidInput("Trusted proxy returned an invalid email address");
+        }
+
+        $user = $this->find_or_create_proxy_user($username, $email);
+        send_event(new UserLoginEvent($user));
+        $user->set_login_cookie();
+        Log::debug("oauth2-login", "Logged in @$user->name from trusted reverse proxy headers");
+    }
+
+    private function configured_header_value(string $config_key): ?string
+    {
+        $server_key = $this->header_server_key($this->config_string($config_key));
+        if ($server_key === "") {
+            return null;
+        }
+
+        $value = $_SERVER[$server_key] ?? null;
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $value = trim((string)$value);
+        return $value === "" ? null : $value;
+    }
+
+    private function header_server_key(string $header): string
+    {
+        $header = strtoupper(str_replace("-", "_", trim($header)));
+        if ($header === "") {
+            return "";
+        }
+        if (str_starts_with($header, "HTTP_") || $header === "REMOTE_USER") {
+            return $header;
+        }
+        return "HTTP_$header";
+    }
+
     private function page_start(): void
     {
-        if (!$this->is_configured()) {
+        if (!$this->is_oauth2_client_configured()) {
             $this->theme->display_not_configured();
             return;
         }
@@ -85,7 +139,7 @@ final class OAuth2Login extends Extension
      */
     private function page_callback(array $query): void
     {
-        if (!$this->is_configured()) {
+        if (!$this->is_oauth2_client_configured()) {
             $this->theme->display_not_configured();
             return;
         }
@@ -223,6 +277,30 @@ final class OAuth2Login extends Extension
         }
 
         return $this->create_user($this->unique_username($this->extract_username($profile)), $email);
+    }
+
+    private function find_or_create_proxy_user(string $username, string $email): User
+    {
+        $username = $this->normalise_username($username);
+
+        if ($email !== "") {
+            $user = $this->find_user_by_email($email);
+            if ($user !== null) {
+                return $user;
+            }
+        }
+
+        try {
+            return User::by_name($username);
+        } catch (UserNotFound) {
+            // The trusted proxy identity will be created below if allowed.
+        }
+
+        if (!$this->config_bool(OAuth2LoginConfig::AUTO_CREATE_USERS)) {
+            throw new InvalidInput("Trusted proxy user does not match an existing account");
+        }
+
+        return $this->create_user($this->unique_username($username), $email);
     }
 
     /**

--- a/ext/oauth2_login/main.php
+++ b/ext/oauth2_login/main.php
@@ -82,7 +82,7 @@ final class OAuth2Login extends Extension
         $user = $this->find_or_create_proxy_user($username, $email);
         send_event(new UserLoginEvent($user));
         $user->set_login_cookie();
-        Log::debug("oauth2-login", "Logged in @$user->name from trusted reverse proxy headers");
+        Log::info("oauth2-login", "Logged in @$user->name from trusted reverse proxy headers");
     }
 
     private function configured_header_value(string $config_key): ?string

--- a/ext/oauth2_login/test.php
+++ b/ext/oauth2_login/test.php
@@ -76,6 +76,21 @@ final class OAuth2LoginTest extends ShimmiePHPUnitTestCase
         self::assertSame("proxy-person@example.com", Ctx::$user->email);
     }
 
+    public function testTrustedProxyRemoteUserCreatesAndLogsInUser(): void
+    {
+        Ctx::$config->set(OAuth2LoginConfig::TRUST_PROXY_HEADERS, true);
+        Ctx::$config->set(OAuth2LoginConfig::PROXY_USERNAME_HEADER, "REMOTE_USER");
+        $_SERVER["REMOTE_USER"] = "Authelia Person";
+
+        try {
+            self::get_page("post/list");
+        } finally {
+            unset($_SERVER["REMOTE_USER"]);
+        }
+
+        self::assertSame("Authelia_Person", Ctx::$user->name);
+    }
+
     public function testRejectsUnverifiedEmail(): void
     {
         self::assertException(InvalidInput::class, function () {

--- a/ext/oauth2_login/test.php
+++ b/ext/oauth2_login/test.php
@@ -60,6 +60,22 @@ final class OAuth2LoginTest extends ShimmiePHPUnitTestCase
         self::assertSame("oauth-person@example.com", $user->email);
     }
 
+    public function testTrustedProxyHeaderCreatesAndLogsInUser(): void
+    {
+        Ctx::$config->set(OAuth2LoginConfig::TRUST_PROXY_HEADERS, true);
+        $_SERVER["HTTP_X_FORWARDED_USER"] = "Proxy Person";
+        $_SERVER["HTTP_X_FORWARDED_EMAIL"] = "proxy-person@example.com";
+
+        try {
+            self::get_page("post/list");
+        } finally {
+            unset($_SERVER["HTTP_X_FORWARDED_USER"], $_SERVER["HTTP_X_FORWARDED_EMAIL"]);
+        }
+
+        self::assertSame("Proxy_Person", Ctx::$user->name);
+        self::assertSame("proxy-person@example.com", Ctx::$user->email);
+    }
+
     public function testRejectsUnverifiedEmail(): void
     {
         self::assertException(InvalidInput::class, function () {

--- a/ext/oauth2_login/test.php
+++ b/ext/oauth2_login/test.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+final class OAuth2LoginTest extends ShimmiePHPUnitTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        Ctx::$config->set(OAuth2LoginConfig::PROVIDER_NAME, "Example SSO");
+        Ctx::$config->set(OAuth2LoginConfig::CLIENT_ID, "client-id");
+        Ctx::$config->set(OAuth2LoginConfig::CLIENT_SECRET, "client-secret");
+        Ctx::$config->set(OAuth2LoginConfig::AUTHORIZATION_URL, "https://idp.example/authorize");
+        Ctx::$config->set(OAuth2LoginConfig::TOKEN_URL, "https://idp.example/token");
+        Ctx::$config->set(OAuth2LoginConfig::USERINFO_URL, "https://idp.example/userinfo");
+        Ctx::$config->set(OAuth2LoginConfig::SCOPES, "openid profile email");
+    }
+
+    public function testLoginBlockShowsWhenConfigured(): void
+    {
+        self::get_page("post/list");
+        self::assert_text("Log in with Example SSO", "left");
+    }
+
+    public function testStartRedirectsToProvider(): void
+    {
+        $page = self::get_page("oauth2_login/start");
+        self::assertSame(PageMode::REDIRECT, $page->mode);
+        self::assertStringStartsWith("https://idp.example/authorize?", (string)$page->redirect);
+        self::assertStringContainsString("response_type=code", (string)$page->redirect);
+        self::assertStringContainsString("client_id=client-id", (string)$page->redirect);
+        self::assertStringContainsString("scope=openid+profile+email", (string)$page->redirect);
+        self::assertStringContainsString("state=", (string)$page->redirect);
+    }
+
+    public function testCallbackRejectsBadState(): void
+    {
+        self::assertException(InvalidInput::class, function () {
+            self::request(
+                "GET",
+                "oauth2_login/callback",
+                ["state" => "bad", "code" => "abc"],
+                [],
+                ["shm_oauth2_login_state" => "good"]
+            );
+        });
+    }
+
+    public function testCreatesUserFromVerifiedProfile(): void
+    {
+        $user = $this->findOrCreateUser([
+            "preferred_username" => "OAuth Person",
+            "email" => "oauth-person@example.com",
+            "email_verified" => true,
+        ]);
+
+        self::assertSame("OAuth_Person", $user->name);
+        self::assertSame("oauth-person@example.com", $user->email);
+    }
+
+    public function testRejectsUnverifiedEmail(): void
+    {
+        self::assertException(InvalidInput::class, function () {
+            $this->findOrCreateUser([
+                "preferred_username" => "oauth-person",
+                "email" => "oauth-person@example.com",
+                "email_verified" => false,
+            ]);
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     */
+    private function findOrCreateUser(array $profile): User
+    {
+        $method = new \ReflectionMethod(OAuth2Login::class, "find_or_create_user");
+        return $method->invoke(new OAuth2Login(), $profile);
+    }
+}

--- a/ext/oauth2_login/theme.php
+++ b/ext/oauth2_login/theme.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shimmie2;
+
+use function MicroHTML\{A, P, SMALL, emptyHTML};
+
+class OAuth2LoginTheme extends Themelet
+{
+    public function display_login_block(string $provider_name): void
+    {
+        Ctx::$page->add_block(new Block(
+            "$provider_name Login",
+            emptyHTML(
+                P(A(["href" => make_link("oauth2_login/start")], "Log in with $provider_name")),
+                SMALL("Uses the OAuth2 provider configured by the board administrator.")
+            ),
+            "left",
+            91
+        ));
+    }
+
+    public function display_not_configured(): void
+    {
+        Ctx::$page->set_title("OAuth2 Login");
+        Ctx::$page->add_block(new Block(
+            "OAuth2 Login",
+            P("OAuth2 login is not fully configured yet.")
+        ));
+    }
+}

--- a/ext/oauth2_login/theme.php
+++ b/ext/oauth2_login/theme.php
@@ -14,7 +14,7 @@ class OAuth2LoginTheme extends Themelet
             "$provider_name Login",
             emptyHTML(
                 P(A(["href" => make_link("oauth2_login/start")], "Log in with $provider_name")),
-                SMALL("Uses the OAuth2 provider configured by the board administrator.")
+                SMALL("Uses the OAuth2 or trusted proxy provider configured by the board administrator.")
             ),
             "left",
             91


### PR DESCRIPTION
Fixes #912.

This adds an OAuth2 login extension with two supported deployment shapes:

- trusted reverse-proxy login for oauth2-proxy/nginx-style setups, enabled only when explicitly configured
- direct OAuth2 authorization-code login using administrator-configured provider endpoints

The trusted reverse-proxy mode covers the confirmed bounty scope from #912: it uses configurable username and email headers, maps the trusted upstream identity to an existing or newly-created Shimmie user, and documents the security boundary that Shimmie must not be reachable directly by clients when header trust is enabled.

The direct OAuth2 client path includes:

- configurable provider name, client credentials, authorization/token/userinfo endpoints, scopes, and profile field mapping
- a short-lived state cookie for callback validation
- JSON token/userinfo requests, verified-email enforcement by default, and existing-account matching by email
- automatic Shimmie user creation with normalized unique usernames when no existing email match is found
- a sidebar login block plus focused tests for login links, provider redirect, callback state rejection, user creation, unverified-email rejection, and trusted proxy header login

Verification run locally:

- PHP lint for `ext/oauth2_login` files
- `php vendor/bin/phpunit --no-coverage --filter "OAuth2LoginTest|UserPageTest"` (9 tests / 26 assertions)
- `php vendor/bin/php-cs-fixer check --diff --using-cache=no ext\oauth2_login`
- `php vendor/bin/phpstan analyse --memory-limit 1G --error-format=raw --no-progress`

Prepared with Codex assistance.