### PR TITLE
[perm_manager] fix undefined array key error

### DIFF
--- a/ext/perm_manager/theme.php
+++ b/ext/perm_manager/theme.php
@@ -46,7 +46,7 @@ class PermManagerTheme extends Themelet
             } elseif (in_array(UserClassSource::DATABASE, $class->sources) && in_array(UserClassSource::DEFAULT, $class->sources)) {
                 $form->appendChild(SHM_SUBMIT("Revert to Default"));
             } elseif (in_array(UserClassSource::DATABASE, $class->sources)) {
-                if ($counts[$class->name] === 0) {
+                if (!\array_key_exists($class->name, $counts) || $counts[$class->name] === 0) {
                     $form->appendChild(SHM_SUBMIT("Delete"));
                 } else {
                     $form->appendChild(BUTTON(["disabled" => true], "Can't delete in-use classes"));


### PR DESCRIPTION
On the perm manager create/delete page it always throws an error when theres a class that has 0 users, since the $counts only contains currently active classes from the database. And so does not let you delete it.

And I guess the `$counts[$class->name] === 0` is redundant either way because of it