### PR TITLE
[index] Remove non-existent meta-tag

### DIFF
--- a/ext/index/main.php
+++ b/ext/index/main.php
@@ -190,9 +190,6 @@ final class Index extends Extension
         } elseif ($matches = $event->matches("/^(hash|md5)[=:]([0-9a-fA-F]*)$/i")) {
             $hash = strtolower($matches[2]);
             $event->add_querylet(new Querylet('images.hash = :hash', ["hash" => $hash]));
-        } elseif ($matches = $event->matches("/^(phash)[=:]([0-9a-fA-F]*)$/i")) {
-            $phash = strtolower($matches[2]);
-            $event->add_querylet(new Querylet('images.phash = :phash', ["phash" => $phash]));
         } elseif ($matches = $event->matches("/^(filename|name)[=:](.+)$/i")) {
             $filename = strtolower($matches[2]);
             $event->add_querylet(new Querylet("SCORE_ILIKE(images.filename, :filename{$event->id})", ["filename{$event->id}" => "%$filename%"]));


### PR DESCRIPTION
This meta-tag got added way back in 9b0edcf4499f1e63177e35b10b32d96fca76c83b but i couldn't find anything about an images.phash row, so i'm not sure why it got added in the first place?