### PR TITLE
[core] send the page, not the path, in a GET form's hidden q field

### DIFF
--- a/core/Util/MicroHTMLTest.php
+++ b/core/Util/MicroHTMLTest.php
@@ -15,4 +15,26 @@ class MicroHTMLTest extends TestCase
             (string)SHM_DATE("2012-06-23 16:14:22")
         );
     }
+
+    /**
+     * Browsers throw away a GET form's action query string and replace it
+     * with the form fields, so uglyurl installs need the page repeating as
+     * a hidden field, see #2131
+     */
+    public function test_get_form_page(): void
+    {
+        Ctx::$config->set(SetupConfig::NICE_URLS, false);
+        self::assertSame(
+            "<form action='/test/index.php?q=post%2Flist%2F1' method='GET'>" .
+            "<input type='hidden' name='q' value='post/list/1' /></form>",
+            (string)SHM_FORM(action: search_link(), method: "GET")
+        );
+
+        // with niceurls the action path carries the page by itself
+        Ctx::$config->set(SetupConfig::NICE_URLS, true);
+        self::assertSame(
+            "<form action='/test/post/list/1' method='GET'></form>",
+            (string)SHM_FORM(action: search_link(), method: "GET")
+        );
+    }
 }

--- a/core/Util/microhtml.php
+++ b/core/Util/microhtml.php
@@ -63,9 +63,14 @@ function SHM_FORM(Url $action, bool $multipart = false, string $id = "", string 
         $attrs["name"] = $name;
     }
 
+    // Browsers throw away the action's query string when submitting a GET
+    // form, so uglyurls need `q` repeating as a field. Niceurls keep the page
+    // in the action's path, where there is nothing to throw away.
+    $page = $method === "GET" ? $action->getPage() : null;
+
     return FORM(
         $attrs,
-        $method === "GET" ? INPUT(["type" => "hidden", "name" => "q", "value" => $action->getPath()]) : null,
+        (!is_null($page) && !Url::are_niceurls_enabled()) ? INPUT(["type" => "hidden", "name" => "q", "value" => $page]) : null,
         $method !== "GET" ? INPUT(["type" => "hidden", "name" => "auth_token", "value" => Ctx::$user->get_auth_token()]) : null,
         ...$children,
     );


### PR DESCRIPTION
Fixes #2131.

## The bug

On an uglyurl install, typing a tag into the search box lands on
`?q=%2Findex.php&search=blue_archive` and errors with
`No handler could be found for the page '/index.php'`.

## Why

Browsers discard a GET form's action query string and rebuild it from the form
fields, so `SHM_FORM` re-adds the page as a hidden `q` field. It was taking that
value from `$action->getPath()`, which on an uglyurl install is
`$install_dir/index.php` (Url.php:169), not the page.

So the action `/index.php?q=post/list/1` lost its `q` on submit and the hidden
field put back `/index.php`, which is not a page any handler matches.

Niceurls hide the bug: the action's *path* is `/post/list/1`, so routing works
off the path and the bogus `q` is never read.

`_get_query()` already documents the intended value, `<input type='hidden'
name='q' value='post/list'>` (util.php:475), and `Url::__toString()` puts
`$this->page` in `q` under exactly the same condition. This just makes the form
agree with both.

## Scope

Every GET form was affected, not only the one in the report: the index and home
search boxes, the `random_list` search box, and the wiki revision comparer.
One shared fix covers all four.

## Verification

`MicroHTMLTest::test_get_form_page` asserts the rendered form in both modes.
Before the fix it produced `value='/test/index.php'`.

Live, on the PHP dev server the reporter used, uglyurls, sqlite:

| submitted query | before | after |
|---|---|---|
| `?q=%2Findex.php&search=blue_archive` | `404` + `No handler could be found for the page '/index.php'` | n/a, no longer generated |
| `?q=post%2Flist%2F1&search=blue_archive` | n/a | `302` to `?q=post%2Flist%2Fblue_archive%2F1` |

All three gates green locally: `composer test` 360 tests / 1179 assertions,
`composer format-ci` 0 of 778 files, `phpstan` no errors.
